### PR TITLE
Bump canonicalwebteam.discourse module to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==8.0.3
 # App dependencies
 canonicalwebteam.flask-base==1.0.5
 canonicalwebteam.candid==0.9.0
-canonicalwebteam.discourse==4.0.10
+canonicalwebteam.discourse==5.0.1
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.2.7
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
## Done
- Bump canonicalwebteam.discourse module that includes the following fix: https://github.com/canonical/canonicalwebteam.discourse/pull/140

## QA
- Click around docs and make sure things works as expected

## Issue / Card
Fixes #4068 
