### PR TITLE
Fix snap preview categories on React listing page

### DIFF
--- a/static/js/publisher/listing/components/PreviewForm/PreviewForm.tsx
+++ b/static/js/publisher/listing/components/PreviewForm/PreviewForm.tsx
@@ -9,15 +9,34 @@ type Props = {
     description: string;
     website: string;
     contact: string;
-    categories: Array<string>;
+    categories: Array<{ name: string; slug: string }>;
     public_metrics_enabled: boolean;
     public_metrics_blacklist: Array<string>;
     license: boolean;
     video_urls: string;
+    snap_categories: Array<string>;
   };
 };
 
 function PreviewForm({ listingData }: Props) {
+  const primaryCategory = listingData?.categories.find((category) => {
+    return category.slug === listingData?.snap_categories[0];
+  });
+
+  const secondaryCategory = listingData?.categories.find((category) => {
+    return category.slug === listingData?.snap_categories[1];
+  });
+
+  listingData.categories = [];
+
+  if (primaryCategory) {
+    listingData.categories.push(primaryCategory);
+  }
+
+  if (secondaryCategory) {
+    listingData.categories.push(secondaryCategory);
+  }
+
   return (
     <Form
       id="preview-form"

--- a/static/js/publisher/listing/utils/getListingData.ts
+++ b/static/js/publisher/listing/utils/getListingData.ts
@@ -108,6 +108,7 @@ function getListingData(listingData: { [key: string]: any }) {
       new File([], ""),
     ],
     images,
+    snap_categories: window?.listingData?.snap_categories?.categories,
   };
 }
 


### PR DESCRIPTION
## Done
Fixed the category display on listing page previews

## QA
- Go to https://snapcraft-io-4085.demos.haus/SNAP_NAME/listing?show_react_listing=true
- Use the preview button to launch a preview of the listing page
- Check that the categories are present underneath the snap title

## Issue
Fixes #4041 

## Screenshots
![Screenshot 2022-08-30 at 11 22 07](https://user-images.githubusercontent.com/501889/187413344-d16e4eb3-65e5-4968-b922-8003869161f9.jpg)
