### PR TITLE
Fix homepage card tooltips

### DIFF
--- a/static/sass/_patterns_media-object--snap.scss
+++ b/static/sass/_patterns_media-object--snap.scss
@@ -2,10 +2,6 @@
   .p-media-object--snap {
     width: 100%;
 
-    .p-media-object__details {
-      overflow: hidden;
-    }
-
     .p-media-object__title {
       max-width: 100%;
       overflow: hidden;
@@ -22,7 +18,6 @@
         display: flex;
         -webkit-line-clamp: 2;
         max-height: 3.4rem;
-        overflow: hidden;
         text-decoration: none;
       }
 


### PR DESCRIPTION
## Done
Fixed hidden tooltip on featured snap cards

## How to QA
- Go to https://snapcraft-io-4107.demos.haus/
- Hover over the tick next to the publisher name on any of the featured snaps
- Check that the tooltip is visible

## Issue / Card
Fixes #4106