### PR TITLE
Fix metadata warning when changing images

### DIFF
--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -8,7 +8,12 @@ import {
   Button,
 } from "@canonical/react-components";
 
-import { getChanges, getFormData, getListingData } from "../../utils";
+import {
+  getChanges,
+  getFormData,
+  getListingData,
+  shouldShowUpdateMetadataWarning,
+} from "../../utils";
 import { initListingTour } from "../../../tour";
 
 import PageHeader from "../../../shared/PageHeader";
@@ -56,7 +61,10 @@ function App() {
   const dirtyFields: { [key: string]: any } = formState.dirtyFields;
 
   const onSubmit = (data: any) => {
-    if (listingData?.update_metadata_on_release) {
+    if (
+      listingData?.update_metadata_on_release &&
+      shouldShowUpdateMetadataWarning(dirtyFields)
+    ) {
       setShowMetadataWarningModal(true);
       setFormData(data);
     } else {
@@ -68,19 +76,24 @@ function App() {
     const changes = getChanges(dirtyFields, data);
     const formData = getFormData(data, snapId, changes);
 
+    const previousDirtyFields = Object.assign({}, dirtyFields);
+
     setIsSaving(true);
 
     fetch(`/${data.snap_name}/listing`, {
       method: "POST",
       body: formData,
     }).then((response) => {
+      if (shouldShowUpdateMetadataWarning(previousDirtyFields)) {
+        setUpdateMetadataOnRelease(false);
+      }
+
       if (response.status === 200) {
         setTimeout(() => {
           setIsSaving(false);
           setHasSaved(true);
           reset(data);
           window.scrollTo(0, 0);
-          setUpdateMetadataOnRelease(false);
         }, 1000);
       } else {
         setTimeout(() => {

--- a/static/js/publisher/listing/utils/index.ts
+++ b/static/js/publisher/listing/utils/index.ts
@@ -4,6 +4,7 @@ import getListingData from "./getListingData";
 import validateImageDimensions from "./validateImageDimensions";
 import validateAspectRatio from "./validateAspectRatio";
 import formatFileSize from "./formatFileSize";
+import shouldShowUpdateMetadataWarning from "./shouldShowUpdateMetadataWarning";
 
 export {
   getChanges,
@@ -12,4 +13,5 @@ export {
   validateImageDimensions,
   validateAspectRatio,
   formatFileSize,
+  shouldShowUpdateMetadataWarning,
 };

--- a/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
@@ -1,0 +1,81 @@
+interface DirtyField {
+  [key: string]: any;
+}
+
+function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
+  const filteredDirtyFields = [];
+
+  for (const [key, value] of Object.entries(dirtyFields)) {
+    if (value === true && key !== "banner_url" && key !== "icon_url") {
+      filteredDirtyFields.push(key);
+    }
+
+    if (
+      key === "banner_url" &&
+      value === true &&
+      !filteredDirtyFields.includes("banner") &&
+      !filteredDirtyFields.includes("screenshot_urls")
+    ) {
+      filteredDirtyFields.push("banner");
+    }
+
+    if (
+      key === "icon_url" &&
+      value === true &&
+      !filteredDirtyFields.includes("icon")
+    ) {
+      filteredDirtyFields.push("icon");
+    }
+
+    if (key === "screenshot_urls" && value.includes(true)) {
+      filteredDirtyFields.push("screenshot_urls");
+    }
+  }
+
+  if (filteredDirtyFields.length === 1) {
+    if (
+      filteredDirtyFields.includes("icon") ||
+      filteredDirtyFields.includes("banner") ||
+      filteredDirtyFields.includes("screenshot_urls")
+    ) {
+      return false;
+    }
+  }
+
+  if (filteredDirtyFields.length === 2) {
+    if (
+      filteredDirtyFields.includes("icon") &&
+      filteredDirtyFields.includes("banner")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("icon") &&
+      filteredDirtyFields.includes("screenshot_urls")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls")
+    ) {
+      return false;
+    }
+  }
+
+  if (filteredDirtyFields.length === 3) {
+    if (
+      filteredDirtyFields.includes("icon") &&
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls")
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export default shouldShowUpdateMetadataWarning;


### PR DESCRIPTION
## Done
- Fixed an issue where the warning about updating metadata showed when the only change was to images (icon, banner, screenshots)

## How to QA
- Go to https://snapcraft-io-4109.demos.haus/SNAP_NAME/settings
- Make sure that `Update metadata on release` is enabled
- Go to https://snapcraft-io-4109.demos.haus/SNAP_NAME/listing
- Change an icon, banner or screenshot
- Check that you can save the changes without a modal warning first
- Go to https://snapcraft-io-4109.demos.haus/SNAP_NAME/settings
- Check that the `Update metadata on release` is still enabled
- Go to https://snapcraft-io-4109.demos.haus/SNAP_NAME/listing
- Change any field that isn't an image
- Check that when you go to save the images you have a modal confirming that you understand that the update metadata setting will be disabled
- Save the change(s)
- Go to https://snapcraft-io-4109.demos.haus/SNAP_NAME/settings
- Check that the `Update metadata on release` is disabled

## Issue / Card
Fixes #4108