### PR TITLE
Remove flash messages from published snaps page

### DIFF
--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -5,22 +5,6 @@ My published snaps — Linux software in the Snap Store
 {% endblock %}
 
 {% block content %}
-{% with messages = get_flashed_messages() %}
-{% if messages %}
-<section class="p-strip is-shallow">
-  {% for message in messages %}
-  <div class="u-fixed-width">
-    <div class="p-notification--positive">
-      <div class="p-notification__content">
-        <h5 class="p-notification__title">Success</h5>  
-        <p class="p-notification__message">{{ message|safe }}</p>
-      </div>
-    </div>
-  </div>
-  {% endfor %}
-</section>
-{% endif %}
-{% endwith %}
 
 {% include "publisher/_noscript.html" %}
 


### PR DESCRIPTION
## Done
Removed flash messages from /snaps

## How to QA
- Go to https://snapcraft-io-4133.demos.haus/SNAP_NAME/listing
- Make some changes and save them
- Go to https://snapcraft-io-4133.demos.haus/snaps
- There should not be any "Changes have been saved" messages

## Issue / Card
Fixes #4132