### PR TITLE
Fix flash message consumption

### DIFF
--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -372,10 +372,6 @@ def post_listing_snap(snap_name):
 
             return flask.render_template("publisher/listing.html", **context)
 
-        flask.flash("Changes applied successfully.", "positive")
-    else:
-        flask.flash("No changes to save.", "information")
-
     return flask.redirect(
         flask.url_for(".get_listing_snap", snap_name=snap_name)
     )

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -191,8 +191,4 @@ def post_settings(snap_name):
 
             return flask.render_template("publisher/settings.html", **context)
 
-        flask.flash("Changes applied successfully.", "positive")
-    else:
-        flask.flash("No changes to save.", "information")
-
     return flask.redirect(flask.url_for(".get_settings", snap_name=snap_name))


### PR DESCRIPTION
## Done
Stopped setting flash messages on listing and settings pages as they are not used and could be displayed on other pages in error

## How to QA
- Go to https://snapcraft-io-4134.demos.haus/SNAP_NAME/listing
- Make changes and save
- Check that you see a saved successfully notification
- Go to https://snapcraft-io-4134.demos.haus/SNAP_NAME/settings
- Make changes and save
- Check that you see a saved successfully notification

## Issue / Card
Fixes #4132