### PR TITLE
Add collaborations tab

### DIFF
--- a/static/js/publisher/collaboration/components/App/App.tsx
+++ b/static/js/publisher/collaboration/components/App/App.tsx
@@ -1,0 +1,19 @@
+import React, { useState } from "react";
+
+import PageHeader from "../../../shared/PageHeader";
+
+function App() {
+  const [data, setData] = useState(window?.data);
+
+  return (
+    <div>
+      <PageHeader
+        snapName={data.snap_name}
+        activeTab="collaboration"
+        publisherName={data?.publisher_name}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/static/js/publisher/collaboration/components/App/index.tsx
+++ b/static/js/publisher/collaboration/components/App/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./App";

--- a/static/js/publisher/collaboration/index.tsx
+++ b/static/js/publisher/collaboration/index.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import * as Sentry from "@sentry/react";
+import { Integrations } from "@sentry/tracing";
+import App from "./components/App";
+
+Sentry.init({
+  dsn: window.SENTRY_DSN,
+  integrations: [new Integrations.BrowserTracing()],
+  tracesSampleRate: 1.0,
+});
+
+ReactDOM.render(<App />, document.getElementById("main-content"));

--- a/static/js/publisher/collaboration/types/index.d.ts
+++ b/static/js/publisher/collaboration/types/index.d.ts
@@ -1,0 +1,11 @@
+// Empty export to mark this file as a module.
+// This is required to augment global scope.
+export {};
+
+declare global {
+  interface Window {
+    SENTRY_DSN: string;
+    CSRF_TOKEN: string;
+    data: any;
+  }
+}

--- a/static/js/publisher/shared/PageHeader/PageHeader.tsx
+++ b/static/js/publisher/shared/PageHeader/PageHeader.tsx
@@ -4,14 +4,25 @@ import { Strip, Tabs } from "@canonical/react-components";
 type Props = {
   snapName: string;
   activeTab: string;
+  publisherName?: string;
 };
 
-function PageHeader({ snapName, activeTab }: Props) {
+function PageHeader({ snapName, activeTab, publisherName }: Props) {
   return (
     <Strip shallow={true} className="u-no-padding--bottom">
       <div className="u-fixed-width">
         <a href="/snaps">&lsaquo;&nbsp;My snaps</a>
-        <h1 className="p-heading--3">{snapName}</h1>
+        <div className="u-flex" style={{ alignItems: "baseline" }}>
+          <h1 className="p-heading--3">{snapName}</h1>
+          {publisherName && (
+            <p
+              className="u-text-muted u-no-margin--bottom"
+              style={{ marginLeft: "0.5rem" }}
+            >
+              by {publisherName}
+            </p>
+          )}
+        </div>
         <Tabs
           listClassName="u-no-margin--bottom"
           links={[

--- a/templates/publisher/collaboration.html
+++ b/templates/publisher/collaboration.html
@@ -1,0 +1,15 @@
+{% extends "publisher/_publisher_layout.html" %}
+
+{% block meta_title %}
+Collaboration for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}{% endif %}
+{% endblock %}
+
+{% block content %}
+<main id="main-content"></main>
+<script>
+  window.SENTRY_DSN = "{{ SENTRY_DSN }}";
+  window.CSRF_TOKEN = "{{ csrf_token() }}";
+  window.data = JSON.parse({{ collaborations_data|tojson }});
+</script>
+<script src="{{ static_url('js/dist/publisher-collaboration.js') }}"></script>
+{% endblock %}

--- a/webapp/publisher/snaps/collaboration_views.py
+++ b/webapp/publisher/snaps/collaboration_views.py
@@ -1,0 +1,46 @@
+# Packages
+import flask
+from flask import json
+from canonicalwebteam.store_api.stores.snapstore import (
+    SnapPublisher,
+    SnapStore,
+)
+from canonicalwebteam.store_api.exceptions import (
+    StoreApiError,
+    StoreApiResponseErrorList,
+)
+
+# Local
+from webapp.helpers import api_publisher_session
+from webapp.api.exceptions import ApiError
+from webapp.decorators import login_required
+from webapp.publisher.views import _handle_error, _handle_error_list
+
+store_api = SnapStore(api_publisher_session)
+publisher_api = SnapPublisher(api_publisher_session)
+
+
+@login_required
+def get_collaboration_snap(snap_name):
+    try:
+        snap_details = publisher_api.get_snap_info(snap_name, flask.session)
+    except StoreApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code == 404:
+            return flask.abort(404, "No snap named {}".format(snap_name))
+        else:
+            return _handle_error_list(api_response_error_list.errors)
+    except (StoreApiError, ApiError) as api_error:
+        return _handle_error(api_error)
+
+    context = {
+        "snap_id": snap_details["snap_id"],
+        "snap_name": snap_details["snap_name"],
+        "snap_title": snap_details["title"],
+        "publisher_name": snap_details["publisher"]["display-name"],
+    }
+
+    return flask.render_template(
+        "publisher/collaboration.html",
+        **context,
+        collaborations_data=json.dumps(context)
+    )

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -19,6 +19,7 @@ from webapp.publisher.snaps import (
     publicise_views,
     release_views,
     settings_views,
+    collaboration_views,
 )
 from webapp.publisher.snaps.builds import map_snap_build_status
 from webapp.publisher.views import _handle_error, _handle_error_list
@@ -62,6 +63,11 @@ publisher_snaps.add_url_rule(
     "/<snap_name>/preview",
     view_func=listing_views.post_preview,
     methods=["POST"],
+)
+publisher_snaps.add_url_rule(
+    "/<snap_name>/collaboration",
+    view_func=collaboration_views.get_collaboration_snap,
+    methods=["GET"],
 )
 
 # Build views

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -21,4 +21,5 @@ module.exports = {
   "brand-store": "./static/js/brand-store/brand-store.js",
   "publisher-listing": "./static/js/publisher/listing/index.tsx",
   "publisher-settings": "./static/js/publisher/settings/index.tsx",
+  "publisher-collaboration": "./static/js/publisher/collaboration/index.tsx",
 };


### PR DESCRIPTION
## Done
Added the collaborations tab to the publisher pages

## How to QA
- Go to https://snapcraft-io-4137.demos.haus/SNAP_NAME/collaboration
- Check that there is a page with the snap name, publisher name and the navigation (note that the link for this page is not in the navigation because we don't want to expose this page)

## Issue / Card
Fixes #4113 