### PR TITLE
Remove email address validation from the listing page

### DIFF
--- a/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
+++ b/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
@@ -86,9 +86,6 @@ function ContactInformationSection({
         placeholder="mailto:example@example.com"
         helpText="An http: or https: link, or an e-mail address"
         getFieldState={getFieldState}
-        pattern={
-          /(^https?:\/\/[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$)|(^mailto:)?([a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$)/
-        }
         tourLabel=""
       />
     </>

--- a/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
+++ b/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
@@ -86,6 +86,9 @@ function ContactInformationSection({
         placeholder="mailto:example@example.com"
         helpText="An http: or https: link, or an e-mail address"
         getFieldState={getFieldState}
+        pattern={
+          /(^https?:\/\/[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$)|(^mailto:)?([a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+(?:\?[a-zA-Z0-9-=&]+)*$)/
+        }
         tourLabel=""
       />
     </>


### PR DESCRIPTION
## Done
Fixed the email validation on the listing page

## How to QA
- Go to https://snapcraft-io-4148.demos.haus/SNAP_NAME/listing
- Check that you can add a query string to the contact email address, e.g. (email@email.com?subject=foo)