### PR TITLE
Remove check as the API will handle it

### DIFF
--- a/tests/publisher/snaps/tests_post_release.py
+++ b/tests/publisher/snaps/tests_post_release.py
@@ -18,28 +18,21 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
     def setUp(self):
         snap_name = "test-snap"
         endpoint_url = "/{}/releases".format(snap_name)
-        api_url = "https://dashboard.snapcraft.io/dev/api/account"
-        self.release_api_url = (
-            "https://dashboard.snapcraft.io/dev/api/snap-release/"
-        )
+        api_url = "https://dashboard.snapcraft.io/dev/api/snap-release/"
 
         super().setUp(
             snap_name=snap_name,
             api_url=api_url,
             endpoint_url=endpoint_url,
-            method_api="GET",
+            method_api="POST",
             method_endpoint="POST",
-            json={snap_name: {}},
+            json={"json": "josn"},
         )
 
     @responses.activate
-    def test_not_a_collaborator(self):
-        responses.add(
-            responses.GET,
-            self.api_url,
-            json={"snaps": {"16": ["other-snap"]}},
-            status=200,
-        )
+    def test_page_not_found(self):
+        payload = {"error_list": []}
+        responses.add(responses.POST, self.api_url, json=payload, status=404)
 
         response = self.client.post(
             self.endpoint_url,
@@ -53,37 +46,6 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
         self.assertEqual(1, len(responses.calls))
         called = responses.calls[0]
         self.assertEqual(self.api_url, called.request.url)
-
-        assert response.status_code == 400
-
-    @responses.activate
-    def test_page_not_found(self):
-        responses.add(
-            responses.GET,
-            self.api_url,
-            json={"snaps": {"16": [self.snap_name]}},
-            status=200,
-        )
-
-        responses.add(
-            responses.POST,
-            self.release_api_url,
-            json={"error_list": []},
-            status=404,
-        )
-
-        response = self.client.post(
-            self.endpoint_url,
-            json={
-                "name": self.snap_name,
-                "revision": "1",
-                "channels": ["stable"],
-            },
-        )
-
-        self.assertEqual(2, len(responses.calls))
-        called = responses.calls[1]
-        self.assertEqual(self.release_api_url, called.request.url)
         self.assertEqual(
             self.authorization, called.request.headers.get("Authorization")
         )
@@ -93,13 +55,6 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_post_no_data(self):
-        responses.add(
-            responses.GET,
-            self.api_url,
-            json={"snaps": {"16": [self.snap_name]}},
-            status=200,
-        )
-
         response = self.client.post(self.endpoint_url)
 
         assert response.status_code == 400
@@ -107,13 +62,6 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_post_data(self):
-        responses.add(
-            responses.GET,
-            self.api_url,
-            json={"snaps": {"16": [self.snap_name]}},
-            status=200,
-        )
-
         payload = {
             "success": True,
             "channel_map": [
@@ -130,9 +78,7 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
             "opened_channels": ["candidate"],
         }
 
-        responses.add(
-            responses.POST, self.release_api_url, json=payload, status=200
-        )
+        responses.add(responses.POST, self.api_url, json=payload, status=200)
 
         response = self.client.post(
             self.endpoint_url,
@@ -143,9 +89,9 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
             },
         )
 
-        self.assertEqual(2, len(responses.calls))
-        called = responses.calls[1]
-        self.assertEqual(self.release_api_url, called.request.url)
+        self.assertEqual(1, len(responses.calls))
+        called = responses.calls[0]
+        self.assertEqual(self.api_url, called.request.url)
         self.assertEqual(
             self.authorization, called.request.headers.get("Authorization")
         )
@@ -154,18 +100,9 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_return_error(self):
-        responses.add(
-            responses.GET,
-            self.api_url,
-            json={"snaps": {"16": [self.snap_name]}},
-            status=200,
-        )
-
         payload = {"success": False, "errors": [{"name": ["message"]}]}
 
-        responses.add(
-            responses.POST, self.release_api_url, json=payload, status=400
-        )
+        responses.add(responses.POST, self.api_url, json=payload, status=400)
 
         response = self.client.post(
             self.endpoint_url,

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -87,25 +87,8 @@ def get_release_history_json(snap_name):
 def post_release(snap_name):
     data = flask.request.json
 
-    # Show error message for no contributors
-    try:
-        account_snaps = publisher_api.get_account_snaps(flask.session)
-    except StoreApiResponseErrorList as api_response_error_list:
-        if api_response_error_list.status_code == 404:
-            return flask.abort(404, "No snap named {}".format(snap_name))
-        else:
-            return flask.jsonify(api_response_error_list.errors), 400
-    except (StoreApiError, ApiError) as api_error:
-        return _handle_error(api_error)
-
     if not data:
         response = {"errors": ["No changes were submitted"]}
-        return flask.jsonify(response), 400
-
-    if snap_name not in account_snaps:
-        response = {
-            "errors": ["You do not have permissions to modify this Snap"]
-        }
         return flask.jsonify(response), 400
 
     try:


### PR DESCRIPTION
## Done

There is no need to check if the user is the owner or has permission because the API will do it.