### PR TITLE
Fix no store screen showing

### DIFF
--- a/static/js/brand-store/slices/membersSlice.ts
+++ b/static/js/brand-store/slices/membersSlice.ts
@@ -11,10 +11,12 @@ export const slice = createSlice({
   reducers: {
     getMembersLoading: (state) => {
       state.loading = true;
+      state.notFound = false;
     },
     getMembersSuccess: (state, { payload }) => {
       state.members = payload || [];
       state.loading = false;
+      state.notFound = false;
     },
     getMembersNotFound: (state) => {
       state.notFound = true;

--- a/static/js/brand-store/slices/snapsSlice.ts
+++ b/static/js/brand-store/slices/snapsSlice.ts
@@ -11,10 +11,12 @@ export const slice = createSlice({
   reducers: {
     getSnapsLoading: (state) => {
       state.loading = true;
+      state.notFound = false;
     },
     getSnapsSuccess: (state, { payload }) => {
       state.snaps = payload || [];
       state.loading = false;
+      state.notFound = false;
     },
     getSnapsNotFound: (state) => {
       state.notFound = true;


### PR DESCRIPTION
## Done
Fixed a bug that shows that a store is not found when navigated to from the side navigation following loading a store that you don't have full access for.

## How to QA
- Go to https://snapcraft-io-4153.demos.haus/admin
- Use the side navigation to go to a store that you are a publisher in
- Then use the side navigation to go to a store that you have access to
- You should see the store and not the "Store not found" page
- Change the store ID in the URL to an ID that doesn't exist
- You should see the "Store not found" page

## Issue / Card
Fixes #4152