### PR TITLE
fix display of checkbox and its label content in the newsletter on blog page

### DIFF
--- a/templates/partials/_newsletter-signup.html
+++ b/templates/partials/_newsletter-signup.html
@@ -8,9 +8,9 @@
                 <input id="Email" name="Email" maxlength="255" type="email" required />
             </div>
             <div class="p-form__group">
-                <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" type="checkbox" value="Receive updates"/>
-                <label for="canonicalUpdatesOptIn">
-                    I agree to receive information about Canonical’s products and services.
+                <label for="canonicalUpdatesOptIn" class="p-checkbox">
+                    <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" type="checkbox" value="Receive updates" class="p-checkbox__input"/>
+                    <span class="p-checkbox__label">I agree to receive information about Canonical’s products and services.</span>
                 </label>
             </div>
             <p>


### PR DESCRIPTION


## Done
- fix display of checkbox and its label content in the newsletter on blog page
## How to QA
- visit /blog and check the newsletter signup card
## Issue / Card
Fixes #4063 
## Screenshots
<img width="351" alt="image" src="https://user-images.githubusercontent.com/47438585/201928275-89602e5a-2faa-4369-aacb-9a3ce70928d5.png">