### PR TITLE
Fix update metadata warning fields

### DIFF
--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -78,6 +78,15 @@ function App() {
 
     const previousDirtyFields = Object.assign({}, dirtyFields);
 
+    if (
+      updateMetadataOnRelease &&
+      !shouldShowUpdateMetadataWarning(previousDirtyFields)
+    ) {
+      formData.set("update_metadata_on_release", "on");
+    } else {
+      formData.set("update_metadata_on_release", "off");
+    }
+
     setIsSaving(true);
 
     fetch(`/${data.snap_name}/listing`, {

--- a/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
@@ -6,7 +6,13 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
   const filteredDirtyFields = [];
 
   for (const [key, value] of Object.entries(dirtyFields)) {
-    if (value === true && key !== "banner_url" && key !== "icon_url") {
+    if (
+      value === true &&
+      key !== "banner_url" &&
+      key !== "video_urls" &&
+      key !== "primary-category" &&
+      key !== "secondary-category"
+    ) {
       filteredDirtyFields.push(key);
     }
 
@@ -19,24 +25,30 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
       filteredDirtyFields.push("banner");
     }
 
-    if (
-      key === "icon_url" &&
-      value === true &&
-      !filteredDirtyFields.includes("icon")
-    ) {
-      filteredDirtyFields.push("icon");
-    }
-
     if (key === "screenshot_urls" && value.includes(true)) {
       filteredDirtyFields.push("screenshot_urls");
+    }
+
+    if (key === "video_urls" && value === true) {
+      filteredDirtyFields.push("video_urls");
+    }
+
+    if (key === "primary-category" && value === true) {
+      filteredDirtyFields.push("primary-category");
+    }
+
+    if (key === "secondary-category" && value === true) {
+      filteredDirtyFields.push("secondary-category");
     }
   }
 
   if (filteredDirtyFields.length === 1) {
     if (
-      filteredDirtyFields.includes("icon") ||
       filteredDirtyFields.includes("banner") ||
-      filteredDirtyFields.includes("screenshot_urls")
+      filteredDirtyFields.includes("screenshot_urls") ||
+      filteredDirtyFields.includes("video_urls") ||
+      filteredDirtyFields.includes("primary-category") ||
+      filteredDirtyFields.includes("secondary-category")
     ) {
       return false;
     }
@@ -44,14 +56,7 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
 
   if (filteredDirtyFields.length === 2) {
     if (
-      filteredDirtyFields.includes("icon") &&
-      filteredDirtyFields.includes("banner")
-    ) {
-      return false;
-    }
-
-    if (
-      filteredDirtyFields.includes("icon") &&
+      filteredDirtyFields.includes("banner") &&
       filteredDirtyFields.includes("screenshot_urls")
     ) {
       return false;
@@ -59,7 +64,42 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
 
     if (
       filteredDirtyFields.includes("banner") &&
-      filteredDirtyFields.includes("screenshot_urls")
+      filteredDirtyFields.includes("video_urls")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("primary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("primary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
     ) {
       return false;
     }
@@ -67,9 +107,92 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
 
   if (filteredDirtyFields.length === 3) {
     if (
-      filteredDirtyFields.includes("icon") &&
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
       filteredDirtyFields.includes("banner") &&
-      filteredDirtyFields.includes("screenshot_urls")
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("video_urls")
+    ) {
+      return false;
+    }
+  }
+
+  if (filteredDirtyFields.length === 4) {
+    if (
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("secondary-category")
+    ) {
+      return false;
+    }
+
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("primary-category")
+    ) {
+      return false;
+    }
+  }
+
+  if (filteredDirtyFields.length === 5) {
+    if (
+      filteredDirtyFields.includes("banner") &&
+      filteredDirtyFields.includes("screenshot_urls") &&
+      filteredDirtyFields.includes("video_urls") &&
+      filteredDirtyFields.includes("primary-category") &&
+      filteredDirtyFields.includes("secondary-category")
     ) {
       return false;
     }

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -237,8 +237,21 @@ def post_listing_snap(snap_name):
                     body_json["description"]
                 )
 
-            if flask.request.form.get("update_metadata_on_release") == "on":
-                body_json["update_metadata_on_release"] = True
+            print("==========================================================")
+            print(body_json)
+
+            print("==========================================================")
+            print(flask.request.form.get("update_metadata_on_release"))
+
+            print("==========================================================")
+            print(body_json)
+
+            body_json["update_metadata_on_release"] = flask.request.form.get(
+                "update_metadata_on_release"
+            )
+
+            print("==========================================================")
+            print(body_json)
 
             try:
                 publisher_api.snap_metadata(snap_id, flask.session, body_json)

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -237,7 +237,8 @@ def post_listing_snap(snap_name):
                     body_json["description"]
                 )
 
-            body_json["update_metadata_on_release"] = False
+            if flask.request.form.get("update_metadata_on_release") == "on":
+                body_json["update_metadata_on_release"] = True
 
             try:
                 publisher_api.snap_metadata(snap_id, flask.session, body_json)

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -88,6 +88,10 @@ def post_settings(snap_name):
     changes = None
     changed_fields = flask.request.form.get("changes")
 
+    print("==================================================================")
+    print(changed_fields)
+    print("==================================================================")
+
     if changed_fields:
         changes = loads(changed_fields)
 
@@ -99,6 +103,8 @@ def post_settings(snap_name):
 
         if body_json:
             try:
+                print("======================================================")
+                print(body_json)
                 publisher_api.snap_metadata(snap_id, flask.session, body_json)
             except StoreApiResponseErrorList as api_response_error_list:
                 if api_response_error_list.status_code == 404:


### PR DESCRIPTION
## Done
- Updated logic on the listing page to not show warning about metadata links when saving changes to video URL and categories.

## How to QA
- Go to https://snapcraft-io-4161.demos.haus/SNAP_NAME/listing
- Make changes only to video URL and category fields
- When saving the form should just save
- Make changes to other fields
- Before saving you should see a modal with a warning
