### PR TITLE
Change position of snap releases change bar

### DIFF
--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -1,6 +1,8 @@
-import React, { Component, Fragment } from "react";
+import React, { Component, createRef } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+
+import debounce from "../../../libs/debounce";
 
 import ReleasesConfirmDetails from "./releasesConfirmDetails/";
 import ReleasesConfirmActions from "./releasesConfirmActions";
@@ -21,6 +23,23 @@ class ReleasesConfirm extends Component {
       isLoading: false,
       showDetails: false,
     };
+
+    this.stickyBar = createRef();
+  }
+
+  componentDidMount() {
+    document.addEventListener(
+      "scroll",
+      debounce(() => {
+        const stickyBarRec = this.stickyBar.current.getBoundingClientRect();
+        const top = stickyBarRec.top;
+        const scrollX = window.scrollX;
+        const topPosition = top + scrollX;
+
+        this.stickyBar.current.classList.toggle("is-pinned", topPosition === 0);
+      }),
+      500
+    );
   }
 
   onRevertClick() {
@@ -83,61 +102,59 @@ class ReleasesConfirm extends Component {
     const isCancelEnabled = updatesCount > 0 && !isLoading;
 
     return (
-      <Fragment>
+      <>
         <div
           className={`p-releases-confirm ${updatesCount > 0 ? "" : "u-hide"}`}
+          ref={this.stickyBar}
         >
-          <div
-            className="row u-vertically-center"
-            style={{ marginBottom: "0.5rem" }}
-          >
-            <div className="col-6">
-              {updatesCount > 0 && (
-                <Fragment>
-                  <button
-                    type="button"
-                    className="p-button--base u-no-margin--bottom has-icon"
-                    onClick={this.toggleDetails.bind(this)}
-                  >
-                    <i
-                      className={`${
-                        showDetails
-                          ? "p-icon--chevron-down"
-                          : "p-icon--chevron-up"
-                      }`}
+          <div className="u-fixed-width">
+            <div className="row u-vertically-center p-releases-row">
+              <div className="col-6">
+                {updatesCount > 0 && (
+                  <>
+                    <button
+                      type="button"
+                      className="p-button--base u-no-margin--bottom has-icon"
+                      onClick={this.toggleDetails.bind(this)}
                     >
-                      {showDetails ? "Hide" : "Show"} details
-                    </i>
-                    <span>
-                      {updatesCount} update
-                      {updatesCount > 1 ? "s" : ""}
-                    </span>
-                  </button>
-                </Fragment>
-              )}
+                      <i
+                        className={`${
+                          showDetails
+                            ? "p-icon--chevron-down"
+                            : "p-icon--chevron-up"
+                        }`}
+                      >
+                        {showDetails ? "Hide" : "Show"} details
+                      </i>
+                      <span>
+                        {updatesCount} update
+                        {updatesCount > 1 ? "s" : ""}
+                      </span>
+                    </button>
+                  </>
+                )}
+              </div>
+              <div className="col-6 p-releases-confirm__actions">
+                {updatesCount > 0 && (
+                  <div
+                    className={`p-releases-confirm__details-toggle ${
+                      showDetails ? "is-open" : ""
+                    }`}
+                  ></div>
+                )}
+                <ReleasesConfirmActions
+                  isCancelEnabled={isCancelEnabled}
+                  cancelPendingReleases={this.onRevertClick.bind(this)}
+                  isApplyEnabled={isApplyEnabled}
+                  applyPendingReleases={this.onApplyClick.bind(this)}
+                  isLoading={isLoading}
+                />
+              </div>
             </div>
-            <div className="col-6 p-releases-confirm__actions">
-              {updatesCount > 0 && (
-                <div
-                  className={`p-releases-confirm__details-toggle ${
-                    showDetails ? "is-open" : ""
-                  }`}
-                ></div>
-              )}
-              <ReleasesConfirmActions
-                isCancelEnabled={isCancelEnabled}
-                cancelPendingReleases={this.onRevertClick.bind(this)}
-                isApplyEnabled={isApplyEnabled}
-                applyPendingReleases={this.onApplyClick.bind(this)}
-                isLoading={isLoading}
-              />
-            </div>
-          </div>
-          <div className="row">
             {showDetails && <ReleasesConfirmDetails updates={updates} />}
           </div>
         </div>
-      </Fragment>
+      </>
     );
   }
 }

--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -39,25 +39,27 @@ class ReleasesHeading extends Component {
 
     const Wrap = tracks.length > 1 ? "label" : "span";
     return (
-      <div className="row">
-        <div className="col-6">
-          <h4>
-            <Wrap htmlFor="track-dropdown">
-              {tracks.length > 1 ? (
-                <>
-                  Track &nbsp;
-                  {this.renderTrackDropdown(tracks)}
-                </>
-              ) : (
-                <>Releases available to install</>
-              )}
-            </Wrap>
-          </h4>
+      <section className="p-strip is-shallow u-no-padding--bottom">
+        <div className="row">
+          <div className="col-6">
+            <h4>
+              <Wrap htmlFor="track-dropdown">
+                {tracks.length > 1 ? (
+                  <>
+                    Track &nbsp;
+                    {this.renderTrackDropdown(tracks)}
+                  </>
+                ) : (
+                  <>Releases available to install</>
+                )}
+              </Wrap>
+            </h4>
+          </div>
+          <div className="col-6" style={{ marginTop: "0.25rem" }}>
+            {tracks.length > 1 && <DefaultTrackModifier />}
+          </div>
         </div>
-        <div className="col-6" style={{ marginTop: "0.25rem" }}>
-          {tracks.length > 1 && <DefaultTrackModifier />}
-        </div>
-      </div>
+      </section>
     );
   }
 }

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -52,6 +52,7 @@ const ReleasesController = ({
   const { visible } = notification;
   return (
     <Fragment>
+      {ready && <ReleasesConfirm />}
       {!ready && (
         <div className="p-strip">
           <div className="row">
@@ -85,7 +86,6 @@ const ReleasesController = ({
           <ReleasesHeading />
           <ReleasesTable />
           {showModal && <Modal />}
-          <ReleasesConfirm />
         </Fragment>
       )}
     </Fragment>

--- a/static/sass/_snapcraft_p-release-details-row.scss
+++ b/static/sass/_snapcraft_p-release-details-row.scss
@@ -2,7 +2,6 @@
   .p-release-details-row {
     align-items: center;
     display: grid;
-    font-size: 0.875rem;
     grid-column-gap: 1rem;
     grid-template-columns: 4rem 15rem 2rem auto 16rem;
     padding: 0.25rem 0;

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -4,17 +4,26 @@
   $color-highlighted: #e9ffec;
   $color-highlighted-border: 1px dashed #0e8420;
 
+  .p-releases-row {
+    border-bottom: $border;
+    padding: $spv--small 0;
+
+    .is-pinned & {
+      border-bottom: none;
+    }
+  }
+
   // RELEASES CONFIRM
 
   .p-releases-confirm {
     background-color: $color-x-light;
-    bottom: 0;
-    box-shadow: 0 1px 7px rgba(0, 0, 0, 0.3);
-    left: 0;
-    padding: 0.5em 0 0;
-    position: fixed;
-    right: 0;
-    z-index: 20;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+
+    &.is-pinned {
+      box-shadow: 0 3px 3px rgba(51, 51, 51, 0.2);
+    }
   }
 
   .p-releases-confirm__buttons {
@@ -46,9 +55,15 @@
   }
 
   .p-releases-confirm__details {
-    border-top: 1px solid $color-mid-light;
+    border-bottom: $border;
     margin-bottom: 1rem;
-    padding-top: 0.25rem;
+    padding-bottom: $spv--small;
+    padding-top: $spv--small;
+
+    .is-pinned & {
+      border-bottom: none;
+      border-top: $border;
+    }
   }
 
   // RELEASES TABLE

--- a/templates/publisher/release-history.html
+++ b/templates/publisher/release-history.html
@@ -9,23 +9,21 @@ Releases and revision history for {% if snap_title %}{{ snap_title }}{% else %}{
   {% set selected_tab='release' %}
   {% include "publisher/_header.html" %}
 
-  <section class="p-strip is-shallow">
-    <div id="release-history">
-      {% if release_history["error-list"] %}
-        <div class="row">
-          <div class="p-notification--negative">
-            <div class="p-notification__content">
-              <p class="p-notification__message">
-                {% for error in release_history["error-list"] %}
-                  <strong>{{ error.code }}:</strong> {{ error.message }}<br />
-                {% endfor %}
-              </p>
-            </div>
+  <div id="release-history">
+    {% if release_history["error-list"] %}
+      <div class="row">
+        <div class="p-notification--negative">
+          <div class="p-notification__content">
+            <p class="p-notification__message">
+              {% for error in release_history["error-list"] %}
+                <strong>{{ error.code }}:</strong> {{ error.message }}<br />
+              {% endfor %}
+            </p>
           </div>
         </div>
-      {% endif %}
-    </div>
-  </section>
+      </div>
+    {% endif %}
+  </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Done
- Moved the changes bar from the footer to the top of the releases page

## How to QA
- Go to a snaps releases page, e.g. https://snapcraft-io-4167.demos.haus/steve-test-snap/releases
- Make a change and check that the sticky bar with the changes is just beneath the publisher pages navigation

## Issue / Card
Fixes #4128 
Fixes https://warthogs.atlassian.net/browse/WD-705

## Screenshots
<img width="1196" alt="Screenshot 2022-11-25 at 14 28 16" src="https://user-images.githubusercontent.com/501889/204005537-900f7bb6-864a-4c05-aa57-f959f171eb41.png">

<img width="1157" alt="Screenshot 2022-11-25 at 14 28 25" src="https://user-images.githubusercontent.com/501889/204005541-4da08d47-bc07-499d-8c8b-b7e787fbb107.png">
