### PR TITLE
Refactor settings page

### DIFF
--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -140,8 +140,7 @@ function App() {
                   setSavedError(false);
                 }}
               >
-                Please try again later. If the problem persists please contact
-                us.
+                Please try again later.
               </Notification>
             </div>
           )}

--- a/static/js/publisher/settings/utils/getFormData.ts
+++ b/static/js/publisher/settings/utils/getFormData.ts
@@ -40,9 +40,11 @@ function getFormData(
     formData.set("blacklist_countries", "");
   }
 
-  if (changes?.update_metadata_on_release === "on") {
-    formData.set("update_metadata_on_release", "on");
-  }
+  // Forcefully send the state of update_metadata_on_release in an attempt
+  // to ensure it doesn't get disabled when other fields are changed.
+  // This hasn't worked:
+  // https://chat.canonical.com/canonical/pl/67rcgxrtmfyufr9fjd46oit87r
+  changes["update_metadata_on_release"] = data?.update_metadata_on_release;
 
   formData.set("changes", JSON.stringify(changes));
 

--- a/tests/publisher/snaps/tests_post_settings.py
+++ b/tests/publisher/snaps/tests_post_settings.py
@@ -107,6 +107,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "keywords": [],
             "status": "published",
             "publisher": {"display-name": "test"},
+            "update_metadata_on_release": False,
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -188,6 +189,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "keywords": [],
             "status": "published",
             "publisher": {"display-name": "test"},
+            "update_metadata_on_release": False,
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)
@@ -279,6 +281,7 @@ class PostMetadataSettingsPage(BaseTestCases.EndpointLoggedIn):
             "store": "stotore",
             "keywords": [],
             "status": "published",
+            "update_metadata_on_release": False,
         }
 
         responses.add(responses.GET, info_url, json=payload, status=200)

--- a/tests/publisher/snaps/tests_settings.py
+++ b/tests/publisher/snaps/tests_settings.py
@@ -59,6 +59,7 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "status": "published",
             "publisher": {"display-name": "test"},
             "update_metadata_on_release": True,
+            "license": "",
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -220,8 +220,17 @@ publisher_snaps.add_url_rule(
     view_func=settings_views.get_settings,
 )
 publisher_snaps.add_url_rule(
+    "/<snap_name>/settings.json",
+    view_func=settings_views.get_settings_json,
+)
+publisher_snaps.add_url_rule(
     "/<snap_name>/settings",
     view_func=settings_views.post_settings,
+    methods=["POST"],
+)
+publisher_snaps.add_url_rule(
+    "/<snap_name>/settings.json",
+    view_func=settings_views.post_settings_json,
     methods=["POST"],
 )
 


### PR DESCRIPTION
## Done
- Settings App.tsx:
  - Refactor onSubmit to handle meta `visibility` field from the form
  - Refactor onSubmit to handle return of success to construct meta `visibility` field for the form
  - Remove notifications of previous saves on submit
  - Call new `settings.json` endpoint to avoid a page reload
  - Set form data to the data returned by the json endpoint
  - Update error message on failure
  - Ensure `update_metadata_on_release` is converted to a boolean
- Settings getFormData:
  - Ensure `update_metadata_on_release` is always set (temporary)

- settings_views.py
  - Add associated json methods for `get_settings` and `post_settings`
  - Update `get_settings` and `post_settings` to accept second param `return_json`
  - Ensure license is using the `snap_details` `license`. Not an undefined variable
  - For `post` return the response of the store `put`.
  - Remove `update_metadata_on_release` conditional as the frontend now returns the proper type
  - If `return_json` is `True` return JSON.

## How to QA
- Visit a snap on the demo and play around with the settings page.
- Make sure settings on other pages, such as `Listings` doesn't break.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-920

## Screenshots
