### PR TITLE
fix(bug): Fix snap links for publisher pages

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -407,7 +407,7 @@ def store_blueprint(store_query=None):
 
         for snap in snaps_results:
             item = snap["snap"]
-            item["name"] = snap["name"]
+            item["package_name"] = snap["name"]
             item["icon_url"] = helpers.get_icon(item["media"])
             snaps.append(item)
 


### PR DESCRIPTION
## Done
- Fix links

## How to QA
- Visit https://snapcraft-io-4179.demos.haus/publisher/canonical
- Click a snap, you should go to the snap page

## Issue / Card
Fixes #

## Screenshots
