### PR TITLE
Remove blog posts from snap details pages

### DIFF
--- a/templates/partials/_hiri-case-study.html
+++ b/templates/partials/_hiri-case-study.html
@@ -6,9 +6,6 @@
         <div class="col-4">
             <h3 class="p-heading--4">Case study</h3>
         </div>
-        <div class="col-8">
-            <h3 class="p-heading--4">Related blog posts</h3>
-        </div>
     </div>
     <div class="row u-equal-height" data-js="blog-articles">
         <div class="col-4">
@@ -16,6 +13,5 @@
                 <a href="https://www.ubuntu.com/engage/hiri-case-study" >Hiri successfully monetises their snap to dispel myths around proprietary Linux apps </a>
             </h3>
         </div>
-        <div class="col-8" data-js="blog-article-list" data-snap="{{ package_name }}" data-limit="2"></div>
     </div>
 </div>

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -176,25 +176,8 @@
     </div>
   </div>
 
-  {% if not IS_BRAND_STORE %}
-    {% if package_name == "hiri" %}
-      {% include "partials/_hiri-case-study.html" %}
-    {% else %}
-      <div data-js="blog-articles" class="u-hide">
-        <div class="u-fixed-width">
-          <hr />
-        </div>
-        <div class="p-strip is-shallow">
-          <div class="row">
-            <div class="col-3">
-              <h3 class="p-heading--4">Related blog posts</h3>
-            </div>
-          </div>
-          <div class="row u-equal-height" data-js="blog-article-list" data-snap="{{ package_name }}">
-          </div>
-        </div>
-      </div>
-    {% endif %}
+  {% if not IS_BRAND_STORE and package_name == "hiri" %}
+    {% include "partials/_hiri-case-study.html" %}
   {% endif %}
 
   {% if countries or normalized_os %}
@@ -362,12 +345,6 @@
 
         try {
           snapcraft.public.storeDetails.videos('.js-video-slide');
-        } catch(e) {
-          Raven.captureException(e);
-        }
-
-        try {
-          snapcraft.public.storeDetails.snapDetailsPosts('[data-js="blog-article-list"]', '#blog-article-template', '[data-js="blog-articles"]');
         } catch(e) {
           Raven.captureException(e);
         }


### PR DESCRIPTION
## Done
Removed calls to blog post fetching and related markdown from snap details pages, as agreed with PdM

## How to QA
Visit https://snapcraft-io-4191.demos.haus/code and make sure blog posts don't show
Visit https://snapcraft-io-4191.demos.haus/hiri and make sure that a case study shows, but no blog posts

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-1196

## Screenshots
