### PR TITLE
Remove specific emoji from display names

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-openid-auth==0.16
 Flask-OpenID==1.3.0
 Flask-WTF==0.15.1
 bleach==3.3.1
+emoji==2.2.0
 humanize==3.13.1
 mistune==2.0.4
 pybadges==3.0.0

--- a/templates/publisher/account-details.html
+++ b/templates/publisher/account-details.html
@@ -45,7 +45,7 @@ Account details — Linux software in the Snap Store
       Full name:
     </div>
     <div class="col-6">
-      <p class="u-no-padding--top"><b>{{ displayname }}</b></p>
+      <p class="u-no-padding--top"><b>{{ format_display_name(displayname) }}</b></p>
       <p class="p-form-help-text">
         Who your users will see as the publisher of your snap.
       </p>

--- a/templates/store/_media-object-snap-partial.html
+++ b/templates/store/_media-object-snap-partial.html
@@ -30,7 +30,7 @@
     <div class="p-media-object__content">
       {% if not hide_publisher %}
         <p class="u-overflow-visible">
-          <span class="u-off-screen">Publisher: </span>{{ snap.developer_name }}
+          <span class="u-off-screen">Publisher: </span>{{ format_display_name(snap.developer_name) }}
             {% if snap.developer_validation %}
               {% set package_name = snap.package_name %}
               {% if snap.developer_validation == VERIFIED_PUBLISHER %}

--- a/templates/store/community-publisher-details.html
+++ b/templates/store/community-publisher-details.html
@@ -2,12 +2,12 @@
 
 {% block meta_copydoc %}{% endblock %}
 
-{% block meta_title %}{{ publisher["display-name"] }} ({{ publisher["username"] }}) published snaps in the Snap Store{% endblock %}
+{% block meta_title %}{{ format_display_name(publisher["display-name"]) }} ({{ publisher["username"] }}) published snaps in the Snap Store{% endblock %}
 {% block meta_description %}
   {% if meta_description %}
     {{ meta_description }}
   {% else %}
-    Install snaps by {{ publisher["display-name"] }} ({{ publisher["username"] }}) for Linux in the Snap Store
+    Install snaps by {{ format_display_name(publisher["display-name"]) }} ({{ publisher["username"] }}) for Linux in the Snap Store
   {% endif %}
 {% endblock %}
 
@@ -17,7 +17,7 @@
     <div class="u-fixed-width">
       <div class="p-snap-heading">
         <div class="p-snap-heading__title">
-          <h1 class="p-heading--2 p-snap-heading__name">{{ publisher["display-name"] }}</h1>
+          <h1 class="p-heading--2 p-snap-heading__name">{{ format_display_name(publisher["display-name"]) }}</h1>
           <p class="p-snap-heading__publisher">
             ({{ publisher["username"] }})
             {% if publisher["validation"] %}
@@ -38,9 +38,9 @@
   <div class="p-strip is-shallow">
     <div class="row">
       {% if snaps_count == 1 %}
-	<h4>{{publisher["display-name"]}} has published 1 snap</h4>
+	<h4>{{ format_display_name(publisher["display-name"]) }} has published 1 snap</h4>
       {% else %}
-	<h4>{{publisher["display-name"]}} has published {{snaps_count}} snaps</h4>
+	<h4>{{ format_display_name(publisher["display-name"]) }} has published {{snaps_count}} snaps</h4>
       {% endif %}
       {% set hide_publisher = True %}
       {% set show_summary = True %}

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -182,7 +182,7 @@
             
     {% if contact or is_preview %}
       <li>
-        <a href="{{ contact }}" data-live="contact">Contact {{ publisher }}</a>
+        <a href="{{ contact }}" data-live="contact">Contact {{ format_display_name(publisher) }}</a>
       </li>
     {% endif %}
   </ul>

--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -82,7 +82,6 @@ class BaseTestCases:
 
     class EndpointLoggedOut(BaseAppTesting):
         def setUp(self, snap_name, endpoint_url, method_endpoint="GET"):
-
             self.method_endpoint = method_endpoint
             super().setUp(snap_name, None, endpoint_url)
 
@@ -109,7 +108,6 @@ class BaseTestCases:
             data=None,
             json=None,
         ):
-
             super().setUp(
                 snap_name=snap_name, api_url=api_url, endpoint_url=endpoint_url
             )

--- a/tests/publisher/tests_publisher.py
+++ b/tests/publisher/tests_publisher.py
@@ -45,7 +45,6 @@ class TestCache(BaseTestCases.EndpointLoggedInErrorHandling):
 
 
 class PublisherPage(TestCase):
-
     render_templates = False
 
     def create_app(self):

--- a/tests/publisher/tests_publisher_logic.py
+++ b/tests/publisher/tests_publisher_logic.py
@@ -4,7 +4,6 @@ from webapp.publisher.snaps import logic
 
 
 class PublisherLogicTest(unittest.TestCase):
-
     # get_snaps_account_info
     # ===
     def test_empty_snaps(self):

--- a/tests/snapcraft/tests_public.py
+++ b/tests/snapcraft/tests_public.py
@@ -7,7 +7,6 @@ responses.mock.assert_all_requests_are_fired = True
 
 
 class StorePage(TestCase):
-
     render_templates = False
 
     def create_app(self):

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -6,7 +6,6 @@ import webapp.store.logic as logic
 
 
 class StoreLogicTest(unittest.TestCase):
-
     # convert_channel_maps
     # ===
     def test_empty_channel_map(self):

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -62,7 +62,6 @@ class TemplateUtilsTest(unittest.TestCase):
         self.assertTrue(result, "10,000")
 
     def test_install_snippet(self):
-
         result = template_utils.install_snippet(
             "spotify", "latest", "stable", ""
         )

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -44,7 +44,6 @@ def get_stores():
 @admin.route("/admin/store/<store_id>")
 @login_required
 def get_settings(store_id):
-
     store = admin_api.get_store(flask.session, store_id)
 
     return jsonify(store)
@@ -83,7 +82,6 @@ def get_snaps_search(store_id):
 @admin.route("/admin/store/<store_id>/snaps")
 @login_required
 def get_store_snaps(store_id):
-
     snaps = admin_api.get_store_snaps(flask.session, store_id)
 
     return jsonify(snaps)
@@ -105,7 +103,6 @@ def post_manage_store_snaps(store_id):
 @admin.route("/admin/store/<store_id>/members")
 @login_required
 def get_manage_members(store_id):
-
     members = admin_api.get_store_members(flask.session, store_id)
 
     for item in members:
@@ -126,7 +123,6 @@ def post_manage_members(store_id):
         admin_api.update_store_members(flask.session, store_id, members)
         res["msg"] = "Changes saved"
     except StoreApiResponseErrorList as api_response_error_list:
-
         codes = [error.get("code") for error in api_response_error_list.errors]
 
         msgs = [
@@ -155,7 +151,6 @@ def post_manage_members(store_id):
 @admin.route("/admin/store/<store_id>/invites")
 @login_required
 def get_invites(store_id):
-
     invites = admin_api.get_store_invites(flask.session, store_id)
 
     return jsonify(invites)

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -188,7 +188,6 @@ def set_handlers(app):
     @app.errorhandler(ApiResponseErrorList)
     @app.errorhandler(StoreApiResponseErrorList)
     def handle_api_error_list(error):
-
         if error.status_code == 404:
             if "snap_name" in request.path:
                 return flask.abort(404, "Snap not found!")

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -115,6 +115,7 @@ def set_handlers(app):
             "join": template_utils.join,
             "static_url": template_utils.static_url,
             "format_number": template_utils.format_number,
+            "format_display_name": template_utils.format_display_name,
             "display_name": template_utils.display_name,
             "install_snippet": template_utils.install_snippet,
             "format_date": template_utils.format_date,

--- a/webapp/metrics/metrics.py
+++ b/webapp/metrics/metrics.py
@@ -304,7 +304,6 @@ class OsMetric(Metric):
 
         for distro in self.series:
             if distro["values"][0]:
-
                 name = _capitalize_os_name(distro["name"])
                 oses.append({"name": name, "value": distro["values"][-1]})
 

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -401,7 +401,6 @@ def categorise_media(media):
 
 
 def get_store_name(store_id, user):
-
     available_stores = filter_available_stores(user["stores"])
     store = next(
         (st for st in available_stores if st["id"] == store_id),

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -26,7 +26,6 @@ def get_account():
 @account.route("/details", methods=["GET"])
 @login_required
 def get_account_details():
-
     # We don't use the data from this endpoint.
     # It is mostly used to make sure the user has signed
     # the terms and conditions.

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -9,7 +9,6 @@ from webapp import helpers
 
 
 def get_n_random_snaps(snaps, choice_number):
-
     if len(snaps) > choice_number:
         return random.sample(snaps, choice_number)
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -16,7 +16,6 @@ from pybadges import badge
 
 
 def snap_details_views(store, api):
-
     snap_regex = "[a-z0-9-]*[a-z][a-z0-9-]*"
     snap_regex_upercase = "[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*"
 

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -112,10 +112,18 @@ def format_number(number: int):
     return "{:,}".format(number)
 
 
+def format_display_name(display_name):
+    """Template function that formats the displayed name
+    primarily to remove emoji
+    """
+    return "".join(display_name.split("✅"))
+
+
 def display_name(display_name, username):
     """Template function that returns the displayed name if the username
     is the same, or the dispayed name and the username if differents
     """
+    display_name = format_display_name(display_name)
     if display_name.lower() == username.lower():
         return display_name
     else:

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -4,6 +4,8 @@ import os
 
 from dateutil import parser
 
+from emoji import replace_emoji
+
 
 # generator functions for templates
 def generate_slug(path):
@@ -116,7 +118,7 @@ def format_display_name(display_name):
     """Template function that formats the displayed name
     primarily to remove emoji
     """
-    return "".join(display_name.split("✅"))
+    return replace_emoji(display_name, replace="")
 
 
 def display_name(display_name, username):


### PR DESCRIPTION
## Done
- Added [emoji](https://carpedm20.github.io/emoji/docs/) dependency
- Added template utility to format display names 

## How to QA
- Load the demo, search for "pdf" the first item should no longer have a checkmark emoji.
- Click the snap, the display name should also not have a checkmark emoji.
- Click the username, on this page the display name should not have a checkmark emoji.

## Issue / Card
Fixes #

## Screenshots
![image](https://user-images.githubusercontent.com/479384/216311132-6905a97a-6e01-4d20-82f2-de2980f2de00.png)
:arrow_down: 
![image](https://user-images.githubusercontent.com/479384/216311200-f8223397-2ad4-4925-9781-ea7af879afd8.png)

