### PR TITLE
snapcraft.io/README.md: LGPv3 License Link Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You can find the deployment config in the deploy folder.
 
 ## License
 
-The content of this project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/), and the underlying code used to format and display that content is licensed under the [LGPLv3](https://opensource.org/licenses/lgpl-3.0.html) by [Canonical Ltd](https://canonical.com/).
+The content of this project is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/), and the underlying code used to format and display that content is licensed under the [LGPLv3](https://opensource.org/license/lgpl-3-0/) by [Canonical Ltd](https://canonical.com/).
 
 
 With ♥ from Canonical


### PR DESCRIPTION
The LGPLv3 license linked is currently pointing to a broken link; https://opensource.org/licenses/lgpl-3.0.html I have updated it to point to the correct link on the opensource.org website; https://opensource.org/license/lgpl-3-0/

## Done
Updated the `README.md` link for the LGPLv3 to the new link on `opensource.org`

## How to QA
Navigated to the [broken link](https://opensource.org/licenses/lgpl-3.0.html)
Searched for the Licensed, and located the new URL for the license [here](https://opensource.org/license/lgpl-3-0/).

## Issue / Card
Fixes #4198

## Screenshots
![Screenshot from 2023-02-15 11-50-30](https://user-images.githubusercontent.com/42560873/219127701-c2f8f33a-f7ba-4c5f-bd15-75f868cd3a6a.png)
![Screenshot from 2023-02-15 11-50-39](https://user-images.githubusercontent.com/42560873/219127720-529e1a48-3486-425c-8d0f-702ffc6317b6.png)