### PR TITLE
Enable dark mode preview for icon upload

### DIFF
--- a/static/js/publisher/listing/components/ImageUpload/ImageUpload.tsx
+++ b/static/js/publisher/listing/components/ImageUpload/ImageUpload.tsx
@@ -1,6 +1,12 @@
 import React, { useState, SyntheticEvent } from "react";
 import { nanoid } from "nanoid";
-import { Row, Col, Notification } from "@canonical/react-components";
+import {
+  Row,
+  Col,
+  Notification,
+  Switch,
+  Icon,
+} from "@canonical/react-components";
 
 import {
   validateImageDimensions,
@@ -32,6 +38,7 @@ type Props = {
   helpText?: string;
   fileTypes: string;
   tourLabel: string;
+  hasDarkThemePreview?: boolean;
 };
 
 function ImageUpload({
@@ -47,13 +54,23 @@ function ImageUpload({
   helpText,
   fileTypes,
   tourLabel,
+  hasDarkThemePreview,
 }: Props) {
   const [showImageRestrictions, setShowImageRestrictions] = useState(false);
   const [imageVaidationError, setImageValidationError] = useState("");
   const [imageIsValid, setImageIsValid] = useState(true);
   const [isDragging, setIsDragging] = useState(false);
+  const [darkThemeEnabled, setDarkThemeEnabled] = useState(false);
 
   const fieldId = nanoid();
+  const isDark = hasDarkThemePreview && darkThemeEnabled;
+
+  const darkThemeStyles = {
+    backgroundColor: hasDarkThemePreview && isDark ? "#2f2f2f" : "#f7f7f7",
+    color: isDark ? "#fff" : "#111",
+    padding: hasDarkThemePreview ? "1rem 1rem 0" : "0",
+    display: "flex",
+  };
 
   const setImage = (image: File) => {
     if (image.size > validationSchema?.maxFileSize) {
@@ -113,99 +130,129 @@ function ImageUpload({
         )}
 
         <input type="hidden" {...register(imageUrlFieldKey)} />
-
-        <div className="snap-image-upload-container" data-tour={tourLabel}>
-          <div
-            className={`snap-image-upload-drop-area ${
-              isDragging ? "is-dragging" : ""
-            }`}
-            style={{
-              width: `${previewWidth}px`,
-              height: `${previewHeight}px`,
-            }}
-            onDragOver={() => {
-              setIsDragging(true);
-            }}
-            onDragLeave={() => {
-              setIsDragging(false);
-            }}
-            onDrop={() => {
-              setIsDragging(false);
-            }}
-          >
-            {imageUrl ? (
-              <div
-                className="snap-image-upload-preview"
-                style={{
-                  width: `${previewWidth}px`,
-                  height: `${previewHeight}px`,
-                }}
-              >
-                <img
-                  src={imageUrl}
-                  width={previewWidth}
-                  height={previewHeight}
-                  alt=""
-                />
+        <div style={hasDarkThemePreview ? darkThemeStyles : {}}>
+          <div className="snap-image-upload-container" data-tour={tourLabel}>
+            <div
+              className={`snap-image-upload-drop-area ${
+                isDragging ? "is-dragging" : ""
+              }`}
+              style={{
+                width: `${previewWidth}px`,
+                height: `${previewHeight}px`,
+                marginRight: hasDarkThemePreview && !imageUrl ? "1rem" : "0",
+              }}
+              onDragOver={() => {
+                setIsDragging(true);
+              }}
+              onDragLeave={() => {
+                setIsDragging(false);
+              }}
+              onDrop={() => {
+                setIsDragging(false);
+              }}
+            >
+              {imageUrl ? (
                 <div
-                  className="snap-image-upload-edit"
+                  className="snap-image-upload-preview"
                   style={{
                     width: `${previewWidth}px`,
                     height: `${previewHeight}px`,
                   }}
                 >
-                  <span>Edit</span>
+                  <img
+                    src={imageUrl}
+                    width={previewWidth}
+                    height={previewHeight}
+                    alt=""
+                  />
+                  <div
+                    className="snap-image-upload-edit"
+                    style={{
+                      width: `${previewWidth}px`,
+                      height: `${previewHeight}px`,
+                    }}
+                  >
+                    <span>Edit</span>
+                  </div>
                 </div>
-              </div>
-            ) : (
-              <div
-                className="snap-add-image"
+              ) : (
+                <div
+                  className="snap-add-image"
+                  style={{
+                    width: `${previewWidth}px`,
+                    height: `${previewHeight}px`,
+                    backgroundColor: isDark ? "#666" : "#d9d9d9",
+                  }}
+                >
+                  <Icon name="plus" light={isDark}>
+                    Add image
+                  </Icon>
+                </div>
+              )}
+              <input
+                className="snap-image-upload-input"
                 style={{
                   width: `${previewWidth}px`,
                   height: `${previewHeight}px`,
                 }}
+                type="file"
+                accept={fileTypes}
+                {...register(imageFieldKey, {
+                  onChange: (
+                    e: SyntheticEvent<HTMLInputElement> & {
+                      target: HTMLInputElement;
+                    }
+                  ) => {
+                    if (e.target.files) {
+                      setImage(e.target.files[0]);
+                    }
+                  },
+                })}
+              />
+            </div>
+
+            {imageUrl && (
+              <button
+                type="button"
+                className="p-button--base snap-remove-icon"
+                onClick={() => {
+                  setImageIsValid(true);
+                  setValue(imageUrlFieldKey, "", {
+                    shouldDirty: window?.listingData?.banner_urls[0] !== null,
+                  });
+                  setValue(imageFieldKey, new File([], ""), {
+                    shouldDirty: window?.listingData?.banner_urls[0] !== null,
+                  });
+                }}
               >
-                <i className="p-icon--plus">Add image</i>
-              </div>
+                <Icon name="delete" light={isDark}>
+                  Remove image
+                </Icon>
+              </button>
             )}
-            <input
-              className="snap-image-upload-input"
-              style={{
-                width: `${previewWidth}px`,
-                height: `${previewHeight}px`,
-              }}
-              type="file"
-              accept={fileTypes}
-              {...register(imageFieldKey, {
-                onChange: (
+          </div>
+
+          {hasDarkThemePreview && (
+            <div>
+              <Switch
+                label="Dark theme"
+                onChange={(
                   e: SyntheticEvent<HTMLInputElement> & {
                     target: HTMLInputElement;
                   }
                 ) => {
-                  if (e.target.files) {
-                    setImage(e.target.files[0]);
+                  if (e.target.checked) {
+                    setDarkThemeEnabled(true);
+                  } else {
+                    setDarkThemeEnabled(false);
                   }
-                },
-              })}
-            />
-          </div>
-
-          {imageUrl && (
-            <button
-              type="button"
-              className="p-button--base"
-              onClick={() => {
-                setImageIsValid(true);
-                setValue(imageUrlFieldKey, "", {
-                  shouldDirty: window?.listingData?.banner_urls[0] !== null,
-                });
-                setValue(imageFieldKey, new File([], ""), {
-                  shouldDirty: window?.listingData?.banner_urls[0] !== null,
-                });
-              }}
-            >
-              <i className="p-icon--delete">Remove image</i>
-            </button>
+                }}
+              />
+              <small>
+                This is how your application&rsquo;s icon will look in{" "}
+                {darkThemeEnabled ? "dark" : "light"} theme
+              </small>
+            </div>
           )}
         </div>
 

--- a/static/js/publisher/listing/sections/ListingDetailsSection/ListingDetailsSection.tsx
+++ b/static/js/publisher/listing/sections/ListingDetailsSection/ListingDetailsSection.tsx
@@ -63,6 +63,7 @@ function ListingDetailsSection({
         previewHeight={120}
         fileTypes="image/png, image/jpeg, image/svg+xml"
         tourLabel="listing-icon"
+        hasDarkThemePreview={true}
       />
 
       <ListingFormInput

--- a/static/sass/_snapcraft_snap-image-upload.scss
+++ b/static/sass/_snapcraft_snap-image-upload.scss
@@ -100,4 +100,8 @@
     display: flex;
     justify-content: center;
   }
+
+  .snap-remove-icon:hover {
+    background-color: transparent;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -56,6 +56,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-p-search-box;
 @include vf-p-form-tick-elements;
 @include vf-p-status-label;
+@include vf-p-switch;
 @include vf-u-floats;
 @include vf-u-off-screen;
 @include vf-u-margin-collapse;


### PR DESCRIPTION
## Done
Added a dark mode preview for snap icons

## How to QA
- Go to a snaps listing page, e.g. https://snapcraft-io-4202.demos.haus/steve-test-snap/listing
- Check that the icon has a working dark mode preview

## Issue / Card
Fixes #4193
Fixes https://warthogs.atlassian.net/browse/WD-1891

## Screenshots
<img width="1108" alt="Screenshot 2023-02-22 at 10 55 27" src="https://user-images.githubusercontent.com/501889/220600446-2a2a436d-609e-44ee-8393-1930d53164ad.png">

<img width="1107" alt="Screenshot 2023-02-22 at 10 55 37" src="https://user-images.githubusercontent.com/501889/220600493-8b2b126d-8f49-498e-984c-a4ae3fb4b18e.png">
