### PR TITLE
Redirect all tutorials from /tutorials -> /docs/snap-tutorials

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,6 +1,9 @@
 # Remove HTML extensions
 (?P<path>.*)(\.html|/): /{path}
 
+# Redirect tutorials
+tutorials(.*?): /docs/snap-tutorials
+
 # Old URL redirects
 docs/build-snaps: /docs/snap-format
 docs/build-snaps/build-for-another-arch: /docs/building-snaps

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -63,7 +63,7 @@
           class="p-navigation__item {% if page_slug == 'tutorials' %}is-selected{% endif %}"
           role="menuitem"
         >
-          <a class="p-navigation__link" href="/tutorials">
+          <a class="p-navigation__link" href="/docs/snap-tutorials">
             Tutorials
           </a>
         </li>

--- a/templates/about/publish.html
+++ b/templates/about/publish.html
@@ -54,8 +54,8 @@
       ) | safe
     }}
     <p>Building your snap locally limits you to your development architecture. Let us do the heavy lifting and build it for multiple architectures including AMD64, i386, ARM and ARM64.</p>
-    <p>Behind the scenes, snaps are built by <a href="https://launchpad.net" >Launchpad</a> the tool used to build all Ubuntu images. When your builds are ready, you can release them together, as a set, ensuring everyone on all architectures receive the same version at the same time.</p>
-    <a href="https://snapcraft.io/build" class="p-button">Find out more</a>
+    <p>Behind the scenes, snaps are built by <a href="https://launchpad.net" class="p-link--external">Launchpad</a> the tool used to build all Ubuntu images. When your builds are ready, you can release them together, as a set, ensuring everyone on all architectures receive the same version at the same time.</p>
+    <a href="https://snapcraft.io/build" class="p-button--neutral">Find out more</a>
   </div>
   <div class="p-strip is-shallow">
     <h2>Publish with a third party CI system</h2>
@@ -70,9 +70,9 @@
       ) | safe
     }}
     <p>If you&rsquo;re already comfortable with a third party CI workflow Snaps are supported there too. You don&rsquo;t need to change or modify anything if you don&rsquo;t want to.</p>
-    <a href="https://snapcraft.io/https://snapcraft.io/tutorials/continuous-snap-delivery-from-travis-ci" class="p-button"><span >Publish with Travis CI</span></a>
-    <a href="https://snapcraft.io/tutorials/continuous-snap-delivery-from-circle-ci" class="p-button"><span >Publish with Circle CI</span></a>
-    <a href="https://github.com/marketplace/actions/snapcraft-action" class="p-button"><span >Publish with GitHub Actions</span></a>
+    <a href="https://docs.travis-ci.com/user/deployment/snaps/" class="p-button--neutral"><span class="p-link--external">Publish with Travis CI</span></a>
+    <a href="https://circleci.com/blog/circleci-and-snapcraft/" class="p-button--neutral"><span class="p-link--external">Publish with Circle CI</span></a>
+    <a href="https://github.com/marketplace/actions/snapcraft-action" class="p-button--neutral"><span class="p-link--external">Publish with GitHub Actions</span></a>
   </div>
   <div class="p-strip is-shallow">
     <h2>Publish with your own infrastructure</h2>
@@ -85,7 +85,7 @@
         hi_def=True
       ) | safe
     }}
-    <p>Already have a build farm, for all the architectures you need? The <a href="https://dashboard.snapcraft.io/docs/" >Publisher Gateway APIs</a> let you automate everything from uploading and releasing a Snap, to adding screenshots to display in the <a href="/store">Storefront</a>.</p>
+    <p>Already have a build farm, for all the architectures you need? The <a href="https://dashboard.snapcraft.io/docs/" class="p-link--external">Publisher Gateway APIs</a> let you automate everything from uploading and releasing a Snap, to adding screenshots to display in the <a href="/store">Storefront</a>.</p>
   </div>
 {% endblock %}
 

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -39,6 +39,9 @@ def generate_slug(path):
     if path.startswith("/iot"):
         return "iot"
 
+    if path.startswith("/docs/snap-tutorials"):
+        return "tutorials"
+
     if path.startswith("/docs"):
         return "docs"
 


### PR DESCRIPTION
## Done
- Redirect all /tutorials to /docs/snap-tutorials
- Update tutorials navigation link
- Update in-page links to removed tutorials to appropriate places
- Ensure "Tutorials" is highlighted when on the /docs/snap-tutorials page

## How to QA
- Visit the [demo](https://snapcraft-io-4205.demos.haus/), attempt to go to the following urls:
  - https://snapcraft-io-4205.demos.haus/tutorials
  - https://snapcraft-io-4205.demos.haus/tutorials/snap-download
  - https://snapcraft-io-4205.demos.haus/tutorials/snap-changes
  - https://snapcraft-io-4205.demos.haus/tutorials/advanced-snap-usage
  - https://snapcraft-io-4205.demos.haus/tutorials/create-your-own-core-20-image
  - https://snapcraft-io-4205.demos.haus/tutorials/create-your-own-core-18-image
  - https://snapcraft-io-4205.demos.haus/tutorials/continuous-snap-delivery-from-circle-ci

They should all redirect to https://snapcraft-io-4205.demos.haus/docs/snaps-tutorials

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/SNPM-296

## Screenshots
