### PR TITLE
Update empty header

### DIFF
--- a/templates/_header_empty.html
+++ b/templates/_header_empty.html
@@ -1,9 +1,12 @@
-<header id="navigation" class="p-navigation">
+<header id="navigation" class="p-navigation is-dark">
   <div class="row">
     <div class="p-navigation__banner">
-      <div class="p-navigation__logo">
+      <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/7f93bb62-snapcraft-logo--web-white-text.svg" alt="Snapcraft" />
+          <div class="p-navigation__logo-tag">
+            <img class="p-navigation__logo-icon" src="https://assets.ubuntu.com/v1/11ff571b-snapcraft.svg" alt="">
+          </div>
+          <span class="p-navigation__logo-title">Canonical Snapcraft</span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Done
- Updated the empty header on distro install pages

## QA
- Go to https://snapcraft-io-4213.demos.haus/install/pinta/ubuntu
- Check that the header is dark and has the new logo

## Issue / Card
Fixes #4212
Fixes https://warthogs.atlassian.net/browse/WD-2429