### PR TITLE
Fix metadata being disabled

### DIFF
--- a/static/js/publisher/listing/utils/getFormData.ts
+++ b/static/js/publisher/listing/utils/getFormData.ts
@@ -11,28 +11,65 @@ function getFormData(
 
   formData.set("csrf_token", window.CSRF_TOKEN);
   formData.set("snap_id", snapId);
-  formData.set("title", data?.title);
-  formData.set("summary", data?.summary);
-  formData.set("description", data?.description);
-  formData.set("video_urls", data?.video_urls);
-  formData.set("website", data?.website);
-  formData.set("contact", data?.contact);
-  formData.set("primary-category", data?.["primary-category"]);
-  formData.set("secondary-category", data?.["secondary-category"]);
-  formData.set("public_metrics_enabled", data?.public_metrics_enabled);
-  formData.set("public_metrics_blacklist", data?.public_metrics_blacklist);
-  formData.set("license", data?.license || "unset");
-  formData.set("images", data?.["images"]);
-  formData.set(
-    "links",
-    JSON.stringify({
-      contact: formatLinkFields(data?.contacts),
-      donation: formatLinkFields(data?.donations),
-      issues: formatLinkFields(data?.issues),
-      "source-code": formatLinkFields(data?.["source-code"]),
-      website: formatLinkFields(data?.websites),
-    })
-  );
+
+  if (changes.title) {
+    formData.set("title", data?.title);
+  }
+
+  if (changes.summary) {
+    formData.set("summary", data?.summary);
+  }
+
+  if (changes.description) {
+    formData.set("description", data?.description);
+  }
+
+  if (changes.video_urls) {
+    formData.set("video_urls", data?.video_urls);
+  }
+
+  if (changes.website) {
+    formData.set("website", data?.website);
+  }
+
+  if (changes.contact) {
+    formData.set("contact", data?.contact);
+  }
+
+  if (changes.categories) {
+    formData.set("primary-category", data?.["primary-category"]);
+    formData.set("secondary-category", data?.["secondary-category"]);
+  }
+
+  if (changes.public_metrics_enabled) {
+    formData.set("public_metrics_enabled", data?.public_metrics_enabled);
+  }
+
+  if (changes.public_metrics_blacklist) {
+    formData.set("public_metrics_blacklist", data?.public_metrics_blacklist);
+  }
+
+  if (changes.license) {
+    formData.set("license", data?.license || "unset");
+  }
+
+  if (changes.images) {
+    formData.set("images", data?.["images"]);
+  }
+
+  if (changes.links) {
+    formData.set(
+      "links",
+      JSON.stringify({
+        contact: formatLinkFields(data?.contacts),
+        donation: formatLinkFields(data?.donations),
+        issues: formatLinkFields(data?.issues),
+        "source-code": formatLinkFields(data?.["source-code"]),
+        website: formatLinkFields(data?.websites),
+      })
+    );
+  }
+
   formData.set("changes", JSON.stringify(changes));
 
   if (data?.icon) {

--- a/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
@@ -32,7 +32,13 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
     }
   }
 
-  const allowedKeys = ["icon", "banner", "screenshot_urls", "video_urls"];
+  const allowedKeys = [
+    "icon",
+    "banner",
+    "screenshot_urls",
+    "video_urls",
+    "categories",
+  ];
 
   let showWarning = false;
 

--- a/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
@@ -32,50 +32,17 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
     }
   }
 
-  if (filteredDirtyFields.length === 1) {
-    if (
-      filteredDirtyFields.includes("icon") ||
-      filteredDirtyFields.includes("banner") ||
-      filteredDirtyFields.includes("screenshot_urls")
-    ) {
-      return false;
-    }
-  }
+  const allowedKeys = ["icon", "banner", "screenshot_urls", "video_urls"];
 
-  if (filteredDirtyFields.length === 2) {
-    if (
-      filteredDirtyFields.includes("icon") &&
-      filteredDirtyFields.includes("banner")
-    ) {
-      return false;
-    }
+  let showWarning = false;
 
-    if (
-      filteredDirtyFields.includes("icon") &&
-      filteredDirtyFields.includes("screenshot_urls")
-    ) {
-      return false;
+  filteredDirtyFields.forEach((field) => {
+    if (!allowedKeys.includes(field)) {
+      showWarning = true;
     }
+  });
 
-    if (
-      filteredDirtyFields.includes("banner") &&
-      filteredDirtyFields.includes("screenshot_urls")
-    ) {
-      return false;
-    }
-  }
-
-  if (filteredDirtyFields.length === 3) {
-    if (
-      filteredDirtyFields.includes("icon") &&
-      filteredDirtyFields.includes("banner") &&
-      filteredDirtyFields.includes("screenshot_urls")
-    ) {
-      return false;
-    }
-  }
-
-  return true;
+  return showWarning;
 }
 
 export default shouldShowUpdateMetadataWarning;

--- a/tests/publisher/snaps/tests_post_listing.py
+++ b/tests/publisher/snaps/tests_post_listing.py
@@ -75,8 +75,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             self.authorization, called.request.headers.get("Authorization")
         )
         self.assertEqual(
-            b'{"contact": "contact-adress", '
-            b'"update_metadata_on_release": false}',
+            b'{"contact": "contact-adress"}',
             called.request.body,
         )
 
@@ -101,8 +100,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             self.authorization, called.request.headers.get("Authorization")
         )
         self.assertEqual(
-            b'{"description": "This is a description\\n", '
-            b'"update_metadata_on_release": false}',
+            b'{"description": "This is a description\\n"}',
             called.request.body,
         )
 
@@ -163,8 +161,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
             self.authorization, called.request.headers.get("Authorization")
         )
         self.assertEqual(
-            b'{"description": "This is an updated description", '
-            b'"update_metadata_on_release": false}',
+            b'{"description": "This is an updated description"}',
             called.request.body,
         )
         called = responses.calls[1]

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -210,8 +210,6 @@ def post_listing_snap(snap_name):
                     body_json["description"]
                 )
 
-            body_json["update_metadata_on_release"] = False
-
             try:
                 publisher_api.snap_metadata(snap_id, flask.session, body_json)
             except StoreApiResponseErrorList as api_response_error_list:


### PR DESCRIPTION
## Done
Fixed a bug where changing icons or video URLs disabled "update_metadata_on_release"

## How to QA
- Go to https://snapcraft-io-4220.demos.haus/<SNAP_NAME>/settings
- Make sure that "Update metadata on release" is enabled
- Go to https://snapcraft-io-4220.demos.haus/<SNAP_NAME>/listing
- Check that changing the icon, banner or video fields don't disable "Update metadata on release"

## Issue / Card
Fixes #4159
Fixed https://warthogs.atlassian.net/browse/WD-488