### PR TITLE
Fix metadata updates

### DIFF
--- a/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
@@ -36,13 +36,20 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
     "banner",
     "icon",
     "primary-category",
-    "public_metrics_blacklist",
-    "public_metrics_distros",
-    "public_metrics_enabled",
-    "public_metrics_territories",
     "screenshot_urls",
     "secondary-category",
     "video_urls",
+    // ========================================================
+    // The following keys can be uncommented once
+    // https://bugs.launchpad.net/snapstore-server/+bug/2011695
+    // is resolved.
+    // We are tracking this internally here:
+    // https://warthogs.atlassian.net/browse/WD-2648
+    // ========================================================
+    // "public_metrics_blacklist",
+    // "public_metrics_distros",
+    // "public_metrics_enabled",
+    // "public_metrics_territories",
   ];
 
   let showWarning = false;

--- a/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher/listing/utils/shouldShowUpdateMetadataWarning.ts
@@ -33,11 +33,16 @@ function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {
   }
 
   const allowedKeys = [
-    "icon",
     "banner",
+    "icon",
+    "primary-category",
+    "public_metrics_blacklist",
+    "public_metrics_distros",
+    "public_metrics_enabled",
+    "public_metrics_territories",
     "screenshot_urls",
+    "secondary-category",
     "video_urls",
-    "categories",
   ];
 
   let showWarning = false;


### PR DESCRIPTION
## Done
Fixed a bug where changing categories on the snap listing page disabled "update_metadata_on_release"

## How to QA
- Go to https://snapcraft-io-4221.demos.haus/<SNAP_NAME>/settings
- Make sure that "Update metadata on release" is enabled
- Go to https://snapcraft-io-4221.demos.haus/<SNAP_NAME>/listing
- Check that changing the category fields doesn't disable "Update metadata on release"
