### PR TITLE
Improve fetching of brand-stores on login

### DIFF
--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -3,7 +3,7 @@ import datetime
 
 import flask
 from canonicalwebteam.candid import CandidClient
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
+from canonicalwebteam.store_api.stores.snapstore import SnapPublisher, SnapStoreAdmin
 
 from django_openid_auth.teams import TeamsRequest, TeamsResponse
 from flask_openid import OpenID
@@ -31,6 +31,7 @@ open_id = OpenID(
 )
 
 publisher_api = SnapPublisher(api_publisher_session)
+admin_api = SnapStoreAdmin(api_publisher_session)
 candid = CandidClient(api_publisher_session)
 
 
@@ -72,8 +73,11 @@ def after_login(resp):
     if not resp.nickname:
         return flask.redirect(LOGIN_URL)
 
-    try:
-        account = publisher_api.get_account(flask.session)
+    account = publisher_api.get_account(flask.session)
+    owned, shared = logic.get_snap_names_by_ownership(account)
+    flask.session["user_shared_snaps"] = shared
+
+    if account:
         flask.session["publisher"] = {
             "identity_url": resp.identity_url,
             "nickname": account["username"],
@@ -83,12 +87,12 @@ def after_login(resp):
             "is_canonical": LP_CANONICAL_TEAM
             in resp.extensions["lp"].is_member,
         }
-        owned, shared = logic.get_snap_names_by_ownership(account)
-        flask.session["user_shared_snaps"] = shared
-        flask.session["publisher"]["stores"] = logic.get_stores(
-            account["stores"], roles=["admin", "review", "view"]
-        )
-    except Exception:
+
+        if (logic.get_stores(
+                account["stores"], roles=["admin", "review", "view"]
+        )):
+            flask.session["publisher"]["stores"] = admin_api.get_stores(flask.session)
+    else:
         flask.session["publisher"] = {
             "identity_url": resp.identity_url,
             "nickname": resp.nickname,
@@ -179,9 +183,10 @@ def login_callback():
         "email": publisher["account"]["email"],
     }
 
-    flask.session["publisher"]["stores"] = logic.get_stores(
+    if (logic.get_stores(
         account["stores"], roles=["admin", "review", "view"]
-    )
+    )):
+        flask.session["publisher"]["stores"] = admin_api.get_stores(flask.session)
 
     response = flask.make_response(
         flask.redirect(

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -3,7 +3,10 @@ import datetime
 
 import flask
 from canonicalwebteam.candid import CandidClient
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher, SnapStoreAdmin
+from canonicalwebteam.store_api.stores.snapstore import (
+    SnapPublisher,
+    SnapStoreAdmin,
+)
 
 from django_openid_auth.teams import TeamsRequest, TeamsResponse
 from flask_openid import OpenID
@@ -88,10 +91,12 @@ def after_login(resp):
             in resp.extensions["lp"].is_member,
         }
 
-        if (logic.get_stores(
-                account["stores"], roles=["admin", "review", "view"]
-        )):
-            flask.session["publisher"]["stores"] = admin_api.get_stores(flask.session)
+        if logic.get_stores(
+            account["stores"], roles=["admin", "review", "view"]
+        ):
+            flask.session["publisher"]["stores"] = admin_api.get_stores(
+                flask.session
+            )
     else:
         flask.session["publisher"] = {
             "identity_url": resp.identity_url,
@@ -183,10 +188,10 @@ def login_callback():
         "email": publisher["account"]["email"],
     }
 
-    if (logic.get_stores(
-        account["stores"], roles=["admin", "review", "view"]
-    )):
-        flask.session["publisher"]["stores"] = admin_api.get_stores(flask.session)
+    if logic.get_stores(account["stores"], roles=["admin", "review", "view"]):
+        flask.session["publisher"]["stores"] = admin_api.get_stores(
+            flask.session
+        )
 
     response = flask.make_response(
         flask.redirect(


### PR DESCRIPTION
## Done
- Removed try-except on login methods – really let's throw and track what's happening
- If the retrieved account has relevant stores, fetch those stores using the admin_api.

## How to QA
- Login to the demo using both https://snapcraft-io-4229.demos.haus/login and https://snapcraft-io-4229.demos.haus/login-beta
- Ensure everything works as expected during the login process
- If you have access to brand stores, "My Stores" should appear in the user menu (and work)

## Issue / Card
Fixes #3838 hopefully

## Screenshots
