### PR TITLE
Add update metadata warning on snap settings page

### DIFF
--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -18,6 +18,7 @@ import { initListingTour } from "../../../tour";
 
 import PageHeader from "../../../shared/PageHeader";
 import SaveAndPreview from "../../../shared/SaveAndPreview";
+import UpdateMetadataModal from "../../../shared/UpdateMetadataModal";
 import ListingDetailsSection from "../../sections/ListingDetailsSection";
 import ContactInformationSection from "../../sections/ContactInformationSection";
 import AdditionalInformationSection from "../../sections/AdditionalInformationSection";
@@ -161,41 +162,11 @@ function App() {
             </section>
 
             {showMetadataWarningModal ? (
-              <Modal
-                close={() => {
-                  setShowMetadataWarningModal(false);
-                }}
-                title="Warning"
-                buttonRow={
-                  <>
-                    <Button
-                      type="button"
-                      className="u-no-margin--bottom"
-                      onClick={() => {
-                        setShowMetadataWarningModal(false);
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      type="button"
-                      className="u-no-margin--bottom u-no-margin--right"
-                      appearance="positive"
-                      onClick={() => {
-                        submitForm(formData);
-                        setShowMetadataWarningModal(false);
-                      }}
-                    >
-                      Save changes
-                    </Button>
-                  </>
-                }
-              >
-                <p>
-                  Making these changes means that the snap will no longer use
-                  the data from snapcraft.yaml.
-                </p>
-              </Modal>
+              <UpdateMetadataModal
+                setShowMetadataWarningModal={setShowMetadataWarningModal}
+                submitForm={submitForm}
+                formData={formData}
+              />
             ) : null}
           </>
         )}

--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -6,11 +6,14 @@ import {
   Row,
   Col,
   Notification,
+  Modal,
+  Button,
 } from "@canonical/react-components";
 
 import PageHeader from "../../../shared/PageHeader";
 import SaveAndPreview from "../../../shared/SaveAndPreview";
 import SearchAutocomplete from "../../../shared/SearchAutocomplete";
+import UpdateMetadataModal from "../../../shared/UpdateMetadataModal";
 
 import { getSettingsData, getFormData } from "../../utils";
 
@@ -21,6 +24,10 @@ function App() {
   const [isSaving, setIsSaving] = useState(false);
   const [hasSaved, setHasSaved] = useState(false);
   const [savedError, setSavedError] = useState(false);
+  const [formData, setFormData] = useState({});
+  const [showMetadataWarningModal, setShowMetadataWarningModal] = useState(
+    false
+  );
 
   const {
     register,
@@ -49,7 +56,21 @@ function App() {
     name: "blacklist_country_keys",
   });
 
-  const onSubmit = async (data: any) => {
+  const onSubmit = (data: any) => {
+    const dirtyFieldsKeys = Object.keys(dirtyFields);
+    const onlyUpdateMetadataField =
+      dirtyFieldsKeys.length === 1 &&
+      dirtyFieldsKeys[0] === "update_metadata_on_release";
+
+    if (getValues("update_metadata_on_release") && !onlyUpdateMetadataField) {
+      setShowMetadataWarningModal(true);
+      setFormData(data);
+    } else {
+      submitForm(data);
+    }
+  };
+
+  const submitForm = async (data: any) => {
     setIsSaving(true);
     setHasSaved(false);
     setSavedError(false);
@@ -407,6 +428,14 @@ function App() {
           </Row>
         </Strip>
       </Form>
+
+      {showMetadataWarningModal ? (
+        <UpdateMetadataModal
+          setShowMetadataWarningModal={setShowMetadataWarningModal}
+          submitForm={submitForm}
+          formData={formData}
+        />
+      ) : null}
     </>
   );
 }

--- a/static/js/publisher/shared/UpdateMetadataModal/UpdateMetadataModal.tsx
+++ b/static/js/publisher/shared/UpdateMetadataModal/UpdateMetadataModal.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Modal, Button } from "@canonical/react-components";
+
+type Props = {
+  setShowMetadataWarningModal: Function;
+  submitForm: Function;
+  formData: any;
+};
+
+function UpdateMetadataModal({
+  setShowMetadataWarningModal,
+  submitForm,
+  formData,
+}: Props) {
+  return (
+    <Modal
+      close={() => {
+        setShowMetadataWarningModal(false);
+      }}
+      title="Warning"
+      buttonRow={
+        <>
+          <Button
+            type="button"
+            className="u-no-margin--bottom"
+            onClick={() => {
+              setShowMetadataWarningModal(false);
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="u-no-margin--bottom u-no-margin--right"
+            appearance="positive"
+            onClick={() => {
+              submitForm(formData);
+              setShowMetadataWarningModal(false);
+            }}
+          >
+            Save changes
+          </Button>
+        </>
+      }
+    >
+      <p>
+        Making these changes means that the snap will no longer use the data
+        from snapcraft.yaml.
+      </p>
+    </Modal>
+  );
+}
+
+export default UpdateMetadataModal;

--- a/static/js/publisher/shared/UpdateMetadataModal/index.ts
+++ b/static/js/publisher/shared/UpdateMetadataModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UpdateMetadataModal";


### PR DESCRIPTION
## Done
Added a warning modal to snap settings page when making changes that disable `update_metadata_on_release`

## How to QA
- Go to https://snapcraft-io-4233.demos.haus/<SNAP_NAME>/settings
- Make sure "Update metadata on release" is enabled
- Make a change to the data and try to save the form
- Check that there is a warning modal

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-2794