### PR TITLE
implement a build page for Snapcraft.io rebranding

### DIFF
--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -45,22 +45,22 @@
     padding: 1.5rem;
 
     .build-notification-text {
-      color: #0066cc;
+      color: #06c;
       font-size: 16px;
     }
   }
 
   .build-container {
     display: flex;
-    flex-direction: row;
     background-position: 56% 80%;
-    bottom: 20px;
+    flex-direction: row;
     background-repeat: no-repeat;
+    bottom: 20px;
     background-image: url('https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg');
 
     .build-divider {
-      width: 1px;
       background-color: rgba(0, 0, 0, 0.15);
+      width: 1px;
       margin: 0;
       padding: 0;
     }

--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -39,4 +39,30 @@
       top: 0.4rem;
     }
   }
+
+  .build-notification {
+    background-color: #e5e5e5;
+    padding: 1.5rem;
+
+    .build-notification-text {
+      color: #0066cc;
+      font-size: 16px;
+    }
+  }
+
+  .build-container {
+    display: flex;
+    flex-direction: row;
+    background-position: 56% 80%;
+    bottom: 20px;
+    background-repeat: no-repeat;
+    background-image: url('https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg');
+
+    .build-divider {
+      width: 1px;
+      background-color: rgba(0, 0, 0, 0.15);
+      margin: 0;
+      padding: 0;
+    }
+  }
 }

--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -51,18 +51,18 @@
   }
 
   .build-container {
-    display: flex;
+    background-image: url('https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg');
     background-position: 56% 80%;
-    flex-direction: row;
     background-repeat: no-repeat;
     bottom: 20px;
-    background-image: url('https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg');
+    display: flex;
+    flex-direction: row;
 
     .build-divider {
       background-color: rgba(0, 0, 0, 0.15);
-      width: 1px;
       margin: 0;
       padding: 0;
+      width: 1px;
     }
   }
 }

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -3,51 +3,58 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1EvemWJDOpjL-8ieCSiStKViFx-fgwfTaENueOYlB5ps/edit{% endblock %}
 
 {% block content %}
-<section class="p-strip is-shallow">
-  <div class="u-fixed-width">
+<section class="p-strip build-notification is-shallow u-hide--small">
+  <div class="u-fixed-width build-notification-text">
     <b>Ubuntu 16.04 is entering ESM.</b> This can impact you as a snap developer. Read more about it on <a href="https://snapcraft.io/blog/how-does-ubuntu-16-04-entering-extended-security-maintenance-esm-affect-snap-publishers">this blog post.</a>
   </div>
 </section>
-<section id="main-content" class="p-strip--suru-background is-dark">
+<section id="main-content" class="p-strip" style="padding: 32px 0px">
   <div class="u-fixed-width">
-    <h2 class="p-heading--1">
+    <h2 class="p-heading--2">
       Build snaps from GitHub repositories
+      <a href="/snaps" class="p-button--positive is-inline u-hide--small" style="float: right;">Get started now</a>
     </h2>
-    <p>Auto-build and publish software for any Linux system or device from your GitHub repos.</p>
-    <p><a href="/snaps" class="p-button--positive">Get started now</a></p>
+    <p><a href="/snaps" class="p-button--positive u-hide--medium u-hide--large">Get started now</a></p>
   </div>
 </section>
-
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-heading--1">How to build from GitHub</h2>
-    <img src="https://assets.ubuntu.com/v1/ed6d1c5b-build.snapcraft.hero.svg" width="100%" />
-  </div>
-  <div class="row">
+<section class="p-strip u-no-padding--top u-hide--medium u-hide--large" style="padding-bottom: 32px;">
+  <div class="row" style="padding-bottom: 32px;">
+    <img src="https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg" width="100%" style="padding-bottom: 32px;"/>
     <div class="col-4">
       <p>Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
     </div>
     <div class="col-4">
-      <p>Register a name on Snapcraft and attach it to your repo to start building. Your snap will be built automatically for all distros.</p>
+      <p>Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
     </div>
     <div class="col-4">
-      <p>Release your snap to your users. From here on, all the updates you do to your code will trigger automatic builds.</p>
+      <p>Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <a href="/snaps" class="p-button--positive">
-      Get started now
-    </a>
+</section>
+<section class="p-strip u-no-padding--top u-hide--small u-no-margin--bottom" style="padding-bottom: 32px;">
+  <div class="row build-container">
+    <div class="build-divider"></div>
+    <div class="col-4" style="height: 565.5px;">
+      <p style="padding-top: 12.6px; margin: 0;">Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
+    </div>
+    <div class="build-divider"></div>
+    <div class="col-4">
+      <p style="padding-top: 12.6px; margin: 0;">Register a name on Snapcraft and attach it to your repo to start building. Your snap will be built automatically for all distros.</p>
+    </div>
+    <div class="build-divider"></div>
+    <div class="col-4">
+      <p style="padding-top: 12.6px; margin: 0;">Release your snap to your users. From here on, all the updates you do to your code will trigger automatic builds.</p>
+    </div>
   </div>
 </section>
 
-<div class="u-fixed-width">
+<div class="u-fixed-width u-no-margin--bottom" style="height: 0;">
   <hr>
 </div>
 
-<section class="p-strip">
+<section class="p-strip u-no-padding--top" style="padding-bottom: 32px;">
   <div class="u-fixed-width">
-    <h3 class="p-heading--2">Publish your software for</h3>
+    <h2 class="p-muted-heading u-no-padding u-no-margin" style="font-weight: 500;">Publish your software for</h2>
   </div>
   <div class="row">
     <div class="p-logo-image col-small-2 col-medium-2 col-2 col-logo">
@@ -89,41 +96,49 @@
   </div>
 </section>
 
-<section class="p-strip--light">
-  <div class="u-fixed-width">
-    <h3 class="p-heading--2">Build makes it easier</h3>
-  </div>
+<div class="u-fixed-width u-no-margin--bottom" style="height: 0;">
+  <hr>
+</div>
+
+<section class="p-strip u-no-padding--top" style="padding-bottom: 64px;">
   <div class="row">
-    <div class="col-4">
-      <h4>Automatic updates</h4>
+    <div class="col-6 col-medium-3">
+      <h2 class="p-muted-heading u-no-padding u-no-margin" style="font-weight: 500;">Build makes it easier</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <h2 class="u-hide--small">Automatic updates</h2>
+      <h2 class="u-hide--large u-hide--medium" style="padding-top: 32px;">Automatic updates</h2>
       <p>Whenever you commit a change in your code on GitHub, Snapcraft will trigger a new build automatically for all the distros you choose. When you are ready, these builds will be available for you to share with your users.</p>
-    </div>
-    <div class="col-4">
-      <h4>Create snaps with tools you<br class="u-hide u-show--large"> already use</h4>
+      <div class="u-fixed-width u-no-margin--bottom" style="height: 0; padding-top: 32px;">
+        <hr>
+      </div>
+      <h2>Create snaps with tools <br> you already use</h2>
       <p>We created the possibility to start building your snaps from a Github repo so that you can focus on the things that matter, using the tools you know.</p>
-    </div>
-    <div class="col-4">
-      <h4>Build for all distros</h4>
+      <div class="u-fixed-width u-no-margin--bottom" style="height: 0; padding-top: 32px;">
+        <hr>
+      </div>
+      <h2>Build for all distros</h2>
       <p>Snaps work across Linux on any distribution or version. Bundle your dependencies and assets, simplifying installs to a single standard command.</p>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <a href="/snaps" class="p-button--positive">
-      Get started now
-    </a>
-  </div>
 </section>
 
-<section class="p-strip u-no-padding--bottom
-  ">
+<div class="u-fixed-width u-no-margin--bottom" style="height: 0;">
+  <hr>
+</div>
+
+<section class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="u-fixed-width">
-    <h3 class="p-heading--2">How Snapcraft fits your workflow</h3>
+    <h2 class="p-heading--2">How Snapcraft fits your workflow</h2>
   </div>
 </section>
-<section class="p-strip">
-  <div class="u-fixed-width u-align--center">
-    <img class="u-hide--small" src="https://assets.ubuntu.com/v1/b70a5c55-workflow-illustration.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable.">
-    <img class="u-hide--medium u-hide--large" src="https://assets.ubuntu.com/v1/a61b3832-workflow.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable" />
+<section class="p-strip u-no-padding">
+  <div class="u-fixed-width u-align--center" style="padding-top: 24px; padding-bottom: 64px;">
+    <img class="u-hide--small" src="https://assets.ubuntu.com/v1/21626379-Group%202899.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable.">
+    <img class="u-hide--medium u-hide--large" src="https://assets.ubuntu.com/v1/80be83a9-Group%202898.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable" />
   </div>
 </section>
+<div class="u-fixed-width u-hide--small" style="padding-top: 10px; padding-bottom: 192px;">
+  <a href="/snaps" class="p-button--positive u-no-margin"> Get started now </a>
+</div>
 {% endblock %}

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -24,10 +24,10 @@
       <p>Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
     </div>
     <div class="col-4">
-      <p>Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
+      <p>Register a name on Snapcraft and attach it to your repo to start building. Your snap will be built automatically for all distros.</p>
     </div>
     <div class="col-4">
-      <p>Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
+      <p>Release your snap to your users. From here on, all the updates you do to your code will trigger automatic builds.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
- implemented a build page for Snapcraft.io rebranding

## How to QA
- Go to https://snapcraft-io-4243.demos.haus/build
- Compare to the designs:
[web](https://app.zeplin.io/project/64107f86ec62b30f2acff2de/screen/640f327cfadf3622886ecb31)
[mobile](https://app.zeplin.io/project/64107f86ec62b30f2acff2de/screen/64218ee4d08a97229b1f33f1)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-2955

