### PR TITLE
Actions: Force node 16 on test-js job 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Install python dependencies
-        run: | 
+        run: |
           python3 -m pip install --upgrade pip
           sudo pip3 install flake8 black
 
@@ -112,6 +112,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Install dependencies
         run: yarn install --immutable
 
@@ -119,7 +123,7 @@ jobs:
         run: |
           yarn test-js
           bash <(curl -s https://codecov.io/bash) -cF javascript
-          
+
   check-inclusive-naming:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Done
Latest actions image started defaulting to node 18 and broke some tests. Forcing node 16 as before to get everything back to green.

## How to QA
- Check `test-js` is passing.