### PR TITLE
Build: Handle none-core bases

### DIFF
--- a/templates/publisher/builds.html
+++ b/templates/publisher/builds.html
@@ -32,7 +32,7 @@ Builds for
       <div class="row">
         <div class="p-notification--information">
           <div class="p-notification__content">
-            <p class="p-notification__message">We have detected that your snap base is core20. This is not compatible with the i386 architecture, therefore that architecture will no longer be built.<br><a href="https://snapcraft.io/docs/migrating-bases#heading--arch">Learn more</a></p>
+            <p class="p-notification__message">We have detected that your snap base is core20 or newer. This is not compatible with the i386 architecture, therefore that architecture will no longer be built.<br><a href="https://snapcraft.io/docs/migrating-bases#heading--arch">Learn more</a></p>
           </div>
         </div>
       </div>

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -128,10 +128,13 @@ def get_snap_builds(snap_name):
         context.update(builds)
 
         # Notify about i386 arch
-        if (
-            gh_snap_base
-            and gh_snap_base.replace("core", "")
-            and int(gh_snap_base.replace("core", "")) >= 20
+        if gh_snap_base and (
+            not gh_snap_base.startswith("core")
+            or (
+                gh_snap_base.startswith("core")
+                and gh_snap_base.replace("core", "")
+                and int(gh_snap_base.replace("core", "")) >= 20
+            )
         ):
             # Check if this publisher was building for i386 recently
             for build in builds["snap_builds"]:


### PR DESCRIPTION
## Done
- More defence against current and future bases that do not start with “core” (specifically fix `bare` base).
- [Drive-by] Update message for i386 on core20+.

## How to QA
- Pull the branch/ Visit the demo
- Update one of your test snaps to build from a github repo.
- Update the github repo's snapcraft.yaml with `base: bare` and `build-base: core22` ([example](https://raw.githubusercontent.com/Lukewh/test-lukewh-build/master/snap/snapcraft.yaml))
- Trigger a build
- Success

## Issue / Card
Fixes #4231 
https://warthogs.atlassian.net/browse/WD-3676