### PR TITLE
Fix active topic caching in docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # App dependencies
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.candid==0.9.0
-canonicalwebteam.discourse==5.4.0
+canonicalwebteam.discourse==5.4.1
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
By using the fixed version of canonicalwebteam.discourse.

https://github.com/canonical/canonicalwebteam.discourse/pull/161/files

## QA

On the demo. go to https://snapcraft-io-4263.demos.haus/docs. Click around a lot, click back to the same page a bunch of times. Check the navigation always reflects the correct page (unlike on live)