### PR TITLE
fix the chevron icon on releases UI

### DIFF
--- a/static/js/publisher/release/components/releasesConfirm.js
+++ b/static/js/publisher/release/components/releasesConfirm.js
@@ -120,8 +120,8 @@ class ReleasesConfirm extends Component {
                       <i
                         className={`${
                           showDetails
-                            ? "p-icon--chevron-down"
-                            : "p-icon--chevron-up"
+                            ? "p-icon--chevron-up"
+                            : "p-icon--chevron-down"
                         }`}
                       >
                         {showDetails ? "Hide" : "Show"} details


### PR DESCRIPTION
## Done
- fixed the chevron icon on releases UI

## How to QA
- Click releases tab in your published snap in https://snapcraft-io-4271.demos.haus 
- Check if the chevron icon is down when release update notification is closed or vice versa.

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-3319

