### PR TITLE
Remove copydoc from pages that don't explicitly have a copydoc

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -42,7 +42,7 @@
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 
     <meta name="description" content="{% block meta_description %}Snaps are containerised software packages that are simple to create and install. They auto-update and are safe to run. And because they bundle their dependencies, they work on all major Linux systems without modification.{% endblock %}">
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/1q9ia7iDuWQlCaJ7nfKVeQ5G-FPyJbP-H{% endblock %}">
+    <meta name="copydoc" content="{% block meta_copydoc %}{% endblock %}">
     <meta name="google-site-verification" content="Y1JayrP2iS6jS6Rd7uGX3Kzgm0oD8rV5R6TkzteLbQg" />
 
     {% block meta %}


### PR DESCRIPTION
## Done
Remove default copydoc url

## How to QA
- Install https://github.com/canonical/ubuntu-copy-docs
- Visit https://snapcraft-io-4283.demos.haus/build - see the copydoc link
- Visit https://snapcraft-io-4283.demos.haus/krita - no copydoc link
- Visit https://snapcraft-io-4283.demos.haus/docs - no copydoc link

## Issue / Card
Fixes https://github.com/canonical/snapcraft.io/issues/4201
