### PR TITLE
Remove list of snaps a user is a collaborator on from session

### DIFF
--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -51,7 +51,6 @@ def empty_session(session):
     session.pop("macaroon_root", None)
     session.pop("macaroon_discharge", None)
     session.pop("publisher", None)
-    session.pop("user_shared_snaps", None)
     session.pop("github_auth_secret", None)
 
 

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -77,8 +77,6 @@ def after_login(resp):
         return flask.redirect(LOGIN_URL)
 
     account = publisher_api.get_account(flask.session)
-    owned, shared = logic.get_snap_names_by_ownership(account)
-    flask.session["user_shared_snaps"] = shared
 
     if account:
         flask.session["publisher"] = {

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -334,14 +334,7 @@ def snap_details_views(store, api):
         # on Publicise page
         show_as_preview = False
         if is_preview and authentication.is_authenticated(flask.session):
-            if (
-                flask.session.get("publisher").get("nickname")
-                == context["username"]
-            ) or (
-                "user_shared_snaps" in flask.session
-                and snap_name in flask.session.get("user_shared_snaps")
-            ):
-                show_as_preview = True
+            show_as_preview = True
 
         if context["trending"] or show_as_preview:
             svg = get_badge_svg(

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -98,9 +98,6 @@ def snap_details_views(store, api):
             if (
                 flask.session.get("publisher").get("nickname")
                 == details["snap"]["publisher"]["username"]
-            ) or (
-                "user_shared_snaps" in flask.session
-                and snap_name in flask.session.get("user_shared_snaps")
             ):
                 is_users_snap = True
 


### PR DESCRIPTION
## Done
- Remove the fetching of the list from login flow

What this means for end users:
- Allow anyone to see the "trending" badge if they set `?preview=true` to the svg file - not a big deal imo
- Only display the "Ensure your snap always stays relevant..." on the details pages of snaps the user owns (won't show on snaps they're a collaborator on)

## How to QA
- Login to https://snapcraft-io-4286.demos.haus/
- Click a snap you own > Publicise > GitHub Badges > check the "Trending status" checkbox and ensure the "Trending" image appears
- Ffind a snap you own, and one you are a collaborator for.
  - Visit the pages for each: https://snapcraft-io-4286.demos.haus/<snap_name>
  - The snap you own should display a message at the top of the page "Ensure your snap always stays relevant and compelling. [Update its listing information here](http://localhost:8004/deno/listing)."
  - The snap you're a collaborator for will no longer display that message.

## Issue / Card
This is part of more work on https://github.com/canonical/snapcraft.io/issues/4277 and https://github.com/canonical/snapcraft.io/issues/3838
