### PR TITLE
Build - ensure image stays centred and segmented

### DIFF
--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -51,7 +51,7 @@
   }
 
   .build-container {
-    background-image: url('https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg');
+    background-image: url("https://assets.ubuntu.com/v1/7242e628-build.snapcraft.hero.svg");
     background-position: 56% 80%;
     background-repeat: no-repeat;
     bottom: 20px;
@@ -63,6 +63,19 @@
       margin: 0;
       padding: 0;
       width: 1px;
+    }
+
+    .col-4 {
+      height: 565.5px;
+    }
+
+    @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
+      background-size: 90%;
+
+      .col-4 {
+        height: auto;
+        padding-bottom: 50%;
+      }
     }
   }
 }

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -130,8 +130,8 @@
 </section>
 <section class="p-strip u-no-padding">
   <div class="u-fixed-width u-align--center" style="padding-top: 24px; padding-bottom: 64px;">
-    <img class="u-hide--small" src="https://assets.ubuntu.com/v1/21626379-Group%202899.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable.">
-    <img class="u-hide--medium u-hide--large" src="https://assets.ubuntu.com/v1/80be83a9-Group%202898.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable" />
+    <img class="u-hide--small u-hide--medium" src="https://assets.ubuntu.com/v1/21626379-Group%202899.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable.">
+    <img class="u-hide--large" src="https://assets.ubuntu.com/v1/80be83a9-Group%202898.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable" />
   </div>
 </section>
 <div class="u-fixed-width u-hide--small" style="padding-top: 10px; padding-bottom: 192px;">

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -130,8 +130,8 @@
 </section>
 <section class="p-strip u-no-padding">
   <div class="u-fixed-width u-align--center" style="padding-top: 24px; padding-bottom: 64px;">
-    <img class="u-hide--small u-hide--medium" src="https://assets.ubuntu.com/v1/21626379-Group%202899.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable.">
-    <img class="u-hide--large" src="https://assets.ubuntu.com/v1/80be83a9-Group%202898.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub master. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable" />
+    <img class="u-hide--small u-hide--medium" src="https://assets.ubuntu.com/v1/21626379-Group%202899.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub main branch. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable.">
+    <img class="u-hide--large" src="https://assets.ubuntu.com/v1/80be83a9-Group%202898.svg" alt="1: You receive a pull request on GitHub. 2: Test with Travis or other CI system. 3: The code lands on your GitHub main branch. 4: Snapcraft builds a new snap version. 5: Auto-released to the snap store for testing. 6: You promote to beta, candidate, or stable" />
   </div>
 </section>
 <div class="u-fixed-width u-hide--small" style="padding-top: 10px; padding-bottom: 192px;">

--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -36,7 +36,7 @@
 <section class="p-strip u-no-padding--top u-hide--small u-no-margin--bottom" style="padding-bottom: 32px;">
   <div class="row build-container">
     <div class="build-divider"></div>
-    <div class="col-4" style="height: 565.5px;">
+    <div class="col-4">
       <p style="padding-top: 12.6px; margin: 0;">Start by creating a repo and pushing your code to GitHub. Make sure that your repo includes a snapcraft.yaml file.</p>
     </div>
     <div class="build-divider"></div>


### PR DESCRIPTION
## Done
- Added some extra css to ensure build image stays correctly positioned on various screen sizes

## How to QA
- Visit https://snapcraft-io-4296.demos.haus/build
- Resize window, the image at the top should stay well positioned.

## Screenshots
![image](https://github.com/canonical/snapcraft.io/assets/479384/735660e1-b1d5-49aa-94cc-d2e07fcbe493)
![image](https://github.com/canonical/snapcraft.io/assets/479384/33bfe381-d9b3-4f11-b405-9215a0f176d5)
![image](https://github.com/canonical/snapcraft.io/assets/479384/d40da611-e5b7-485a-8276-ef42f57b3472)
