### PR TITLE
Fix ROS 2 not working on mobile

### DIFF
--- a/templates/partials/fsf_language.html
+++ b/templates/partials/fsf_language.html
@@ -31,7 +31,7 @@
         <option value="rust">Rust</option>
         <option value="moos">MOOS</option>
         <option value="ros">ROS</option>
-        <option value="ros-2">ROS 2</option>
+        <option value="ros2">ROS 2</option>
       </select>
     </div>
     <h3 class="p-muted-heading u-hide--small u-hide--medium u-sv2">Choose <br>your language:</h3>


### PR DESCRIPTION
## Done
Fixed a bug where the ROS 2 link wasn't working

## How to QA
- Go to https://snapcraft-io-4297.demos.haus/
- Resize to mobile view
- In the "Learn how to snap an app in 30 minutes" section, change language to "ROS 2"
- It should update the content

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4729