### PR TITLE
Convert brand store root to TypeScript

### DIFF
--- a/static/js/brand-store/brand-store.tsx
+++ b/static/js/brand-store/brand-store.tsx
@@ -14,7 +14,7 @@ Sentry.init({
 });
 
 const container = document.getElementById("root");
-const root = createRoot(container);
+const root = createRoot(container as HTMLDivElement);
 root.render(
   <Provider store={store}>
     <RecoilRoot>

--- a/static/js/brand-store/types/global.d.ts
+++ b/static/js/brand-store/types/global.d.ts
@@ -1,4 +1,5 @@
 declare interface Window {
   CSRF_TOKEN: string;
   API_URL: string;
+  SENTRY_DSN: string;
 }

--- a/webpack.config.entry.js
+++ b/webpack.config.entry.js
@@ -18,7 +18,7 @@ module.exports = {
   search: "./static/js/public/search.js",
   "distro-install": "./static/js/public/distro-install.js",
   "publisher-details": "./static/js/public/publisher-details.js",
-  "brand-store": "./static/js/brand-store/brand-store.js",
+  "brand-store": "./static/js/brand-store/brand-store.tsx",
   "publisher-listing": "./static/js/publisher/listing/index.tsx",
   "publisher-settings": "./static/js/publisher/settings/index.tsx",
   "publisher-collaboration": "./static/js/publisher/collaboration/index.tsx",


### PR DESCRIPTION
## Done
Converted the brand store root file to TypeScript

## How to QA
- Go to https://snapcraft-io-4305.demos.haus/admin
- Check that the app loads without errors