### PR TITLE
Update navigation label

### DIFF
--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -50,7 +50,7 @@
     height: $layout-height;
     position: absolute;
     top: auto;
-    z-index: 99;
+    z-index: 9;
 
     @media (min-width: $application-layout--breakpoint-side-nav-expanded) {
       position: static;

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -27,7 +27,7 @@
           role="menuitem"
         >
           <a class="p-navigation__link" href="/about">
-            About
+            About <span class="u-hide--large">Snapcraft</span>
           </a>
         </li>
         <li


### PR DESCRIPTION
## Done
- Changed the label for "About" in the navigation to "About Snapcraft" on mobile
- Drive by: Fixed z-index issue with global nav and brand store side navigation

## How to QA
- Go to https://snapcraft-io-4311.demos.haus/
- Resize to mobile
- Check that the "About" label in the navigation has changed to "About Snapcraft"

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4868