### PR TITLE
Fix for superset brand stores not loading

### DIFF
--- a/static/js/brand-store/components/Snaps/Snaps.tsx
+++ b/static/js/brand-store/components/Snaps/Snaps.tsx
@@ -255,8 +255,9 @@ function SnapsSlice() {
         return {
           id: storeId,
           name: getStoreName(storeId),
-          snaps: snaps.filter((snap) =>
-            snap?.["other-stores"].includes(storeId)
+          snaps: snaps.filter(
+            (snap) =>
+              snap["other-stores"] && snap["other-stores"].includes(storeId)
           ),
         };
       })


### PR DESCRIPTION
## Done
Fixed issue where superset brand stores are not loading

## QA
Can't QA as we don't have access to any of these stores, however the reporter of the bug has confirmed this fix works (https://github.com/canonical/snapcraft.io/issues/4314#issuecomment-1621728759)

In relation to https://github.com/canonical/snapcraft.io/issues/4314#issuecomment-1620932748