### PR TITLE
Make header full width in brand store

### DIFF
--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -2,6 +2,7 @@
   // main navigation height is based on padding and line height of a nav link
   $main-nav-height: map-get($line-heights, default-text) + $spv--large * 2;
   $layout-height: calc(100vh - #{$main-nav-height});
+  $layout-height-small: calc(100vh - 48px);
 
   .l-application {
     height: $layout-height;
@@ -47,10 +48,14 @@
   }
 
   .l-navigation {
-    height: $layout-height;
+    height: $layout-height-small;
     position: absolute;
     top: auto;
     z-index: 9;
+
+    @media (max-width: $breakpoint-small) {
+      height: $layout-height;
+    }
 
     @media (min-width: $application-layout--breakpoint-side-nav-expanded) {
       position: static;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -451,3 +451,7 @@ code {
 .p-strip--dark {
   background-color: #333 !important;
 }
+
+.p-navigation__row.is-full-width {
+  max-width: 100%;
+}

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -1,5 +1,5 @@
 <header id="navigation" class="p-navigation is-dark">
-  <div class="p-navigation__row">
+  <div class="p-navigation__row {% if full_width_nav %}is-full-width{% endif %}">
     <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">
         <a class="p-navigation__link" href="/">

--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -1,4 +1,5 @@
 {% set page_slug = "admin" %}
+{% set full_width_nav = True %}
 {% extends "_base-layout.html" %}
 {% block content %}
 <div id="root">


### PR DESCRIPTION
## Done
Made the header navigation full width on the brand store

## How to QA
- Go to https://snapcraft-io-4330.demos.haus/
- Check that the header is the same as on snapcraft.io
- Go to https://snapcraft-io-4330.demos.haus/admin
- Check that the header is full width
