### PR TITLE
Update openSUSE page with new Leap, optimize systemctl commands

### DIFF
--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -9,12 +9,12 @@ install:
       Snap can be installed from the command line on openSUSE Leap 15.x and Tumbleweed.
   -
     action: |
-      You need first add the <em>snappy</em> repository from the terminal. Leap 15.2 users, for example, can do this with the following command:
+      You need first add the <em>snappy</em> repository from the terminal. Leap 15.5 users, for example, can do this with the following command:
     command: |
-      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.2 snappy
+      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.5 snappy
   -
     action: |
-      Swap out <code>openSUSE_Leap_15.2</code> for <code>openSUSE_Leap_15.1</code>, <code>openSUSE_Leap_15.0</code>, or <code>openSUSE_Tumbleweed</code> if you’re using a different version of openSUSE.
+      Swap out <code>openSUSE_Leap_15.5</code> for <code>openSUSE_Leap_15.4</code> or <code>openSUSE_Tumbleweed</code> if you’re using a different version of openSUSE.
   -
     action: |
       With the repository added, import its GPG key:
@@ -35,11 +35,5 @@ install:
       You then need to either reboot, logout/login or <code>source /etc/profile</code> to have /snap/bin added to PATH.
       Additionally, enable and start both the <em>snapd</em> and the <em>snapd.apparmor</em> services with the following commands:
     command: |
-      sudo systemctl enable snapd
-      sudo systemctl start snapd
-  -
-    action: |
-      Tumbleweed users also need to run the following:
-    command: |
-      sudo systemctl enable snapd.apparmor
-      sudo systemctl start snapd.apparmor
+      sudo systemctl enable --now snapd
+      sudo systemctl enable --now snapd.apparmor


### PR DESCRIPTION
## Done
Updated 3 years old openSUSE page

## How to QA
Install snap via updated description on both openSUSE versions