### PR TITLE
Fix name overflow on models table

### DIFF
--- a/static/js/brand-store/components/Model/Policies.tsx
+++ b/static/js/brand-store/components/Model/Policies.tsx
@@ -14,13 +14,17 @@ import PoliciesFilter from "./PoliciesFilter";
 import PoliciesTable from "./PoliciesTable";
 import CreatePolicyForm from "./CreatePolicyForm";
 
-import { usePolicies } from "../../hooks";
-import { policiesListFilterState, policiesListState } from "../../atoms";
+import { usePolicies, useSigningKeys } from "../../hooks";
+import {
+  policiesListFilterState,
+  policiesListState,
+  signingKeysListState,
+} from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
 import { isClosedPanel, setPageTitle } from "../../utils";
 
-import type { Policy } from "../../types/shared";
+import type { Policy, SigningKey } from "../../types/shared";
 
 function Policies() {
   const { id, model_id } = useParams();
@@ -30,6 +34,7 @@ function Policies() {
     id,
     model_id
   );
+  const signingKeys = useSigningKeys(id);
   const setPoliciesList = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(policiesListFilterState);
   const brandStore = useRecoilValue(brandStoreState(id));
@@ -38,6 +43,15 @@ function Policies() {
   const [showErrorNotification, setShowErrorNotification] = useState<boolean>(
     false
   );
+  const setSigningKeysList = useSetRecoilState<Array<SigningKey>>(
+    signingKeysListState
+  );
+
+  useEffect(() => {
+    if (!signingKeys.isLoading && !signingKeys.isError) {
+      setSigningKeysList(signingKeys.data);
+    }
+  }, [signingKeys]);
 
   useEffect(() => {
     if (!isLoading && !isError) {
@@ -106,7 +120,11 @@ function Policies() {
             <div className="u-fixed-width">
               <>
                 {isLoading && <p>Fetching policies...</p>}
-                {isError && error && <p>Error: {error.message}</p>}
+                {isError && error && (
+                  <Notification severity="negative">
+                    Error: {error.message}
+                  </Notification>
+                )}
                 <PoliciesTable />
               </>
             </div>

--- a/static/js/brand-store/components/Models/Models.tsx
+++ b/static/js/brand-store/components/Models/Models.tsx
@@ -124,7 +124,11 @@ function Models() {
             <div className="u-fixed-width">
               <>
                 {isLoading && <p>Fetching models...</p>}
-                {isError && error && <p>Error: {error.message}</p>}
+                {isError && error && (
+                  <Notification severity="negative">
+                    Error: {error.message}
+                  </Notification>
+                )}
                 <ModelsTable />
               </>
             </div>

--- a/static/js/brand-store/components/Models/ModelsTable.tsx
+++ b/static/js/brand-store/components/Models/ModelsTable.tsx
@@ -53,6 +53,7 @@ function ModelsTable() {
                   {model.name}
                 </Link>
               ),
+              className: "u-truncate",
             },
             {
               content: maskString(model["api-key"]),


### PR DESCRIPTION
## Done
- Fixed an issue where the signing keys weren't showing in the policies table
- Drive by: Truncated model names in the models table
- Drive by: Made loading error messages a Vanilla notification

## How to QA
- Go to https://snapcraft-io-4359.demos.haus/login-beta and log in
- Go to https://snapcraft-io-4359.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/test_model_without_api_key/policies
- Check that there are signing keys in the table
