### PR TITLE
Fix other stores not showing in brand store

### DIFF
--- a/static/js/brand-store/components/Snaps/Snaps.tsx
+++ b/static/js/brand-store/components/Snaps/Snaps.tsx
@@ -211,6 +211,14 @@ function SnapsSlice() {
     const storeIds: Array<string> = [];
 
     snaps.forEach((snap) => {
+      if (snap.store === "ubuntu" || snap.store === id) {
+        return;
+      }
+
+      if (!storeIds.includes(snap.store)) {
+        storeIds.push(snap.store);
+      }
+
       if (snap?.["other-stores"]?.length) {
         snap["other-stores"].forEach((otherStoreId) => {
           if (otherStoreId !== id && !storeIds.includes(otherStoreId)) {
@@ -259,10 +267,24 @@ function SnapsSlice() {
         return {
           id: storeId,
           name: getStoreName(storeId),
-          snaps: snaps.filter(
-            (snap) =>
-              snap["other-stores"] && snap["other-stores"].includes(storeId)
-          ),
+          snaps: snaps.filter((snap) => {
+            if (storeId === "ubuntu") {
+              return false;
+            }
+
+            if (snap.store === storeId) {
+              return true;
+            }
+
+            if (
+              snap["other-stores"] &&
+              snap["other-stores"].includes(storeId)
+            ) {
+              return true;
+            }
+
+            return false;
+          }),
         };
       })
     );


### PR DESCRIPTION
## Done
Fixed a bug where other stores weren't showing in the brand store

## How to QA
- Go to https://snapcraft-io-4366.demos.haus/admin/TestInternalStoreTeam2023/snaps
- Check that "Test Store Team Store" is in the table and contains "newsnapbuild"

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-5427