### PR TITLE
Change display of api keys in models service

### DIFF
--- a/static/js/brand-store/components/Models/ModelsTable.tsx
+++ b/static/js/brand-store/components/Models/ModelsTable.tsx
@@ -56,7 +56,7 @@ function ModelsTable() {
               className: "u-truncate",
             },
             {
-              content: maskString(model["api-key"]),
+              content: maskString(model["api-key"]) || "-",
               className: "u-align--right",
             },
             {

--- a/static/js/brand-store/utils/maskString.test.ts
+++ b/static/js/brand-store/utils/maskString.test.ts
@@ -3,19 +3,20 @@ import maskString from "./maskString";
 describe("maskString", () => {
   const str = "761bbec69e2844958fcd";
 
-  it("returns the given argument if less than or equal to 4 characters", () => {
+  it("returns an empty string if no argument is given", () => {
+    expect(maskString(undefined)).toEqual("");
+  });
+
+  it("returns the given argument if less than or equal to 6 characters", () => {
     expect(maskString("a")).toEqual("a");
     expect(maskString("ab")).toEqual("ab");
     expect(maskString("abc")).toEqual("abc");
     expect(maskString("abcd")).toEqual("abcd");
-    expect(maskString("abcde")).toEqual("*bcde");
+    expect(maskString("abcde")).toEqual("abcde");
+    expect(maskString("abcdef")).toEqual("abcdef");
   });
 
-  it("returns a string of asterisks and 4 characters", () => {
-    expect(maskString(str)).toEqual("****************8fcd");
-  });
-
-  it("returns a string that same length as its given argument", () => {
-    expect(maskString(str).length).toEqual(str.length);
+  it("returns the last 6 charcters with a prepended ellipsis", () => {
+    expect(maskString(str)).toEqual("...958fcd");
   });
 });

--- a/static/js/brand-store/utils/maskString.ts
+++ b/static/js/brand-store/utils/maskString.ts
@@ -1,24 +1,18 @@
 function maskString(str: string | undefined) {
-  const visibleCharacterCount = 4;
+  const visibleCharacterCount = 6;
 
   if (!str) {
     return "";
   }
 
-  if (str.length < visibleCharacterCount) {
+  if (str.length <= visibleCharacterCount) {
     return str;
   }
 
   const strLength = str.length;
   const strEnd = str.slice(strLength - visibleCharacterCount, strLength);
 
-  let strMask = "";
-
-  for (let i = 0, ii = strLength - visibleCharacterCount; i < ii; i++) {
-    strMask += "*";
-  }
-
-  return `${strMask}${strEnd}`;
+  return `...${strEnd}`;
 }
 
 export default maskString;


### PR DESCRIPTION
## Done
Changed the way API keys are masked in the models service

## How to QA
- Go to https://snapcraft-io-4367.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- Check that the API key is displayed in the following format: "...abcdef"

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-5600