### PR TITLE
Swap search and CTA in brand store

### DIFF
--- a/static/js/brand-store/components/Members/Members.tsx
+++ b/static/js/brand-store/components/Members/Members.tsx
@@ -202,15 +202,6 @@ function Members() {
               <>
                 <Row>
                   <Col size={6}>
-                    <Button
-                      onClick={() => {
-                        setSidePanelOpen(true);
-                      }}
-                    >
-                      Add new member
-                    </Button>
-                  </Col>
-                  <Col size={6}>
                     <SearchBox
                       placeholder="Search and filter"
                       autocomplete="off"
@@ -228,6 +219,15 @@ function Members() {
                         }
                       }}
                     />
+                  </Col>
+                  <Col size={6} className="u-align--right">
+                    <Button
+                      onClick={() => {
+                        setSidePanelOpen(true);
+                      }}
+                    >
+                      Add new member
+                    </Button>
                   </Col>
                 </Row>
                 <div className="u-fixed-width app-accordion">

--- a/static/js/brand-store/components/Model/Policies.tsx
+++ b/static/js/brand-store/components/Model/Policies.tsx
@@ -106,15 +106,15 @@ function Policies() {
             )}
             <Row>
               <Col size={6}>
+                <PoliciesFilter />
+              </Col>
+              <Col size={6} className="u-align--right">
                 <Link
                   className="p-button"
                   to={`/admin/${id}/models/${model_id}/policies/create`}
                 >
                   Create policy
                 </Link>
-              </Col>
-              <Col size={6}>
-                <PoliciesFilter />
               </Col>
             </Row>
             <div className="u-fixed-width">

--- a/static/js/brand-store/components/Models/Models.tsx
+++ b/static/js/brand-store/components/Models/Models.tsx
@@ -113,12 +113,12 @@ function Models() {
             )}
             <Row>
               <Col size={6}>
+                <ModelsFilter />
+              </Col>
+              <Col size={6} className="u-align--right">
                 <Link className="p-button" to={`/admin/${id}/models/create`}>
                   Create new model
                 </Link>
-              </Col>
-              <Col size={6}>
-                <ModelsFilter />
               </Col>
             </Row>
             <div className="u-fixed-width">

--- a/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
+++ b/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
@@ -136,15 +136,15 @@ function SigningKeys() {
             )}
             <Row>
               <Col size={6}>
+                <SigningKeysFilter />
+              </Col>
+              <Col size={6} className="u-align--right">
                 <Link
                   className="p-button"
                   to={`/admin/${id}/signing-keys/create`}
                 >
                   Create new signing key
                 </Link>
-              </Col>
-              <Col size={6}>
-                <SigningKeysFilter />
               </Col>
             </Row>
             <div className="u-fixed-width">

--- a/static/js/brand-store/components/Snaps/Snaps.tsx
+++ b/static/js/brand-store/components/Snaps/Snaps.tsx
@@ -338,7 +338,7 @@ function SnapsSlice() {
               <Reviewer />
             ) : currentStore && isPublisherOnly ? (
               <Publisher />
-            ) : snapsNotFound || membersNotFound ? (
+            ) : snapsNotFound ? (
               <StoreNotFound />
             ) : (
               <>
@@ -353,12 +353,17 @@ function SnapsSlice() {
                 {!isReloading && (
                   <Row>
                     <Col size={6}>
-                      {isOnlyViewer() && (
-                        <h2 className="p-heading--4">
-                          Snaps in {getStoreName(id || "")}
-                        </h2>
-                      )}
-
+                      <SnapsFilter
+                        setSnapsInStore={setSnapsInStore}
+                        snapsInStore={snapsInStore}
+                        setOtherStores={setOtherStores}
+                        otherStoreIds={otherStoreIds}
+                        getStoreName={getStoreName}
+                        snaps={snaps}
+                        id={id || ""}
+                      />
+                    </Col>
+                    <Col size={6} className="u-align--right">
                       {!isOnlyViewer() && (
                         <>
                           <Button onClick={() => setSidePanelOpen(true)}>
@@ -371,7 +376,11 @@ function SnapsSlice() {
                             onClick={() => {
                               setShowRemoveSnapsConfirmation(true);
                             }}
-                            className={removeSnapSaving ? "has-icon" : ""}
+                            className={
+                              removeSnapSaving
+                                ? "has-icon u-no-margin--right"
+                                : "u-no-margin--right"
+                            }
                           >
                             {removeSnapSaving ? (
                               <>
@@ -386,17 +395,6 @@ function SnapsSlice() {
                           </Button>
                         </>
                       )}
-                    </Col>
-                    <Col size={6}>
-                      <SnapsFilter
-                        setSnapsInStore={setSnapsInStore}
-                        snapsInStore={snapsInStore}
-                        setOtherStores={setOtherStores}
-                        otherStoreIds={otherStoreIds}
-                        getStoreName={getStoreName}
-                        snaps={snaps}
-                        id={id || ""}
-                      />
                     </Col>
                   </Row>
                 )}


### PR DESCRIPTION
## Done
- Swapped the order of the search and CTA on the brand store pages
- Drive by: Fixed bug where view stores would redirect to "Store not found" if the members didn't load

## How to QA
- Go to the following pages and check that the search/filter is on the left and the CTA buttons are on the right
- https://snapcraft-io-4370.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- https://snapcraft-io-4370.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/test_model_without_api_key/policies
- https://snapcraft-io-4370.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/signing-keys
- https://snapcraft-io-4370.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- https://snapcraft-io-4370.demos.haus/admin/ahnuP3quahti9vis8aiw/members

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-5613