### PR TITLE
Check brand for models navigation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.4.2
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==4.4.0
+canonicalwebteam.store-api==4.5.0
 canonicalwebteam.launchpad==0.8.4
 django-openid-auth==0.16
 Flask-OpenID==1.3.0

--- a/static/js/brand-store/components/SectionNav/SectionNav.test.tsx
+++ b/static/js/brand-store/components/SectionNav/SectionNav.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
+import { QueryClient, QueryClientProvider, useQuery } from "react-query";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import SectionNav from "./SectionNav";
@@ -9,86 +10,111 @@ jest.mock("react-router-dom", () => ({
   useParams: jest.fn().mockReturnValue({ id: "test" }),
 }));
 
-test("active state is set on snaps when on snaps section", () => {
-  render(
+jest.mock("react-query", () => ({
+  ...jest.requireActual("react-query"),
+  useQuery: jest.fn(),
+}));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+});
+
+function renderComponent(sectionName: string) {
+  return render(
     <Router>
-      <SectionNav sectionName="snaps" />
+      <QueryClientProvider client={queryClient}>
+        <SectionNav sectionName={sectionName} />
+      </QueryClientProvider>
     </Router>
   );
+}
 
+const defaultQueryResponse = {
+  data: {
+    success: false,
+  },
+  isLoading: false,
+  isSuccess: true,
+};
+
+test("active state is set on snaps when on snaps section", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue(defaultQueryResponse);
+  renderComponent("snaps");
   expect(
     screen.getByRole("tab", { name: "Snaps" }).getAttribute("aria-selected")
   ).toEqual("true");
 });
 
-test("active state is not set on members or settings when on snaps section", () => {
-  render(
-    <Router>
-      <SectionNav sectionName="snaps" />
-    </Router>
-  );
-
-  expect(
-    screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")
-  ).toEqual("false");
-
-  expect(
-    screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")
-  ).toEqual("false");
-});
-
-test("active state is set on snaps when on members section", () => {
-  render(
-    <Router>
-      <SectionNav sectionName="members" />
-    </Router>
-  );
-
+test("active state is set on snaps when on members section", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue(defaultQueryResponse);
+  renderComponent("members");
   expect(
     screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")
   ).toEqual("true");
 });
 
-test("active state is not set on snaps or settings when on members section", () => {
-  render(
-    <Router>
-      <SectionNav sectionName="members" />
-    </Router>
-  );
-
-  expect(
-    screen.getByRole("tab", { name: "Snaps" }).getAttribute("aria-selected")
-  ).toEqual("false");
-
-  expect(
-    screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")
-  ).toEqual("false");
-});
-
-test("active state is set on snaps when on settings section", () => {
-  render(
-    <Router>
-      <SectionNav sectionName="settings" />
-    </Router>
-  );
-
+test("active state is set on snaps when on settings section", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue(defaultQueryResponse);
+  renderComponent("settings");
   expect(
     screen.getByRole("tab", { name: "Settings" }).getAttribute("aria-selected")
   ).toEqual("true");
 });
 
-test("active state is not set on members or settings when on settings section", () => {
-  render(
-    <Router>
-      <SectionNav sectionName="settings" />
-    </Router>
-  );
-
+test("active state is set on snaps when on models section", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue({
+    ...defaultQueryResponse,
+    data: { success: true },
+  });
+  renderComponent("models");
   expect(
-    screen.getByRole("tab", { name: "Snaps" }).getAttribute("aria-selected")
-  ).toEqual("false");
+    screen.getByRole("tab", { name: "Models" }).getAttribute("aria-selected")
+  ).toEqual("true");
+});
 
+test("active state is set on snaps when on signing keys section", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue({
+    ...defaultQueryResponse,
+    data: { success: true },
+  });
+  renderComponent("signing-keys");
   expect(
-    screen.getByRole("tab", { name: "Members" }).getAttribute("aria-selected")
-  ).toEqual("false");
+    screen
+      .getByRole("tab", { name: "Signing keys" })
+      .getAttribute("aria-selected")
+  ).toEqual("true");
+});
+
+test("it renders 'Models' and 'Signing keys' in nav if response is successful", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue({
+    ...defaultQueryResponse,
+    data: { success: true },
+  });
+  renderComponent("models");
+  expect(screen.getByRole("tab", { name: "Models" })).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "Signing keys" })).toBeInTheDocument();
+});
+
+test("it doesn't render 'Models' and 'Signing keys' in nav if response is not successful", async () => {
+  // @ts-ignore
+  useQuery.mockReturnValue({
+    ...defaultQueryResponse,
+    data: { success: false },
+  });
+  renderComponent("snaps");
+  expect(screen.queryByRole("tab", { name: "Models" })).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("tab", { name: "Signing keys" })
+  ).not.toBeInTheDocument();
 });

--- a/static/js/brand-store/components/SectionNav/SectionNav.tsx
+++ b/static/js/brand-store/components/SectionNav/SectionNav.tsx
@@ -1,63 +1,76 @@
 import React from "react";
 import { Link, useParams } from "react-router-dom";
+
+import { useBrand } from "../../hooks";
+
 import type { RouteParams } from "../../types/shared";
 
 function SectionNav({ sectionName }: { sectionName: string }) {
   const { id } = useParams<RouteParams>();
+  const { isLoading, isSuccess, data } = useBrand(id);
 
   return (
     <nav className="p-tabs">
-      <ul className="p-tabs__list">
-        <li className="p-tabs__item">
-          <Link
-            to={`/admin/${id}/snaps`}
-            className="p-tabs__link"
-            aria-selected={sectionName === "snaps"}
-            role="tab"
-          >
-            Snaps
-          </Link>
-        </li>
-        {/* <li className="p-tabs__item">
-          <Link
-            to={`/admin/${id}/models`}
-            className="p-tabs__link"
-            aria-selected={sectionName === "models"}
-            role="tab"
-          >
-            Models
-          </Link>
-        </li>
-        <li className="p-tabs__item">
-          <Link
-            to={`/admin/${id}/signing-keys`}
-            className="p-tabs__link"
-            aria-selected={sectionName === "signing-keys"}
-            role="tab"
-          >
-            Signing keys
-          </Link>
-        </li> */}
-        <li className="p-tabs__item">
-          <Link
-            to={`/admin/${id}/members`}
-            className="p-tabs__link"
-            aria-selected={sectionName === "members"}
-            role="tab"
-          >
-            Members
-          </Link>
-        </li>
-        <li className="p-tabs__item">
-          <Link
-            to={`/admin/${id}/settings`}
-            className="p-tabs__link"
-            aria-selected={sectionName === "settings"}
-            role="tab"
-          >
-            Settings
-          </Link>
-        </li>
+      <ul className="p-tabs__list brand-store-tabs">
+        {!isLoading && isSuccess && (
+          <>
+            <li className="p-tabs__item">
+              <Link
+                to={`/admin/${id}/snaps`}
+                className="p-tabs__link"
+                aria-selected={sectionName === "snaps"}
+                role="tab"
+              >
+                Snaps
+              </Link>
+            </li>
+            {/* If success then models and signing keys are available */}
+            {data.success && (
+              <>
+                <li className="p-tabs__item">
+                  <Link
+                    to={`/admin/${id}/models`}
+                    className="p-tabs__link"
+                    aria-selected={sectionName === "models"}
+                    role="tab"
+                  >
+                    Models
+                  </Link>
+                </li>
+                <li className="p-tabs__item">
+                  <Link
+                    to={`/admin/${id}/signing-keys`}
+                    className="p-tabs__link"
+                    aria-selected={sectionName === "signing-keys"}
+                    role="tab"
+                  >
+                    Signing keys
+                  </Link>
+                </li>
+              </>
+            )}
+            <li className="p-tabs__item">
+              <Link
+                to={`/admin/${id}/members`}
+                className="p-tabs__link"
+                aria-selected={sectionName === "members"}
+                role="tab"
+              >
+                Members
+              </Link>
+            </li>
+            <li className="p-tabs__item">
+              <Link
+                to={`/admin/${id}/settings`}
+                className="p-tabs__link"
+                aria-selected={sectionName === "settings"}
+                role="tab"
+              >
+                Settings
+              </Link>
+            </li>
+          </>
+        )}
       </ul>
     </nav>
   );

--- a/static/js/brand-store/components/Settings/Settings.test.tsx
+++ b/static/js/brand-store/components/Settings/Settings.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import * as reactRedux from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
 import { Provider } from "react-redux";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import Settings from "./Settings";
@@ -17,6 +18,27 @@ jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
   useSelector: jest.fn(),
 }));
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+});
+
+function renderComponent() {
+  return render(
+    <Provider store={store}>
+      <Router>
+        <QueryClientProvider client={queryClient}>
+          <Settings />
+        </QueryClientProvider>
+      </Router>
+    </Provider>
+  );
+}
 
 function getInitialState(): RootState {
   return {
@@ -59,15 +81,7 @@ beforeEach(() => {
 
 test("the 'is public' checkbox should not be checked when the current store is set to private", () => {
   setupMockSelector(initialState);
-
-  render(
-    <Provider store={store}>
-      <Router>
-        <Settings />
-      </Router>
-    </Provider>
-  );
-
+  renderComponent();
   expect(
     screen.getByLabelText("Include this store in public lists")
   ).not.toBeChecked();
@@ -76,15 +90,7 @@ test("the 'is public' checkbox should not be checked when the current store is s
 test("the 'is public' checkbox should be checked when the current store is not set to private", () => {
   initialState.currentStore.currentStore.private = false;
   setupMockSelector(initialState);
-
-  render(
-    <Provider store={store}>
-      <Router>
-        <Settings />
-      </Router>
-    </Provider>
-  );
-
+  renderComponent();
   expect(
     screen.getByLabelText("Include this store in public lists")
   ).toBeChecked();
@@ -92,35 +98,17 @@ test("the 'is public' checkbox should be checked when the current store is not s
 
 test("the correct value is given to the store ID field", () => {
   setupMockSelector(initialState);
-
-  render(
-    <Provider store={store}>
-      <Router>
-        <Settings />
-      </Router>
-    </Provider>
-  );
-
+  renderComponent();
   const storeIdInput = screen.getByLabelText("Store ID") as HTMLInputElement;
-
   expect(storeIdInput.value).toEqual(initialState.currentStore.currentStore.id);
 });
 
 test("the correct radio button is checked by default for manual review policy", () => {
   setupMockSelector(initialState);
-
-  render(
-    <Provider store={store}>
-      <Router>
-        <Settings />
-      </Router>
-    </Provider>
-  );
-
+  renderComponent();
   const checkedRadioButton = screen.getByRole("radio", {
     checked: true,
   }) as HTMLInputElement;
-
   expect(checkedRadioButton.value).toEqual(
     initialState.currentStore.currentStore["manual-review-policy"]
   );
@@ -128,29 +116,13 @@ test("the correct radio button is checked by default for manual review policy", 
 
 test("the save button is disabled by default", () => {
   setupMockSelector(initialState);
-
-  render(
-    <Provider store={store}>
-      <Router>
-        <Settings />
-      </Router>
-    </Provider>
-  );
-
+  renderComponent();
   expect(screen.getByText("Save changes")).toBeDisabled();
 });
 
 test("the save button is enabled when the data changes", () => {
   setupMockSelector(initialState);
-
-  render(
-    <Provider store={store}>
-      <Router>
-        <Settings />
-      </Router>
-    </Provider>
-  );
-
+  renderComponent();
   screen.getByRole("checkbox").click();
   expect(screen.getByText("Save changes")).not.toBeDisabled();
 });

--- a/static/js/brand-store/components/SigningKeys/DeactivateSigningKeyModal.tsx
+++ b/static/js/brand-store/components/SigningKeys/DeactivateSigningKeyModal.tsx
@@ -19,8 +19,6 @@ function DeactivateSigningKeyModal({
 }: Props) {
   const { id } = useParams();
 
-  console.log("signingKey", signingKey);
-
   return signingKey.models && signingKey.models.length > 0 ? (
     <Modal
       title={

--- a/static/js/brand-store/hooks/index.ts
+++ b/static/js/brand-store/hooks/index.ts
@@ -63,3 +63,20 @@ export function useSigningKeys(id: string | undefined) {
     return signingKeysData.data;
   });
 }
+
+export function useBrand(id: string | undefined) {
+  return useQuery("brand", async () => {
+    const response = await fetch(`/admin/store/${id}/brand`);
+
+    if (!response.ok) {
+      return {
+        success: false,
+        message: "Brand not found",
+      };
+    }
+
+    const brand = await response.json();
+
+    return brand;
+  });
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -463,3 +463,12 @@ code {
 .p-panel__logo {
   margin-left: 0;
 }
+
+// To prevent layout shift
+.brand-store-tabs {
+  height: 48px;
+
+  @media only screen and (min-width: $breakpoint-x-large) {
+    height: 54px;
+  }
+}

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -462,6 +462,33 @@ def delete_policy(store_id: str, model_name: str, revision: str):
     return make_response(res)
 
 
+@admin.route("/admin/store/<store_id>/brand")
+@login_required
+def get_brand_store(store_id: str):
+    res = {}
+    try:
+        print(admin_api.get_brand(flask.session, store_id))
+        brand = admin_api.get_brand(flask.session, store_id)
+
+        res["data"] = brand
+        res["success"] = True
+
+    except StoreApiResponseErrorList as error_list:
+        res["success"] = False
+        res["message"] = " ".join(
+            [
+                f"{error.get('message', 'An error occurred')}"
+                for error in error_list.errors
+            ]
+        )
+        res["data"] = []
+
+    response = make_response(res)
+    response.cache_control.max_age = 3600
+
+    return response
+
+
 @admin.route("/admin/store/<store_id>/signing-keys")
 @login_required
 def get_signing_keys(store_id: str):


### PR DESCRIPTION
## Done
- Show models and signing keys in the brand store navigation if available to the user

## How to QA
- Go to https://snapcraft-io-4385.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- Check that "Models" and "Signing keys" are in the horizontal navigation
- Go to https://snapcraft-io-4385.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Check that "Models" and "Signing keys" are not in the horizontal navigation

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4749