### PR TITLE
Update ubuntu logo on /build

### DIFF
--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -58,7 +58,7 @@
   </div>
   <div class="row">
     <div class="p-logo-image col-small-2 col-medium-2 col-2 col-logo">
-      <img src="https://assets.ubuntu.com/v1/4e18e57c-logo-ubuntu--in-card.png" alt="">
+      <img src="https://assets.ubuntu.com/v1/46dc42a1-ubuntu-logo.png" alt="">
     </div>
     <div class="p-logo-image col-small-2 col-medium-2 col-2 col-logo">
       <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="">


### PR DESCRIPTION
## Done
- Updated ubuntu logo on /build page

## How to QA
- Visit https://snapcraft-io-4386.demos.haus/build
- See the new ubuntu logo.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-5846

## Screenshots
