### PR TITLE
Make new policy form submit with enter key

### DIFF
--- a/static/js/brand-store/components/Model/Policies.tsx
+++ b/static/js/brand-store/components/Model/Policies.tsx
@@ -188,13 +188,11 @@ function Policies() {
           isClosedPanel(location.pathname, "create") ? "is-collapsed" : ""
         }`}
       >
-        {!isClosedPanel(location.pathname, "create") && (
-          <CreatePolicyForm
-            setShowNotification={setShowNotification}
-            setShowErrorNotification={setShowErrorNotification}
-            refetchPolicies={refetch}
-          />
-        )}
+        <CreatePolicyForm
+          setShowNotification={setShowNotification}
+          setShowErrorNotification={setShowErrorNotification}
+          refetchPolicies={refetch}
+        />
       </aside>
     </>
   );


### PR DESCRIPTION
## Done
Fixed issue where the "Create policy" form didn't submit when the enter key was pressed

## How to QA
- Go to https://snapcraft-io-4394.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/alimot_test_model_a/policies/create
- Select a signing key
- Whilst still focused in the signing key field press "Enter"
- The form should submit and a new policy should be created

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-5589