### PR TITLE
Convert model service cancel buttons to links and clear forms on close

### DIFF
--- a/static/js/brand-store/components/Model/CreatePolicyForm.tsx
+++ b/static/js/brand-store/components/Model/CreatePolicyForm.tsx
@@ -7,7 +7,7 @@ import { Button } from "@canonical/react-components";
 import { setPageTitle } from "../../utils";
 
 import { useSigningKeys } from "../../hooks";
-import { signingKeysListState } from "../../atoms";
+import { signingKeysListState, newSigningKeyState } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
 type Props = {
@@ -25,13 +25,13 @@ function CreatePolicyForm({
   const navigate = useNavigate();
   const { isLoading, isError, error, data }: any = useSigningKeys(id);
   const [signingKeys, setSigningKeys] = useRecoilState(signingKeysListState);
+  const [newSigningKey, setNewSigningKey] = useRecoilState(newSigningKeyState);
   const brandStore = useRecoilValue(brandStoreState(id));
-  const [selectedSigningKey, setSelectedSigningKey] = useState("");
 
   const handleError = () => {
     setShowErrorNotification(true);
     navigate(`/admin/${id}/models/${model_id}/policies`);
-    setSelectedSigningKey("");
+    setNewSigningKey({ name: "" });
     setTimeout(() => {
       setShowErrorNotification(false);
     }, 5000);
@@ -64,7 +64,7 @@ function CreatePolicyForm({
       }
 
       setShowNotification(true);
-      setSelectedSigningKey("");
+      setNewSigningKey({ name: "" });
       refetchPolicies();
       navigate(`/admin/${id}/models/${model_id}/policies`);
       setTimeout(() => {
@@ -91,7 +91,7 @@ function CreatePolicyForm({
     <form
       onSubmit={(event) => {
         event.preventDefault();
-        mutation.mutate(selectedSigningKey);
+        mutation.mutate(newSigningKey.name);
       }}
       style={{ height: "100%" }}
     >
@@ -110,9 +110,11 @@ function CreatePolicyForm({
               id="signing-key"
               required
               disabled={signingKeys.length < 1}
-              value={selectedSigningKey}
+              value={newSigningKey.name}
               onChange={(event) => {
-                setSelectedSigningKey(event.target.value);
+                setNewSigningKey({
+                  name: event.target.value,
+                });
               }}
             >
               <option value="">Select a signing key</option>
@@ -139,19 +141,21 @@ function CreatePolicyForm({
           <div className="u-fixed-width">
             <hr />
             <div className="u-align--right">
-              <Button
-                className="u-no-margin--bottom"
+              <Link
+                className="p-button u-no-margin--bottom"
+                to={`/admin/${id}/models/${model_id}/policies`}
                 onClick={() => {
-                  navigate(`/admin/${id}/models/${model_id}/policies`);
+                  setNewSigningKey({ name: "" });
+                  setShowErrorNotification(false);
                 }}
               >
                 Cancel
-              </Button>
+              </Link>
               <Button
                 type="submit"
                 appearance="positive"
                 className="u-no-margin--bottom u-no-margin--right"
-                disabled={!selectedSigningKey}
+                disabled={!newSigningKey.name}
               >
                 Add policy
               </Button>

--- a/static/js/brand-store/components/Model/Policies.tsx
+++ b/static/js/brand-store/components/Model/Policies.tsx
@@ -20,6 +20,7 @@ import {
   policiesListFilterState,
   policiesListState,
   signingKeysListState,
+  newSigningKeyState,
 } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
@@ -38,6 +39,7 @@ function Policies() {
   const signingKeys = useSigningKeys(id);
   const setPoliciesList = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(policiesListFilterState);
+  const setNewSigningKey = useSetRecoilState(newSigningKeyState);
   const brandStore = useRecoilValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
   const [showNotification, setShowNotification] = useState<boolean>(false);
@@ -181,6 +183,8 @@ function Policies() {
         }`}
         onClick={() => {
           navigate(`/admin/${id}/models/${model_id}/policies`);
+          setNewSigningKey({ name: "" });
+          setShowErrorNotification(false);
         }}
       ></div>
       <aside

--- a/static/js/brand-store/components/Models/CreateModelForm.tsx
+++ b/static/js/brand-store/components/Models/CreateModelForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, Link } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { useMutation } from "react-query";
 import { Input, Button } from "@canonical/react-components";
@@ -165,14 +165,16 @@ function CreateModelForm({
             <p>* Mandatory field</p>
             <hr />
             <div className="u-align--right">
-              <Button
-                className="u-no-margin--bottom"
+              <Link
+                className="p-button u-no-margin--bottom"
+                to={`/admin/${id}/models`}
                 onClick={() => {
-                  navigate(`/admin/${id}/models`);
+                  setNewModel({ name: "", apiKey: "" });
+                  setShowErrorNotification(false);
                 }}
               >
                 Cancel
-              </Button>
+              </Link>
               <Button
                 type="submit"
                 appearance="positive"

--- a/static/js/brand-store/components/Models/Models.tsx
+++ b/static/js/brand-store/components/Models/Models.tsx
@@ -14,6 +14,7 @@ import {
   modelsListFilterState,
   modelsListState,
   policiesListState,
+  newModelState,
 } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
@@ -59,6 +60,7 @@ function Models() {
   const { isLoading, isError, error, data }: any = useModels(id);
   const setModelsList = useSetRecoilState<Array<Model>>(modelsListState);
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
+  const setNewModel = useSetRecoilState(newModelState);
   const setFilter = useSetRecoilState<string>(modelsListFilterState);
   const brandStore = useRecoilValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
@@ -151,6 +153,7 @@ function Models() {
         onClick={() => {
           navigate(`/admin/${id}/models`);
           setShowErrorNotification(false);
+          setNewModel({ name: "", apiKey: "" });
         }}
       ></div>
       <aside

--- a/static/js/brand-store/components/SigningKeys/CreateSigningKeyForm.tsx
+++ b/static/js/brand-store/components/SigningKeys/CreateSigningKeyForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, Link } from "react-router-dom";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { useMutation } from "react-query";
 import { Input, Button } from "@canonical/react-components";
@@ -137,14 +137,16 @@ function CreateSigningKeyForm({
             <p>* Mandatory field</p>
             <hr />
             <div className="u-align--right">
-              <Button
-                className="u-no-margin--bottom"
+              <Link
+                className="p-button u-no-margin--bottom"
+                to={`/admin/${id}/signing-keys`}
                 onClick={() => {
-                  navigate(`/admin/${id}/signing-keys`);
+                  setNewSigningKey({ name: "" });
+                  setErrorMessage("");
                 }}
               >
                 Cancel
-              </Button>
+              </Link>
               <Button
                 type="submit"
                 appearance="positive"

--- a/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
+++ b/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
@@ -14,6 +14,7 @@ import {
   signingKeysListState,
   signingKeysListFilterState,
   policiesListState,
+  newSigningKeyState,
 } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
@@ -63,6 +64,7 @@ function SigningKeys() {
   );
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(signingKeysListFilterState);
+  const setNewSigningKey = useSetRecoilState(newSigningKeyState);
   const brandStore = useRecoilValue(brandStoreState(id));
   const [searchParams] = useSearchParams();
   const [showNotification, setShowNotification] = useState<boolean>(false);
@@ -178,6 +180,7 @@ function SigningKeys() {
         }`}
         onClick={() => {
           navigate(`/admin/${id}/signing-keys`);
+          setNewSigningKey({ name: "" });
           setErrorMessage("");
         }}
       ></div>


### PR DESCRIPTION
## Done
- Converted "Cancel" buttons to links on the create model/policy/signing key forms
- Clear the create model/policy/signing key forms when closed

## How to QA
- Go to https://snapcraft-io-4399.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/create
  - Fill out the form
  - Click outside the side panel
  - Reopen the side panel
  - Check that the form has been reset
- Go to https://snapcraft-io-4399.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/alimot_test_model_a/policies/create
  - Fill out the form
  - Click outside the side panel
  - Reopen the side panel
  - Check that the form has been reset
- Go to https://snapcraft-io-4399.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/signing-keys/create
  - Fill out the form
  - Click outside the side panel
  - Reopen the side panel
  - Check that the form has been reset

