### PR TITLE
Disable model key revert button if no change

### DIFF
--- a/static/js/brand-store/components/Model/Model.test.tsx
+++ b/static/js/brand-store/components/Model/Model.test.tsx
@@ -81,6 +81,18 @@ describe("Model", () => {
     );
   });
 
+  it("disables the 'Revert' button if the API key hasn't been modified", async () => {
+    renderComponent();
+    expect(screen.getByRole("button", { name: "Revert" })).toBeDisabled();
+  });
+
+  it("enables the 'Revert' button when the API key has been modified", async () => {
+    renderComponent();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Generate key" }));
+    expect(screen.getByRole("button", { name: "Revert" })).not.toBeDisabled();
+  });
+
   it("resets the API when clicking the 'Revert' button", async () => {
     renderComponent();
     const user = userEvent.setup();

--- a/static/js/brand-store/components/Model/Model.tsx
+++ b/static/js/brand-store/components/Model/Model.tsx
@@ -249,6 +249,7 @@ function Model() {
                   onClick={() => {
                     setNewApiKey("");
                   }}
+                  disabled={!newApiKey}
                 >
                   Revert
                 </Button>


### PR DESCRIPTION
## Done
Disable the "Revert" button on the model page unless a new key has been generated

## How to QA
- Go to https://snapcraft-io-4402.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/alimot_test_model_a
- Check that the "Revert" button is disabled
- Generate a new key
- Check that the "Revert" button is enabled
- "Revert" the change
- Check that the "Revert" button is disabled

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6232