### PR TITLE
Fix duplicated content in build table

### DIFF
--- a/static/js/publisher/builds/components/buildsTable.js
+++ b/static/js/publisher/builds/components/buildsTable.js
@@ -18,7 +18,7 @@ const StatusCell = ({ build, queueTime }) => {
   return (
     <Fragment>
       <span className="u-hide u-show--small">{status.shortStatusMessage}</span>
-      <span className="u-hide--small" title={title}>
+      <span className="u-hide--small u-hide--medium" title={title}>
         {status.statusMessage}
       </span>
     </Fragment>


### PR DESCRIPTION
## Done
Fixed issue with builds table column duplicating content

## How to QA
- Go to https://snapcraft-io-4412.demos.haus/mindustry/builds
- Resize to mobile/tablet view and check that the "Result" column doesn't have duplicated content

## Issue / Card
Fixes #4411