### PR TITLE
Add CSRF protection to the free youtube proxy we have created

### DIFF
--- a/templates/partials/_video.html
+++ b/templates/partials/_video.html
@@ -38,7 +38,14 @@
       const thumbnailButton = document.querySelector("#youtube-thumbnail-button");
       const videoUrl = "{{ video.url }}?autoplay=1&cc_load_policy=1&modestbranding=1&rel=0";
 
-      fetch(thumbnailUrl)
+      const data = new FormData();
+      data.append("videoId", videoId);
+      data.append("csrf_token", "{{csrf_token() }}");
+
+      fetch(`/youtube`, {
+        method: "POST",
+        body:  data
+      })
         .then(function(r) {
           if (r.ok === true) {
             return r.json();

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -269,11 +269,12 @@ def store_blueprint(store_query=None):
             status_code,
         )
 
-    @store.route("/youtube/<video_id>")
-    def get_video_thumbnail_data(video_id):
+    @store.route("/youtube", methods=[ "POST"])
+    def get_video_thumbnail_data():
+        body = flask.request.form
         thumbnail_url = "https://www.googleapis.com/youtube/v3/videos"
         thumbnail_data = session.get(
-            f"{thumbnail_url}?id={video_id}&part=snippet&key={YOUTUBE_API_KEY}"
+          f"{thumbnail_url}?id={body['videoId']}&part=snippet&key={YOUTUBE_API_KEY}"
         )
 
         if thumbnail_data:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -269,12 +269,12 @@ def store_blueprint(store_query=None):
             status_code,
         )
 
-    @store.route("/youtube", methods=[ "POST"])
+    @store.route("/youtube", methods=["POST"])
     def get_video_thumbnail_data():
         body = flask.request.form
         thumbnail_url = "https://www.googleapis.com/youtube/v3/videos"
         thumbnail_data = session.get(
-          f"{thumbnail_url}?id={body['videoId']}&part=snippet&key={YOUTUBE_API_KEY}"
+            f"{thumbnail_url}?id={body['videoId']}&part=snippet&key={YOUTUBE_API_KEY}"
         )
 
         if thumbnail_data:

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -274,7 +274,10 @@ def store_blueprint(store_query=None):
         body = flask.request.form
         thumbnail_url = "https://www.googleapis.com/youtube/v3/videos"
         thumbnail_data = session.get(
-            f"{thumbnail_url}?id={body['videoId']}&part=snippet&key={YOUTUBE_API_KEY}"
+            (
+                f"{thumbnail_url}?id={body['videoId']}"
+                f"&part=snippet&key={YOUTUBE_API_KEY}"
+            )
         )
 
         if thumbnail_data:


### PR DESCRIPTION
## Done
- Updated the /youtube endpoint to be POST only
- Pass CSRF token from the ajax POST request

## How to QA
- Visit https://snapcraft-io-4416.demos.haus/code
- The youtube thumbnail should not be pixelated

## Issue / Card
Fixes https://sentry.is.canonical.com/canonical/snapcraft-io/issues/40203/?query=is%3Aunresolved