### PR TITLE
Only show metadata warning modal for visibility changes

### DIFF
--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -6,8 +6,6 @@ import {
   Row,
   Col,
   Notification,
-  Modal,
-  Button,
 } from "@canonical/react-components";
 
 import PageHeader from "../../../shared/PageHeader";
@@ -62,7 +60,7 @@ function App() {
       dirtyFieldsKeys.length === 1 &&
       dirtyFieldsKeys[0] === "update_metadata_on_release";
 
-    if (getValues("update_metadata_on_release") && !onlyUpdateMetadataField) {
+    if (getValues("update_metadata_on_release") && dirtyFields.visibility) {
       setShowMetadataWarningModal(true);
       setFormData(data);
     } else {


### PR DESCRIPTION
## Done
Stop showing modal when changes are made to a snaps distribution settings

## How to QA
- Go to https://snapcraft-io-4422.demos.haus/SNAP_NAME/settings
- Enable "Update metadata on release" if it isn't already and submit the form
- Make a change to the "Distribution" field and save the form
- You should **not** get a warning modal
- This "Update metadata on release" does get disabled which is something the store team are fixing

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6609
