### PR TITLE
Fix invite modal display

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -488,3 +488,8 @@ code {
 .u-off-screen--top {
   top: -100%;
 }
+
+// Breaks modals
+.p-accordion__panel[aria-hidden="false"] {
+  transform: none;
+}


### PR DESCRIPTION
## Done
Fix visual bug where invites modal doesn't cover the whole screen

## How to QA
- Go to https://snapcraft-io-4423.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Go to the invites table and click "Revoke" on one of the invites
- Check that the modal background covers the whole screen

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4855

## Screenshot

### Before
<img width="1440" alt="before" src="https://github.com/canonical/snapcraft.io/assets/501889/9251701b-b916-439a-8295-ad628a689193">

### After
<img width="1056" alt="Screenshot 2023-10-11 at 14 40 55" src="https://github.com/canonical/snapcraft.io/assets/501889/4195b8db-b2f4-4530-b5f9-564165214793">
