### PR TITLE
Use build-base if available, fallback to base

### DIFF
--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -111,11 +111,14 @@ def get_snap_builds(snap_name):
 
             if context["yaml_file_exists"]:
                 try:
-                    gh_snap_base = github.get_snapcraft_yaml_data(
+                    yaml_data = github.get_snapcraft_yaml_data(
                         github_owner,
                         github_repo,
                         location=context["yaml_file_exists"],
-                    ).get("base", None)
+                    )
+                    gh_snap_base = yaml_data.get(
+                        "build-base", yaml_data.get("base", None)
+                    )
                 except InvalidYAML:
                     # If we can't parse the yaml we don't
                     # want to cause an error


### PR DESCRIPTION
## Done
If available, use `build-base` from the snapcraft.yaml, fallback to `base` if not available.

## How to QA
Visit the build page for a snap that only has `base` defined – it should work as before (https://snapcraft-io-4435.demos.haus/test-snap-lukewh-7/builds)
Visit the build page for a snap that has `build-base` defined – it should also work (https://snapcraft-io-4435.demos.haus/pc-desktop/builds)

## Issue / Card
Fixes https://github.com/canonical/snapcraft.io/issues/4427
Fixes https://warthogs.atlassian.net/browse/WD-7002

