### PR TITLE
Add both highest stable version and most recent updated

### DIFF
--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -8,7 +8,12 @@
 
 <h5 class="p-muted-heading">Last updated</h5>
 <ul class="p-list">
-  <li>{{ last_updated }}</li>
+  {% if updates[0] %}
+    <li>{{ updates[0]["released-at-display"] }} - <small>{{ updates[0]["track"] }}/{{ updates[0]["risk"] }}</small></li>
+  {% endif %}
+  {% if updates[1] %}
+    <li>{{ updates[1]["released-at-display"] }} - <small>{{ updates[1]["track"] }}/{{ updates[1]["risk"] }}</small></li>
+  {% endif %}
 </ul>
 <hr>
 

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -357,3 +357,87 @@ class StoreLogicTest(unittest.TestCase):
         result = logic.get_snap_banner_url(snap_with_banner)
 
         self.assertEqual(result.get("banner_url"), None)
+
+    def test_get_latest_versions(self):
+        latest_stable = {
+            "channel": {
+                "risk": "stable",
+                "track": "latest",
+                "released-at": "2023-02-02",
+            }
+        }
+
+        latest_edge = {
+            "channel": {
+                "risk": "edge",
+                "track": "latest",
+                "released-at": "2023-03-01",
+            }
+        }
+        channel_map_single_channel = [latest_stable]
+
+        channel_map_stable_first = [latest_stable, latest_edge]
+
+        channel_map_stable_second = [latest_edge, latest_stable]
+
+        single_result = logic.get_latest_versions(
+            channel_map_single_channel, "latest", "stable"
+        )
+        self.assertEqual(
+            single_result[0]["released-at-display"], "2 February 2023"
+        )
+        self.assertEqual(single_result[1], None)
+
+        stable_first_result = logic.get_latest_versions(
+            channel_map_stable_first, "latest", "stable"
+        )
+        self.assertEqual(
+            stable_first_result[0]["released-at-display"], "2 February 2023"
+        )
+        self.assertEqual(
+            stable_first_result[1]["released-at-display"], "1 March 2023"
+        )
+
+        stable_second_result = logic.get_latest_versions(
+            channel_map_stable_second, "latest", "stable"
+        )
+        self.assertEqual(
+            stable_second_result[0]["released-at-display"], "2 February 2023"
+        )
+        self.assertEqual(
+            stable_second_result[1]["released-at-display"], "1 March 2023"
+        )
+
+        edge_highest_risk_result = logic.get_latest_versions(
+            channel_map_stable_first, "latest", "edge"
+        )
+        self.assertEqual(
+            edge_highest_risk_result[0]["released-at-display"], "1 March 2023"
+        )
+        self.assertEqual(
+            edge_highest_risk_result[1]["released-at-display"],
+            "2 February 2023",
+        )
+
+    def test_get_last_updated_versions(self):
+        latest_stable = {
+            "channel": {
+                "risk": "stable",
+                "track": "latest",
+                "released-at": "2023-02-02",
+            }
+        }
+
+        latest_edge = {
+            "channel": {
+                "risk": "edge",
+                "track": "latest",
+                "released-at": "2023-03-01",
+            }
+        }
+
+        result = logic.get_last_updated_versions([latest_stable, latest_edge])
+
+        self.assertEqual(
+            result, [latest_edge["channel"], latest_stable["channel"]]
+        )

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -100,159 +100,159 @@ class TemplateUtilsTest(unittest.TestCase):
         result = template_utils.format_date(
             "2019-09-02T09:27:58.930567+00:00", "%d %B %Y"
         )
-        self.assertEquals(result, "02 September 2019")
+        self.assertEqual(result, "02 September 2019")
 
     def test_format_member_role(self):
         result = template_utils.format_member_role("admin")
-        self.assertEquals(result, "admin")
+        self.assertEqual(result, "admin")
 
         result = template_utils.format_member_role("review")
-        self.assertEquals(result, "reviewer")
+        self.assertEqual(result, "reviewer")
 
         result = template_utils.format_member_role("view")
-        self.assertEquals(result, "viewer")
+        self.assertEqual(result, "viewer")
 
         result = template_utils.format_member_role("access")
-        self.assertEquals(result, "publisher")
+        self.assertEqual(result, "publisher")
 
     def test_format_link(self):
         result = template_utils.format_link("mailto:hello@example.com")
-        self.assertEquals(result, "hello@example.com")
+        self.assertEqual(result, "hello@example.com")
 
         result = template_utils.format_link("https://example.com")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/path")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/path/")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path/")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/path/path")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path/path")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/path/path/")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path/path/")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com/?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/path?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/path/?foo=bar"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path/?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/path/path?foo=bar"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com/path/path?foo=bar"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/path/path/?foo=bar"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com/path/path/?foo=bar"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("https://example.com/path?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link("http://example.com/path?foo=bar")
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/path/?foo=bar"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com/path/?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/path/path?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com/path/path?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "https://example.com/path/path/?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")
 
         result = template_utils.format_link(
             "http://example.com/path/path/?foo=bar&bar=foo"
         )
-        self.assertEquals(result, "example.com")
+        self.assertEqual(result, "example.com")

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -277,6 +277,59 @@ def get_snap_categories(snap_categories):
     return categories
 
 
+def get_latest_versions(channel_maps, default_track, lowest_risk):
+    """Get the latest versions of both default/stable and the latest of
+    all other channels, unless it's default/stable
+
+    :param channel_map: Channel map list
+
+    :returns: A tuple of default/stable, track/risk channel map objects
+    """
+    ordered_versions = get_last_updated_versions(channel_maps)
+
+    default_stable = None
+    other = None
+
+    if (
+        ordered_versions[0]["track"] == default_track
+        and ordered_versions[0]["risk"] == lowest_risk
+    ):
+        default_stable = ordered_versions[0]
+
+        if len(ordered_versions) > 1:
+            other = ordered_versions[1]
+    else:
+        other = ordered_versions[0]
+        for channel in ordered_versions:
+            if (
+                channel["track"] == default_track
+                and channel["risk"] == lowest_risk
+            ):
+                default_stable = channel
+
+    if default_stable:
+        default_stable["released-at-display"] = convert_date(
+            default_stable["released-at"]
+        )
+    if other:
+        other["released-at-display"] = convert_date(other["released-at"])
+    return default_stable, other
+
+
+def get_last_updated_versions(channel_maps):
+    """Get all channels in order of updates
+
+    :param channel_map: Channel map list
+
+    :returns: A list of channels ordered by last updated time
+    """
+    releases = []
+    for channel_map in channel_maps:
+        releases.append(channel_map["channel"])
+
+    return list(reversed(sorted(releases, key=lambda c: c["released-at"])))
+
+
 def get_last_updated_version(channel_maps):
     """Get the oldest channel that was created
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -56,6 +56,9 @@ def snap_details_views(store, api):
         )
 
         last_updated = latest_channel["channel"]["released-at"]
+        updates = logic.get_latest_versions(
+            details.get("channel-map"), default_track, lowest_risk_available
+        )
         binary_filesize = latest_channel["download"]["size"]
 
         # filter out banner and banner-icon images from screenshots
@@ -149,6 +152,7 @@ def snap_details_views(store, api):
                 "openhab": "openhab",
             },
             "links": details["snap"].get("links"),
+            "updates": updates,
         }
 
         return context


### PR DESCRIPTION
## Done
- Added the last updated from `default_track/highest_stability` + the most recently updated channel.
- Updated some tests that were giving a deprecation warning

## How to QA
- Visit the demo
- Click on a lot of different snaps
- Make sure the "Last Updated" metadata makes sense

## Issue / Card
Fixes https://github.com/canonical/snapcraft.io/issues/4424
Fixes https://warthogs.atlassian.net/browse/WD-7005

## Screenshots
