### PR TITLE
Update HTTP method for settings in brand store

### DIFF
--- a/static/js/brand-store/components/Settings/Settings.tsx
+++ b/static/js/brand-store/components/Settings/Settings.tsx
@@ -83,7 +83,7 @@ function Settings() {
     settingsData.set("manual-review-policy", manualReviewPolicy);
 
     fetch(`/admin/store/${id}/settings`, {
-      method: "POST",
+      method: "PUT",
       body: settingsData,
     })
       .then((response) => {

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -54,7 +54,7 @@ def get_settings(store_id):
     return jsonify(store)
 
 
-@admin.route("/admin/store/<store_id>/settings", methods=["POST"])
+@admin.route("/admin/store/<store_id>/settings", methods=["PUT"])
 @login_required
 def post_settings(store_id):
     settings = {}


### PR DESCRIPTION
## Done
Changed the HTTP method of settings updates in the brand store from `POST` to `PUT` as it is only updating existing data rather than creating new data

## How to QA
- Go to https://snapcraft-io-4441.demos.haus/admin/ahnuP3quahti9vis8aiw/settings
- Make a change and save it
- Check that the change is made successfully