### PR TITLE
Add hack for long code blocks in docs

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -493,3 +493,11 @@ code {
 .p-accordion__panel[aria-hidden="false"] {
   transform: none;
 }
+
+[data-live="description"] code {
+  display: inline-block;
+  max-width: 100%;
+  overflow: scroll;
+  position: relative;
+  top: 0.3rem;
+}


### PR DESCRIPTION
## Done
Added styles to make `code` blocks work like `pre` in docs

## How to QA
- Go to https://snapcraft-io-4443.demos.haus/ondra-snap-ssh-debug
- Check that the code blocks don't break out of the text boundaries

## Screenshots

### Before
<img width="844" alt="Screenshot 2023-11-10 at 10 07 09" src="https://github.com/canonical/snapcraft.io/assets/501889/b25545fd-1a28-4e86-ad29-8ee65da6c4d5">

### After
<img width="754" alt="Screenshot 2023-11-10 at 10 06 58" src="https://github.com/canonical/snapcraft.io/assets/501889/06e5ed27-b864-434a-b943-6a2a6855990b">