### PR TITLE
list a store name in a snap name request form

### DIFF
--- a/templates/publisher/request-reserved-name.html
+++ b/templates/publisher/request-reserved-name.html
@@ -56,7 +56,7 @@ Snapcraft - Register name dispute
       </div>
     </div>
     <div class="u-fixed-width">
-      <p>Are you sure you want to request reserved name {{snap_name}} in the Global store?</p>
+      <p>Are you sure you want to request reserved name {{snap_name}} in the {{store}} store?</p>
     </div>
     <div class="u-fixed-width">
       <hr />


### PR DESCRIPTION
## Done
- list a store name in a snap name request form

## How to QA
- Go to https://snapcraft-io-4462.demos.haus/snaps
- Click `Register a snap name` and then `request a reserved name` in the form.
<img width="1288" alt="Screenshot 2023-11-23 at 4 00 41 PM" src="https://github.com/canonical/snapcraft.io/assets/90341644/31d9b4de-44c8-4f6e-8a73-81f83c6eb6e6">

- Check if you see your `store name` instead of `Global` in the "Are you sure" message

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-7511
Fixes #https://github.com/canonical/snapcraft.io/issues/4398

