### PR TITLE
Create json endpoints for updating listing data. Handle errors.

### DIFF
--- a/tests/publisher/snaps/tests_post_binary_metadata.py
+++ b/tests/publisher/snaps/tests_post_binary_metadata.py
@@ -172,7 +172,7 @@ class PostBinaryMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         )
 
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_upload_new_icon(self):
@@ -227,7 +227,7 @@ class PostBinaryMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         )
 
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_upload_new_screenshot_with_existing_ones(self):
@@ -301,7 +301,7 @@ class PostBinaryMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         self.assertIn(b'"filename": "red.png"', called.request.body)
 
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_upload_duplicated_screenshot(self):
@@ -370,7 +370,7 @@ class PostBinaryMetadataListingPage(BaseTestCases.EndpointLoggedIn):
 
         assert called.request.body.count(b'"key": "blue.png"') == 1
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_upload_screenshot_with_duplicates_current_ones(self):
@@ -451,4 +451,4 @@ class PostBinaryMetadataListingPage(BaseTestCases.EndpointLoggedIn):
 
         assert called.request.body.count(b'"url": "URL"') == 1
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"

--- a/tests/publisher/snaps/tests_post_listing.py
+++ b/tests/publisher/snaps/tests_post_listing.py
@@ -44,7 +44,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         response = self.client.post(self.endpoint_url)
 
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_update_invalid_field(self):
@@ -55,7 +55,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
 
         assert 0 == len(responses.calls)
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_update_valid_field(self):
@@ -80,7 +80,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         )
 
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_update_description_with_carriage_return(self):
@@ -105,7 +105,7 @@ class PostMetadataListingPage(BaseTestCases.EndpointLoggedIn):
         )
 
         assert response.status_code == 302
-        assert response.location == self._get_location()
+        assert response.location == f"{self._get_location()}.json"
 
     @responses.activate
     def test_return_error_udpate_one_field(self):

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -43,7 +43,7 @@ def redirect_post_market_snap(snap_name):
 
 
 @login_required
-def get_listing_snap(snap_name):
+def get_listing_snap(snap_name, is_json=False):
     snap_details = publisher_api.get_snap_info(snap_name, flask.session)
 
     details_metrics_enabled = snap_details["public_metrics_enabled"]
@@ -126,13 +126,18 @@ def get_listing_snap(snap_name):
         "links": snap_details["links"],
     }
 
-    return flask.render_template(
-        "publisher/listing.html", **context, listing_data=json.dumps(context)
-    )
+    if is_json:
+        return flask.jsonify(context)
+    else:
+        return flask.render_template(
+            "publisher/listing.html",
+            **context,
+            listing_data=json.dumps(context)
+        )
 
 
 @login_required
-def post_listing_snap(snap_name):
+def post_listing_snap(snap_name, is_json=False):
     changes = None
     changed_fields = flask.request.form.get("changes")
 
@@ -312,10 +317,15 @@ def post_listing_snap(snap_name):
                 "tour_steps": tour_steps,
             }
 
-            return flask.render_template("publisher/listing.html", **context)
+            if is_json:
+                return flask.jsonify(context)
+            else:
+                return flask.render_template(
+                    "publisher/listing.html", **context
+                )
 
     return flask.redirect(
-        flask.url_for(".get_listing_snap", snap_name=snap_name)
+        flask.url_for(".get_listing_snap", snap_name=snap_name, is_json=True)
     )
 
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -58,9 +58,21 @@ publisher_snaps.add_url_rule(
     methods=["GET"],
 )
 publisher_snaps.add_url_rule(
+    "/<snap_name>/listing.json",
+    view_func=listing_views.get_listing_snap,
+    methods=["GET"],
+    defaults={"is_json": True},
+)
+publisher_snaps.add_url_rule(
     "/<snap_name>/listing",
     view_func=listing_views.post_listing_snap,
     methods=["POST"],
+)
+publisher_snaps.add_url_rule(
+    "/<snap_name>/listing.json",
+    view_func=listing_views.post_listing_snap,
+    methods=["POST"],
+    defaults={"is_json": True},
 )
 publisher_snaps.add_url_rule(
     "/<snap_name>/preview",


### PR DESCRIPTION
## Done
- Created `.json` endpoints for the `<snap_name>/listing` endpoint `<snap_name>/listing.json` that supports GET and POST
- Updated the frontend to use the new json endpoints
- Based on the returned data of the API - show more useful error messages.
- Clear all notifications when saving starts.

## How to QA
- Visit demo/<snap_name>/listing
- Play around with the listings page, make changes, reset it, save it, revert changes
- Specifically play with images - use https://github.com/canonical/snapcraft.io/issues/4468#issuecomment-1845009966 to see an error, but add images, remove images, save between adding and removing, refresh the page between different states
- Don't rush it, take some time.

## Issue / Card
Fixes #4468 

## Screenshots
