### PR TITLE
Fix search results heading

### DIFF
--- a/static/js/store/components/Packages/Packages.tsx
+++ b/static/js/store/components/Packages/Packages.tsx
@@ -130,7 +130,7 @@ function Packages() {
                     Showing {currentPage === "1" ? "1" : firstResultNumber} to{" "}
                     {lastResultNumber} of{" "}
                     {data?.total_items < 100 ? data?.total_items : "over 100"}{" "}
-                    items
+                    results for <strong>"{searchParams.get("q")}"</strong>.{" "}
                     <Button
                       appearance="link"
                       onClick={() => {
@@ -149,7 +149,9 @@ function Packages() {
                 ) : (
                   <p>
                     Showing {currentPage === "1" ? "1" : firstResultNumber} to{" "}
-                    {lastResultNumber} of {data?.total_items} items
+                    {lastResultNumber} of{" "}
+                    {data?.total_items < 100 ? data?.total_items : "over 100"}{" "}
+                    items
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Done
Fixed the syntax of the search results heading

## How to QA
- Go to https://snapcraft-io-4473.demos.haus/beta-store?q=zoom
- Check that the search results heading reads: "Showing 1 to 15 of 38 results for "zoom". Clear search"

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-7854