### PR TITLE
Remove last_login_method cookie. Extra logging for account endpoint

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -206,13 +206,8 @@ def set_handlers(app):
             "macaroon-permission-required",
             "macaroon-authorization-required",
         ]:
-            last_login_method = flask.request.cookies.get("last_login_method")
-            if last_login_method == "candid":
-                login_path = "login-beta"
-            else:
-                login_path = "login"
             authentication.empty_session(flask.session)
-            return flask.redirect(f"/{login_path}?next={flask.request.path}")
+            return flask.redirect(f"/login?next={flask.request.path}")
 
         status_code = 502
         codes = [

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -1,5 +1,4 @@
 import os
-import datetime
 
 import flask
 from canonicalwebteam.candid import CandidClient

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -115,13 +115,6 @@ def after_login(resp):
         ),
     )
 
-    # Set cookie to know where to redirect users for re-auth
-    response.set_cookie(
-        "last_login_method",
-        "sso",
-        expires=datetime.datetime.now() + datetime.timedelta(days=365),
-    )
-
     return response
 
 

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -1,8 +1,8 @@
 import flask
 import prometheus_client
+from talisker import logging
 
 from webapp.snapcraft import logic
-
 
 users_with_js = prometheus_client.Counter(
     "users_with_js", "A counter of sessions with JS"
@@ -10,7 +10,6 @@ users_with_js = prometheus_client.Counter(
 users_without_js = prometheus_client.Counter(
     "users_without_js", "A counter of sessions without JS"
 )
-
 
 def snapcraft_blueprint():
     snapcraft = flask.Blueprint("snapcraft", __name__)
@@ -30,16 +29,27 @@ def snapcraft_blueprint():
         """
         A JSON endpoint to request login status
         """
-        publisher = None
+        try:
+            publisher = None
 
-        if "publisher" in flask.session:
-            publisher = flask.session["publisher"]
+            if "publisher" in flask.session:
+                publisher = flask.session["publisher"]
 
-        response = {"publisher": publisher}
-        response = flask.make_response(response)
-        response.headers["Cache-Control"] = "no-store"
+            response = {"publisher": publisher}
+            response = flask.make_response(response)
+            # Unset the last_login_method cookie to avoid forcing login through candid
+            response.set_cookie("last_login_method", "", expires=0)
 
-        return response
+            response.headers["Cache-Control"] = "no-store"
+
+            return response
+        except Exception as e:
+            logging.getLogger("talisker.wsgi").error("Error with session: %s", e)
+
+            response = {"error": "Error fetching account information"}
+            response = flask.make_response(response)
+            response.headers["Cache-Control"] = "no-store"
+            return response, 502
 
     @snapcraft.route("/iot")
     def iot():

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -38,7 +38,8 @@ def snapcraft_blueprint():
 
             response = {"publisher": publisher}
             response = flask.make_response(response)
-            # Unset the last_login_method cookie to avoid forcing login through candid
+
+            # Unset the last_login_method cookie to avoid forcing
             response.set_cookie("last_login_method", "", expires=0)
 
             response.headers["Cache-Control"] = "no-store"

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -11,6 +11,7 @@ users_without_js = prometheus_client.Counter(
     "users_without_js", "A counter of sessions without JS"
 )
 
+
 def snapcraft_blueprint():
     snapcraft = flask.Blueprint("snapcraft", __name__)
 
@@ -44,7 +45,9 @@ def snapcraft_blueprint():
 
             return response
         except Exception as e:
-            logging.getLogger("talisker.wsgi").error("Error with session: %s", e)
+            logging.getLogger("talisker.wsgi").error(
+                "Error with session: %s", e
+            )
 
             response = {"error": "Error fetching account information"}
             response = flask.make_response(response)


### PR DESCRIPTION
## Done
- Removed `last_login_method` cookie on `/account.json` call as it's no longer used
- Removed all references to `last_login_method`
- Wrapped `get_account_json` in a `try: except` to attempt to log issues
- Return a 502 from `account.json` if there is an error and log it

## How to QA
- Visit the demo
- For most users everything should work as usual.
  - Logout
  - Login
  - Account menu should work
  - Going to `/snaps` and individual snap publisher pages should work

## Issue / Card
Fixes #

## Screenshots
