### PR TITLE
Fix settings page error messages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,4 +24,9 @@ module.exports = {
     semi: ["error", "always"],
     "object-curly-spacing": ["error", "always"],
   },
+  settings: {
+    react: {
+      version: "detect"
+    }
+  }
 };

--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -204,12 +204,15 @@ function App() {
             <div className="u-fixed-width">
               <Notification
                 severity="negative"
-                title={savedError === true ? "Something went wrong." : savedError.map((error) => `${error.message}`).join("\n")}
+                title="Error"
                 onDismiss={() => {
                   setHasSaved(false);
                   setSavedError(false);
                 }}
-              />
+              >
+              Changes have not been saved.<br />
+              {savedError === true ? "Something went wrong." : savedError.map((error) => `${error.message}`).join("\n")}
+              </Notification>
             </div>
           )}
 


### PR DESCRIPTION
## Done
- Updated settings page to work the same as listings page.
- Make error messages a little more friendly on both
- Drive-by: Updated eslintrc to remove linting warning

## How to QA
- Visit the settings page for a snap without a description and or summary
- Try and update visibility
- ERRORS 🥳 
- The changes made should not be reverted on the page

## Issue / Card
Fixes #

## Screenshots
