### PR TITLE
Publisher header consistency

### DIFF
--- a/static/js/base/navigation.js
+++ b/static/js/base/navigation.js
@@ -20,6 +20,9 @@ if (navAccountContainer) {
         notAuthenticatedMenu.classList.add("u-hide");
         authenticatedMenu.classList.remove("u-hide");
         displayName.innerHTML = data.publisher["fullname"];
+        if (window.sessionStorage) {
+          window.sessionStorage.setItem("displayName", data.publisher["fullname"]);
+        }
 
         if (data.publisher.has_stores) {
           authenticatedMenu

--- a/static/js/base/navigation.js
+++ b/static/js/base/navigation.js
@@ -21,7 +21,10 @@ if (navAccountContainer) {
         authenticatedMenu.classList.remove("u-hide");
         displayName.innerHTML = data.publisher["fullname"];
         if (window.sessionStorage) {
-          window.sessionStorage.setItem("displayName", data.publisher["fullname"]);
+          window.sessionStorage.setItem(
+            "displayName",
+            data.publisher["fullname"]
+          );
         }
 
         if (data.publisher.has_stores) {

--- a/static/js/publisher/listing/components/App/App.tsx
+++ b/static/js/publisher/listing/components/App/App.tsx
@@ -1,11 +1,9 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import {
   Form,
   Strip,
-  Notification,
-  Modal,
-  Button,
+  Notification
 } from "@canonical/react-components";
 
 import {
@@ -143,7 +141,12 @@ function App() {
 
   return (
     <>
-      <PageHeader snapName={listingData?.snap_name} activeTab="listing" />
+      <PageHeader
+        snapName={listingData?.snap_name}
+        snapTitle={listingData?.title}
+        publisherName={publisherName}
+        activeTab="listing"
+      />
 
       <Form
         onSubmit={handleSubmit(onSubmit)}

--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -129,7 +129,12 @@ function App() {
 
   return (
     <>
-      <PageHeader snapName={settingsData?.snap_name} activeTab="settings" />
+      <PageHeader
+        snapName={settingsData?.snap_name}
+        snapTitle={settingsData?.snap_title}
+        publisherName={settingsData?.publisher_name}
+        activeTab="settings"
+      />
 
       <Form onSubmit={handleSubmit(onSubmit)} stacked={true}>
         <SaveAndPreview

--- a/static/js/publisher/settings/types/SettingsData.d.ts
+++ b/static/js/publisher/settings/types/SettingsData.d.ts
@@ -1,4 +1,6 @@
 type SettingsData = {
+  snap_title: string;
+  publisher_name: string;
   snap_name: string;
   snap_id: string;
   store: string;

--- a/static/js/publisher/shared/PageHeader/PageHeader.tsx
+++ b/static/js/publisher/shared/PageHeader/PageHeader.tsx
@@ -3,18 +3,21 @@ import { Strip, Tabs } from "@canonical/react-components";
 
 type Props = {
   snapName: string;
+  snapTitle?: string;
   activeTab: string;
   publisherName?: string;
 };
 
-function PageHeader({ snapName, activeTab, publisherName }: Props) {
+function PageHeader({ snapName, snapTitle, activeTab, publisherName }: Props) {
+  // Get the users display name from sessionStorage
+  const accountName = window.sessionStorage.getItem("displayName") ?? undefined;
   return (
     <Strip shallow={true} className="u-no-padding--bottom">
       <div className="u-fixed-width">
         <a href="/snaps">&lsaquo;&nbsp;My snaps</a>
         <div className="u-flex" style={{ alignItems: "baseline" }}>
-          <h1 className="p-heading--3">{snapName}</h1>
-          {publisherName && (
+          <h1 className="p-heading--3">{snapTitle ? snapTitle : snapName}</h1>
+          {publisherName && accountName && publisherName !== accountName && (
             <p
               className="u-text-muted u-no-margin--bottom"
               style={{ marginLeft: "0.5rem" }}

--- a/templates/publisher/_header.html
+++ b/templates/publisher/_header.html
@@ -24,9 +24,14 @@
     <a href="/snaps">&lsaquo; My snaps</a>
     {% endif %}
     {% if not suppress_title %}
-    <h1 class="p-heading--3">
-      {% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}
-      {% if publisher_name and publisher_name != user_name %} <small>by {{publisher_name}}</small>{% endif %}</h1>
+      <div class="u-flex" style="align-items: baseline;">
+        <h1 class="p-heading--3">
+          {% if snap_title %}{{ snap_title }}{% else %}{{ snap_name }}{% endif %}
+        </h1>
+        {% if publisher_name and publisher_name != user_name %}
+          <p class="u-text-muted u-no-margin--bottom" style="margin-left: 0.5rem;">by {{publisher_name}}</p>
+        {% endif %}
+      </div>
     {% endif %}
     {% if not suppress_nav %}
     <nav class="p-tabs">

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -11,6 +11,8 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
   window.CSRF_TOKEN = "{{ csrf_token() }}";
   window.countries = {{ countries|tojson }};
   window.settingsData = {
+    publisher_name: "{{ publisher_name }}",
+    snap_title: "{{ snap_title }}",
     snap_name: "{{ snap_name }}",
     snap_id: "{{ snap_id }}",
     store: "{{ store }}",

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -76,6 +76,7 @@ def get_snap_builds(snap_name):
     )
 
     context = {
+        "publisher_name": details["publisher"]["display-name"],
         "snap_id": details["snap_id"],
         "snap_name": details["snap_name"],
         "snap_title": details["title"],


### PR DESCRIPTION
## Done
Ensured the headers for all publisher pages are consistent
- Added some extra data to certain pages and views
- Updated `navigation.js` to set the users displayname in session storage
- Updated PageHeader component to conditionally show "By [publishername]" based on the session storage display name

## How to QA
- Visit a snap you own, go through the publisher pages
  - Make sure the header shows the snap title, not the snap name
- Visit a snap you don't own, go through each publisher page
  - Make sure the header shows the snap title and "by [publishername]"

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-7927

## Screenshots
