### PR TITLE
Add show more to beta store categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@canonical/global-nav": "3.6.2",
     "@canonical/latest-news": "1.5.0",
     "@canonical/react-components": "0.47.1",
-    "@canonical/store-components": "0.44.0",
+    "@canonical/store-components": "0.45.0",
     "@dnd-kit/core": "6.0.8",
     "@dnd-kit/sortable": "7.0.2",
     "@dnd-kit/utilities": "3.2.1",

--- a/static/js/store/components/Packages/Packages.tsx
+++ b/static/js/store/components/Packages/Packages.tsx
@@ -97,6 +97,8 @@ function Packages() {
               </div>
               <div className="p-filter-panel__inner">
                 <Filters
+                  showMore
+                  showMoreCount={9}
                   categories={data?.categories || []}
                   selectedCategories={
                     searchParams.get("categories")?.split(",") || ["featured"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,10 +1089,10 @@
     react-table "7.8.0"
     react-useportal "1.0.18"
 
-"@canonical/store-components@0.44.0":
-  version "0.44.0"
-  resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.44.0.tgz#0a8e1278e4928d42d8c2777bbf19067da86880d7"
-  integrity sha512-0AcoIJfDRn5Vl2oM2X0BHpSO7+1md7wuot2LiEeQDmtjiXSXAMuOkM3degN0X++0+XIUT+ZUd1NoBfLvYFMVTg==
+"@canonical/store-components@0.45.0":
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/@canonical/store-components/-/store-components-0.45.0.tgz#70da0c14fc373cd41146ef5b3e011b1b1e08d9a4"
+  integrity sha512-x9nyYG0qjcWUtPDISaS0Bxvjr1fbkxXq5fUOXjoUG36TMXOhennoA84k8WI2/MwF6gBD6gwBCVIPWIXJHvTxqw==
   dependencies:
     "@canonical/react-components" "0.47.1"
     "@types/jest" "27.5.2"


### PR DESCRIPTION
## Done
Added "See more" categories

## How to QA
- Go to https://snapcraft-io-4486.demos.haus/beta-store
- Check that only 10 categories (inc. featured) are visible
- Check that there is a "See more" button that shows the rest of the categories