### PR TITLE
Fix search pagination

### DIFF
--- a/static/js/store/components/Banner/Banner.tsx
+++ b/static/js/store/components/Banner/Banner.tsx
@@ -21,6 +21,7 @@ function Banner({ searchRef, searchSummaryRef }: Props) {
               e.preventDefault();
 
               if (searchRef.current && searchRef.current.value) {
+                searchParams.delete("page");
                 searchParams.set("q", searchRef.current.value);
                 setSearchParams(searchParams);
               }


### PR DESCRIPTION
## Done
Fixed the pagination for beta store searches

## How to QA
- Go to https://snapcraft-io-4499.demos.haus/beta-store?categories=games&page=4
- Search for "code"
- Check that the `page` query parameter has been removed
- Check that the results count above the search results is correct