### PR TITLE
chore: make lint-python use requirements versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,13 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install node dependencies
-        run: yarn install --immutable
-
       - name: Install python dependencies
         run: |
           python3 -m pip install --upgrade pip
-          sudo pip3 install flake8 black
+          sudo pip3 install -r requirements.txt
 
       - name: Lint python
         run: yarn lint-python

--- a/yarn.lock
+++ b/yarn.lock
@@ -4536,7 +4536,7 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-identity-obj-proxy@^3.0.0:
+identity-obj-proxy@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
   integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==


### PR DESCRIPTION
## Done
- Ensure lint-python uses the versions of black and flake8 defined in requirements.txt

## How to QA
- The checks should pass for this PR

