### PR TITLE
Fix preview of links for listing page

### DIFF
--- a/static/js/publisher/listing/components/PreviewForm/PreviewForm.tsx
+++ b/static/js/publisher/listing/components/PreviewForm/PreviewForm.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Form } from "@canonical/react-components";
 
+type Link = Array<{ url: string }>;
+
 type Props = {
   listingData: {
     snap_name: string;
@@ -15,6 +17,18 @@ type Props = {
     license: boolean;
     video_urls: string;
     snap_categories: Array<string>;
+    websites: Link;
+    "source-code": Link;
+    donations: Link;
+    issues: Link;
+    contacts: Link;
+    links: {
+      website: Array<string>;
+      contact: Array<string>;
+      donations: Array<string>;
+      source: Array<string>;
+      issues: Array<string>;
+    };
   };
 };
 
@@ -36,6 +50,14 @@ function PreviewForm({ listingData }: Props) {
   if (secondaryCategory) {
     listingData.categories.push(secondaryCategory);
   }
+
+  listingData.links = {
+    website: listingData.websites.map((url) => url.url),
+    contact: listingData.contacts.map((url) => url.url),
+    donations: listingData.donations.map((url) => url.url),
+    source: listingData["source-code"].map((url) => url.url),
+    issues: listingData.issues.map((url) => url.url),
+  };
 
   return (
     <Form


### PR DESCRIPTION
## Done
Fixed contact links not being reflected in the list page preview

## How to QA
- Go to https://snapcraft-io-4522.demos.haus/<SNAP_NAME>/listing
- Add or remove links from the "Contact information" section
- Click the preview button
- Check that those changes are reflected in the sidebar of the preview page

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8417
Fixes #4509