### PR TITLE
fix: remove extra list on search results

### DIFF
--- a/static/js/brand-store/components/Snaps/Snaps.tsx
+++ b/static/js/brand-store/components/Snaps/Snaps.tsx
@@ -468,13 +468,6 @@ function SnapsSlice() {
                 storeId={id || ""}
                 nonEssentialSnapIds={nonEssentialSnapIds}
               />
-              {selectedSnaps.length ? (
-                <ul>
-                  {selectedSnaps.map((snap: Snap) => (
-                    <li key={snap.id}>{snap.name}</li>
-                  ))}
-                </ul>
-              ) : null}
             </div>
           </div>
           <div className="p-panel__footer u-align--right">


### PR DESCRIPTION
## Done
- Removed extra ul below the card when searching for a snap

## How to QA
- Visit a brand store admin
- Click "Include snap"
- Search and click on a snap
- Only see the result once

## Screenshots
Before:
![image](https://github.com/canonical/snapcraft.io/assets/479384/c10a2149-9f3b-45f6-9a9c-809b3b088aba)

After:
![image](https://github.com/canonical/snapcraft.io/assets/479384/85960724-c268-4e5c-a3d5-02ba4b6a87ab)

