### PR TITLE
fix: dont show models and signing keys tabs

### DIFF
--- a/static/js/brand-store/components/SectionNav/SectionNav.tsx
+++ b/static/js/brand-store/components/SectionNav/SectionNav.tsx
@@ -27,7 +27,7 @@ function SectionNav({ sectionName }: { sectionName: string }) {
               </Link>
             </li>
             {/* If success then models and signing keys are available */}
-            {data.success && (
+            {data.success && !data.data?.Code && (
               <>
                 <li className="p-tabs__item">
                   <Link


### PR DESCRIPTION
## Done

## How to QA
- Visit brand stores
- ensure the tabs don't show

## Issue / Card
Fixes #

## Screenshots
