### PR TITLE
fix: enforce macaroon-discharge based on unique session field

### DIFF
--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -32,10 +32,10 @@ def login_required(func):
 def exchange_required(func):
     @functools.wraps(func)
     def is_exchanged(*args, **kwargs):
-        if "developer_token" not in flask.session:
-            flask.session["developer_token"] = (
-                publisher_api.exchange_dashboard_macaroons(flask.session)
-            )
+        if "exchanged_developer_token" not in flask.session:
+            result = publisher_api.exchange_dashboard_macaroons(flask.session)
+            flask.session["developer_token"] = result
+            flask.session["exchanged_developer_token"] = True
         return func(*args, **kwargs)
 
     return is_exchanged


### PR DESCRIPTION
## Done
- Moved from checking `developer_token` in the flask session to a more explicit `exchanged_developer_token`

## How to QA
- Visit the demo
- Go to the admin and view a brand store
- There shouldn't be a "Models" or "Signing Keys" tab for any store
- Visit demo/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models and you should see the tabs (and everything should work as expected)

## Issue / Card
Fixes #

## Screenshots
