### PR TITLE
Fix imports for screenshot slider

### DIFF
--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -1,5 +1,6 @@
 import lightbox from "./../../publisher/market/lightbox";
-import { Swiper, Navigation } from "swiper";
+import Swiper from "swiper";
+import { Navigation } from "swiper/modules";
 import { SCREENSHOTS_CONFIG } from "../../config/swiper.config";
 import iframeSize from "../../libs/iframeSize";
 


### PR DESCRIPTION
## Done
Fixed bug with preview screenshot slider caused by broken imports

## How to QA
- Go to https://snapcraft-io-4533.demos.haus/<SNAP_NAME>/listing
- Click on the "Preview" button
- Check that the screenshot/video carousel works as expected

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8964