### PR TITLE
Remove brand store header

### DIFF
--- a/static/js/public/snap-details/screenshots.js
+++ b/static/js/public/snap-details/screenshots.js
@@ -1,5 +1,6 @@
 import lightbox from "./../../publisher/market/lightbox";
-import { Swiper, Navigation } from "swiper";
+import Swiper from "swiper";
+import { Navigation } from "swiper/modules";
 import { SCREENSHOTS_CONFIG } from "../../config/swiper.config";
 import iframeSize from "../../libs/iframeSize";
 

--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -81,8 +81,10 @@
     <!-- JS that is needed right away -->
     <script src="{{ static_url('js/dist/cookie-policy.js') }}"></script>
 
-    {% from "_header_macros.html" import header %}
-    {{ header() }}
+      {% if show_header != False %}
+        {% from "_header_macros.html" import header %}
+        {{ header() }}
+      {% endif %}
     {% endblock %}
 
     {% block content %}{% endblock %}

--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -1,5 +1,5 @@
 {% set page_slug = "admin" %}
-{% set full_width_nav = True %}
+{% set show_header = False %}
 {% extends "_base-layout.html" %}
 {% block content %}
 <div id="root">


### PR DESCRIPTION
## Done
Removed the header from the brand store layout

## How to QA
- Go to https://snapcraft-io-4534.demos.haus/admin
- Check that there is no header

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8956