### PR TITLE
direct first snap flow links to relevant docs pages instead of first snap flow contents

### DIFF
--- a/templates/home/_fsf_c.html
+++ b/templates/home/_fsf_c.html
@@ -60,9 +60,9 @@
 
     </div>
   </div>
-  
+
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/c/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/c-c-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_electron.html
+++ b/templates/home/_fsf_electron.html
@@ -47,12 +47,12 @@
 }</pre>
 
         {% include "home/_fsf_yaml_show_more.html" %}
-        
+
     </div>
   </div>
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/docs/build-snaps/electron">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/electron-apps">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_flutter.html
+++ b/templates/home/_fsf_flutter.html
@@ -48,6 +48,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/flutter/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/flutter-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_go.html
+++ b/templates/home/_fsf_go.html
@@ -53,6 +53,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/golang/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/go-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_java.html
+++ b/templates/home/_fsf_java.html
@@ -62,6 +62,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/java/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/java-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_moos.html
+++ b/templates/home/_fsf_moos.html
@@ -46,6 +46,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/moos/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/moos-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_node.html
+++ b/templates/home/_fsf_node.html
@@ -45,6 +45,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/node/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/node-apps">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_pre-built.html
+++ b/templates/home/_fsf_pre-built.html
@@ -51,6 +51,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/pre-built/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/pre-built-apps">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_python.html
+++ b/templates/home/_fsf_python.html
@@ -54,6 +54,6 @@ OfflineIMAP is software that downloads [&hellip;]
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/python/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/python-apps">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_ros.html
+++ b/templates/home/_fsf_ros.html
@@ -47,6 +47,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/ros/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/ros-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_ros2.html
+++ b/templates/home/_fsf_ros2.html
@@ -49,6 +49,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/ros2/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/ros2-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -54,6 +54,6 @@
 
   <div class="u-align--right">
     <hr class="p-rule">
-    <a class="p-button--positive" href="/first-snap/ruby/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/ruby-applications">Continue &rsaquo;</a>
   </div>
 </div>

--- a/templates/home/_fsf_rust.html
+++ b/templates/home/_fsf_rust.html
@@ -45,6 +45,6 @@
 
   <div class="u-align--right">
     <hr>
-    <a class="p-button--positive" href="/first-snap/rust/">Continue &rsaquo;</a>
+    <a class="p-button--positive" href="/docs/rust-applications">Continue &rsaquo;</a>
   </div>
 </div>


### PR DESCRIPTION
## Done
- direct first snap flow links to relevant docs pages instead first snap flow contents

## How to QA
- go to first snap flow section on [https://snapcraft-io-4535.demos.haus](https://snapcraft-io-4535.demos.haus/)
- For each language, the `continue` button directs to relevant docs pages as follows:

    Python → https://snapcraft.io/docs/python-apps
    Pre-built apps → https://snapcraft.io/docs/pre-built-apps
    C/C++ → https://snapcraft.io/docs/c-c-applications
    Go → https://snapcraft.io/docs/go-applications
    Java → https://snapcraft.io/docs/java-applications
    Node.js → https://snapcraft.io/docs/node-apps
    Electron → https://snapcraft.io/docs/electron-apps
    Flutter → https://snapcraft.io/docs/flutter-applications
    Ruby → https://snapcraft.io/docs/ruby-applications
    Rust → https://snapcraft.io/docs/rust-applications
    MOOS → https://snapcraft.io/docs/moos-applications
    ROS → https://snapcraft.io/docs/ros-applications
    ROS2 → https://snapcraft.io/docs/ros2-applications


## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-8213

