### PR TITLE
Add warning icon to release UI

### DIFF
--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -282,7 +282,7 @@ export const ReleasesTableCellView = (props) => {
       className={className}
       onMouseEnter={() => {
         const hoveredRow = document.querySelector(
-          ".p-releases-table__row.is-hovered"
+          ".p-releases-table__row.is-hovered",
         );
 
         if (hoveredRow) {

--- a/static/js/publisher/release/components/releasesTable/cellViews.js
+++ b/static/js/publisher/release/components/releasesTable/cellViews.js
@@ -184,6 +184,8 @@ export const RevisionInfo = ({
             isProgressive={isProgressive}
             previousRevision={previousRevision?.revision}
           />
+          &nbsp;
+          {!releasable && <i className="p-icon--warning"></i>}
         </span>
         <span className="p-release-data__meta">
           {isProgressive
@@ -280,7 +282,7 @@ export const ReleasesTableCellView = (props) => {
       className={className}
       onMouseEnter={() => {
         const hoveredRow = document.querySelector(
-          ".p-releases-table__row.is-hovered",
+          ".p-releases-table__row.is-hovered"
         );
 
         if (hoveredRow) {


### PR DESCRIPTION
## Done
Added a warning icon to non-releasable revision cells

## How to QA
- Go to https://snapcraft-io-4536.demos.haus/ght/releases
- Check that non-releasable cells have a yellow warning icon

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-8970