### PR TITLE
align header to documentation-layout

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -90,7 +90,6 @@
                   <a class="p-navigation__link " href="https://forum.snapcraft.io/">Forum</a>
                 </li>
               </ul>
-              {% if not docs %}
               <ul class="p-navigation__items js-nav-account global-nav" role="menu"> {# Authenticated #} <li class="p-navigation__item--dropdown-toggle js-nav-account--authenticated u-hide" role="menuitem" id="link-1">
                   <a class="p-subnav__toggle p-navigation__link js-account--name" aria-controls="account-menu" aria-expanded="false"> My account </a>
                   <ul class="p-navigation__dropdown--right" id="account-menu" aria-hidden="true">
@@ -112,7 +111,6 @@
                   </a>
                 </li>
               </ul>
-              {% endif %}
             </nav>
         {% if docs %}
           </div>
@@ -121,28 +119,4 @@
         {% if not docs %}
         </div>
         {% endif %}
-        {% if docs %}
-        <ul class="p-navigation__items js-nav-account global-nav" role="menu"> {# Authenticated #} <li class="p-navigation__item--dropdown-toggle js-nav-account--authenticated u-hide" role="menuitem" id="link-1">
-            <a class="p-subnav__toggle p-navigation__link js-account--name" aria-controls="account-menu" aria-expanded="false"> My account </a>
-            <ul class="p-navigation__dropdown--right" id="account-menu" aria-hidden="true">
-              <li>
-                <a href="/account/snaps" class="p-navigation__dropdown-item">My published snaps</a>
-              </li>
-              <li class="js-nav-account--stores u-hide">
-                <a href="/admin" class="p-navigation__dropdown-item">My stores</a>
-              </li>
-              <li>
-                <a href="/account/details" class="p-navigation__dropdown-item">Account details</a>
-              </li>
-              <li>
-                <a href="/logout" class="p-navigation__dropdown-item">Sign out</a>
-              </li>
-            </ul>
-          </li> {# Not authenticated #} <li class="p-navigation__item js-nav-account--notauthenticated u-hide" role="menuitem">
-            <a class="p-navigation__link" href="{{ url_for('publisher_snaps.get_account_snaps') }}"> Sign in <i class="p-icon--user is-light"></i>
-            </a>
-          </li>
-        </ul>
-      </div>
-    {% endif %}
     </header>


### PR DESCRIPTION
## Done
- move `global-nav` to `l-docs__main` to align with the documentation layout

## How to QA
- go to https://snapcraft-io-4538.demos.haus/docs
- log in and check if `global-nav` is aligned with the rest of the header

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-8968

