### PR TITLE
Add margin between <hr> and continue button in the first-snap-flow Ruby section

### DIFF
--- a/templates/home/_fsf_ruby.html
+++ b/templates/home/_fsf_ruby.html
@@ -53,7 +53,7 @@
   </div>
 
   <div class="u-align--right">
-    <hr class="p-rule">
+    <hr>
     <a class="p-button--positive" href="/docs/ruby-applications">Continue &rsaquo;</a>
   </div>
 </div>


### PR DESCRIPTION
## Done
- remove `<hr>` classname on first-snap-flow Ruby section so that there is margin between `<hr>` and `continue` button

## How to QA
- go to https://snapcraft-io-4541.demos.haus/ and select Ruby for first-snap-flow
- check if there is margin between `<hr>` and `continue` button

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-9177
