### PR TITLE
feat: show percentages in the metrics graph for publishers

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
+++ b/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
@@ -13,6 +13,7 @@ export function tooltips() {
   const tooltipTemplate = (dateData, currentHoverKey) => {
     const tooltipRows = (dateData, currentHoverKey) => {
       let dataArr = [];
+      let total = 0;
       let other = {
         key: "other",
         value: 0,
@@ -30,6 +31,7 @@ export function tooltips() {
       }
 
       keys.forEach((key) => {
+        total += dateData[key];
         dataArr.push({
           key: key,
           value: dateData[key],
@@ -67,15 +69,17 @@ export function tooltips() {
               `<span class="snapcraft-graph-tooltip__series${
                 item.key === currentHoverKey ? " is-hovered" : ""
               }" title="${item.key}">`,
+              `<span class="snapcraft-graph-tooltip__series-start">`,
               `<span class="snapcraft-graph-tooltip__series-color"${
                 !item.count
                   ? `style="background:${this.colorScale(item.key)};"`
                   : ""
               }></span>`,
               `<span class="snapcraft-graph-tooltip__series-name">${item.key}</span>`,
+              `</span>`,
               `<span class="snapcraft-graph-tooltip__series-value">${commaValue(
                 item.value,
-              )}</span>`,
+              )} (${((item.value / total) * 100).toFixed(2)}%)</span>`,
               `</span>`,
             ].join("");
           }

--- a/static/sass/_snapcraft_graph-tooltip.scss
+++ b/static/sass/_snapcraft_graph-tooltip.scss
@@ -28,11 +28,11 @@
       }
 
       &-start {
-        overflow: hidden;
+        align-items: center;
         display: flex;
         flex-direction: row;
         flex-shrink: 1;
-        align-items: center;
+        overflow: hidden;
       }
 
       &-name {
@@ -42,9 +42,9 @@
       }
 
       &-color {
-        flex-grow: 0;
         border-radius: 0.75rem;
         display: inline-block;
+        flex-grow: 0;
         height: 0.75rem;
         width: 0.75rem;
         margin: {

--- a/static/sass/_snapcraft_graph-tooltip.scss
+++ b/static/sass/_snapcraft_graph-tooltip.scss
@@ -15,9 +15,9 @@
       display: flex;
       font-family: Ubuntu, sans-serif;
       font-size: 12px;
-      justify-content: center;
+      justify-content: space-between;
       margin-top: 0.25rem;
-      width: 215px;
+      width: 265px;
 
       &:last-child {
         margin-bottom: 0.25rem;
@@ -27,15 +27,22 @@
         font-weight: bold;
       }
 
+      &-start {
+        overflow: hidden;
+        display: flex;
+        flex-direction: row;
+        flex-shrink: 1;
+        align-items: center;
+      }
+
       &-name {
-        display: inline-block;
         overflow: hidden;
         text-align: left;
         text-overflow: ellipsis;
-        width: calc(70% - 0.5rem);
       }
 
       &-color {
+        flex-grow: 0;
         border-radius: 0.75rem;
         display: inline-block;
         height: 0.75rem;
@@ -50,7 +57,6 @@
         display: inline-block;
         margin-top: 0;
         text-align: right;
-        width: calc(30% - 0.5rem);
       }
     }
   }


### PR DESCRIPTION
## Done
- Added percentages to graph tooltip
- Added an extra 50pixels to the width of the tooltip
- Made the CSS handle variable strings better

## How to QA
- Visit demo/{snap-name}/metrics - preferably a snap with many users
- Hover over the active devices graph, change the dropdowns etc. and make sure percentages show as expected

## Issue / Card
Fixes #4543 

## Screenshots
![image](https://github.com/canonical/snapcraft.io/assets/479384/c850c337-f45e-41bf-b9f6-73e6bbd0ec4d)
