### PR TITLE
fix: build page 503ing when api key access forbidden

### DIFF
--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -4,7 +4,7 @@ from os import getenv
 
 from webapp import api
 from webapp.helpers import get_yaml_loader
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Unauthorized, Forbidden
 from requests.exceptions import HTTPError
 
 GITHUB_WEBHOOK_SECRET = getenv("GITHUB_WEBHOOK_SECRET")
@@ -58,6 +58,8 @@ class GitHub:
         if raise_exceptions:
             if response.status_code == 401:
                 raise Unauthorized(response=response)
+            if response.status_code == 403:
+                raise Forbidden(response=response)
 
             response.raise_for_status()
 
@@ -81,6 +83,8 @@ class GitHub:
 
         if response.status_code == 401:
             raise Unauthorized(response=response)
+        if response.status_code == 403:
+            raise Forbidden
 
         response.raise_for_status()
         return response.json()["data"]
@@ -243,6 +247,8 @@ class GitHub:
             )
         except Unauthorized:
             return False
+        except Forbidden:
+            return false
         except HTTPError as e:
             if e.response.status_code == 404:
                 return False
@@ -269,6 +275,8 @@ class GitHub:
             return True
         elif response.status_code == 401:
             raise Unauthorized
+        elif response.status_code == 403:
+            raise Forbidden
 
         response.raise_for_status()
 
@@ -291,6 +299,8 @@ class GitHub:
                 return loc
             elif response.status_code == 401:
                 raise Unauthorized
+            elif response.status_code == 403:
+                raise Forbidden
 
             response.raise_for_status()
 

--- a/webapp/api/github.py
+++ b/webapp/api/github.py
@@ -248,7 +248,7 @@ class GitHub:
         except Unauthorized:
             return False
         except Forbidden:
-            return false
+            return False
         except HTTPError as e:
             if e.response.status_code == 404:
                 return False

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -14,7 +14,7 @@ from webapp.api.github import GitHub, InvalidYAML
 from webapp.decorators import login_required
 from webapp.extensions import csrf
 from webapp.publisher.snaps.builds import map_build_and_upload_states
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Unauthorized, Forbidden
 
 GITHUB_SNAPCRAFT_USER_TOKEN = os.getenv("GITHUB_SNAPCRAFT_USER_TOKEN")
 GITHUB_WEBHOOK_HOST_URL = os.getenv("GITHUB_WEBHOOK_HOST_URL")
@@ -152,7 +152,7 @@ def get_snap_builds(snap_name):
 
         try:
             context["github_user"] = github.get_user()
-        except Unauthorized:
+        except (Unauthorized, Forbidden):
             context["github_user"] = None
 
         if context["github_user"]:


### PR DESCRIPTION
## Done
Don't crash on 403 when a build does not exist

## How to QA
- Visit https://snapcraft-io-4553.demos.haus/lukewh-test/builds - you should see the page to connect your github account
- Visit https://snapcraft-io-4553.demos.haus/test-snap-lukewh-7/builds - you should see a list of failed builds

## Issue / Card
Fixes #4360
Fixes https://warthogs.atlassian.net/browse/WD-9419
Fixes https://forum.snapcraft.io/t/internal-server-error-on-builds-page/39234

## Screenshots
