### PR TITLE
Fix invisible links in global nav

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -451,7 +451,7 @@ dl {
 // Vanilla override - documentaion layout
 .l-docs__subgrid {
   @media (width >= 1036px) {
-      grid-template-columns: 15rem minmax(0, 1fr) 15rem;
+    grid-template-columns: 15rem minmax(0, 1fr) 15rem;
   }
 
   @media (width >= calc(1036px + 15rem)) {
@@ -508,4 +508,9 @@ dl {
 
 .p-search-box .p-search-box__input:placeholder-shown ~ .p-search-box__reset {
   display: none !important;
+}
+
+// XXX - Can be removed once https://github.com/canonical/vanilla-framework/issues/5031 is resolved
+.global-nav__strip .p-link--inverted {
+  color: $color-light;
 }


### PR DESCRIPTION
## Done
Fixed white headings being displayed as black in the global nav

## How to QA
- Go to https://snapcraft-io-4556.demos.haus/
- Click on global nav ("All Canonical")
- Check that all text is visible
