### PR TITLE
Clear new member form on close

### DIFF
--- a/static/js/brand-store/components/Members/Members.tsx
+++ b/static/js/brand-store/components/Members/Members.tsx
@@ -290,6 +290,9 @@ function Members() {
         className={`l-aside__overlay ${sidePanelOpen ? "" : "u-hide"}`}
         onClick={() => {
           setSidePanelOpen(false);
+          setShowInviteForm(false);
+          setNewMemberEmail("");
+          setNewMemberRoles([]);
         }}
       ></div>
       <aside
@@ -367,6 +370,7 @@ function Members() {
                   setSidePanelOpen(false);
                   setNewMemberEmail("");
                   setNewMemberRoles([]);
+                  setShowInviteForm(false);
                 }}
               >
                 Cancel


### PR DESCRIPTION
## Done
Fixed the new members form not being cleared when closed

## How to QA
- Go to https://snapcraft-io-4558.demos.haus/admin
- Go to the "Members" section of a store
- Click "Add new member"
- Enter an email address and select a role
- Close the form by either using the "Cancel" button or clicking outside of the panel
- Re-open the form
- The form should have been cleared

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-9800