### PR TITLE
Add overview link to brand store navigation

### DIFF
--- a/static/js/brand-store/components/Navigation/Navigation.tsx
+++ b/static/js/brand-store/components/Navigation/Navigation.tsx
@@ -96,7 +96,24 @@ function Navigation({ sectionName }: { sectionName: string | null }) {
               {!brandIsLoading && brandIsSuccess && (
                 <>
                   <div className="p-side-navigation--icons is-dark">
-                    <ul className="p-side-navigation__list sidenav-top-ul u-no-margin--bottom">
+                    <ul className="p-side-navigation__list">
+                      <li className="p-side-navigation__item--title p-muted-heading">
+                        <span className="p-side-navigation__link">
+                          <span className="p-side-navigation__label">
+                            My snaps
+                          </span>
+                        </span>
+                      </li>
+                      <li className="p-side-navigation__item">
+                        <a className="p-side-navigation__link" href="/snaps">
+                          <i className="p-icon--pods is-light p-side-navigation__icon"></i>
+                          <span className="p-side-navigation__label">
+                            Overview
+                          </span>
+                        </a>
+                      </li>
+                    </ul>
+                    <ul className="p-side-navigation__list u-no-margin--bottom">
                       <li className="p-side-navigation__item--title p-muted-heading">
                         <span className="p-side-navigation__link">
                           <i className="p-icon--pods is-light p-side-navigation__icon"></i>

--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -47,10 +47,6 @@
       width: 100%;
     }
 
-    .sidenav-top-ul::after {
-      display: none;
-    }
-
     .sidenav-bottom-ul {
       bottom: 0;
       position: absolute;


### PR DESCRIPTION
## Done
Added a My snaps overview link to the brand store navigation

## How to QA
- Go to https://snapcraft-io-4566.demos.haus/admin
- Check that the side navigation has a "My snaps" section with a link to /snaps
