### PR TITLE
Add publisher data endpoint

### DIFF
--- a/tests/publisher/tests_account_details.py
+++ b/tests/publisher/tests_account_details.py
@@ -28,7 +28,7 @@ class AccountDetailsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         )
 
     @responses.activate
-    @patch("webapp.publisher.views.marketo")
+    @patch("webapp.helpers.marketo")
     def test_account(self, marketo):
         responses.add(responses.GET, self.api_url, json={}, status=200)
 
@@ -51,7 +51,7 @@ class AccountDetailsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("subscriptions", {"newsletter": True})
 
     @responses.activate
-    @patch("webapp.publisher.views.marketo")
+    @patch("webapp.helpers.marketo")
     def test_account_marketo_no_sub(self, marketo):
         responses.add(responses.GET, self.api_url, json={}, status=200)
 
@@ -72,7 +72,7 @@ class AccountDetailsPage(BaseTestCases.EndpointLoggedInErrorHandling):
         self.assert_context("subscriptions", {"newsletter": False})
 
     @responses.activate
-    @patch("webapp.publisher.views.marketo")
+    @patch("webapp.helpers.marketo")
     def test_account_marketo_exception(self, marketo):
         responses.add(responses.GET, self.api_url, json={}, status=200)
 


### PR DESCRIPTION
## Done
Added an endpoint for publisher data

## How to QA
- Go to https://snapcraft-io-4567.demos.haus/account/publisher
- Check that you can see publisher data which includes `has_stores` and `subscriptions`
- Go to https://snapcraft-io-4567.demos.haus/account/details
- Check that it works as expected ([compare to live](https://snapcraft.io/account/details))

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-9991