### PR TITLE
add endpoint to update featured snaps

### DIFF
--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -7,7 +7,10 @@ from canonicalwebteam.store_api.exceptions import (
     StoreApiResponseErrorList,
     StoreApiResourceNotFound,
 )
-from canonicalwebteam.store_api.stores.snapstore import SnapStoreAdmin
+from canonicalwebteam.store_api.stores.snapstore import (
+    SnapStoreAdmin,
+    SnapPublisher,
+)
 from flask.json import jsonify
 
 # Local
@@ -15,6 +18,7 @@ from webapp.decorators import login_required, exchange_required
 from webapp.helpers import api_publisher_session
 
 admin_api = SnapStoreAdmin(api_publisher_session)
+publisher_api = SnapPublisher(api_publisher_session)
 
 admin = flask.Blueprint(
     "admin", __name__, template_folder="/templates", static_folder="/static"
@@ -631,3 +635,68 @@ def delete_signing_key(store_id: str, signing_key_sha3_384: str):
             res["message"] = error_list.errors[0]["message"]
 
         return make_response(res, 500)
+
+
+# ---------------------- END MODELS SERVICES ----------------------
+
+
+# -------------------- FEATURED SNAPS AUTOMATION ------------------
+@admin.route("/admin/featured", methods=["POST"])
+@login_required
+@exchange_required
+def post_featured_snaps():
+    """
+    In this view, we do three things:
+    1. Fetch all currently featured snaps
+    2. Delete the currently featured snaps
+    3. Update featured snaps to be newly featured
+
+    Args:
+        None
+
+    Returns:
+        dict: A dictionary containing the response message and success status.
+    """
+
+    # new_featured_snaps is the list of featured snaps to be updated
+    new_featured_snaps = flask.request.form.get("snaps").split(",")
+    # currently_featured_snap is the list of featured snaps to be deleted
+    currently_featured_snaps = []
+
+    next = True
+    while next:
+        featured_snaps = admin_api.get_featured_snaps(flask.session)
+        currently_featured_snaps.extend(
+            featured_snaps.get("_embedded", {}).get("clickindex:package", [])
+        )
+        next = featured_snaps.get("_links", {}).get("next", False)
+
+    currently_featured_snap_ids = [
+        snap["snap_id"] for snap in currently_featured_snaps
+    ]
+
+    delete_response = admin_api.delete_featured_snaps(
+        flask.session, {"packages": currently_featured_snap_ids}
+    )
+    if delete_response.status_code != 201:
+        response = {
+            "success": False,
+            "message": "An error occurred while deleting featured snaps",
+        }
+        return response
+
+    snap_ids = [
+        publisher_api.get_snap_id(snap_name, flask.session)
+        for snap_name in new_featured_snaps
+    ]
+
+    update_response = admin_api.update_featured_snaps(
+        flask.session, {"packages": snap_ids}
+    )
+    if update_response.status_code != 201:
+        response = {
+            "success": False,
+            "message": "An error occured while updating featured snaps",
+        }
+        return response
+    return {"success": True}


### PR DESCRIPTION
## Done
- add an endpoint that allows an admin member to do the following:
   - fetch currently featured snaps and delete them
   - update a list of new featured snaps

## How to QA

## Issue / Card https://warthogs.atlassian.net/browse/WD-8298
Fixes #

## Screenshots
