### PR TITLE
Add track dropdown on all Snap release pages

### DIFF
--- a/static/js/publisher/release/components/defaultTrackModifier.js
+++ b/static/js/publisher/release/components/defaultTrackModifier.js
@@ -123,10 +123,6 @@ class DefaultTrackModifier extends Component {
     const isCurrentDefault = defaultTrack === currentTrack;
     const defaultIsLatest = defaultTrack === "latest";
 
-    if (currentTrack === "latest") {
-      return null;
-    }
-
     return (
       <div className="u-float-right">
         {!isCurrentDefault && this.renderSetButton()}

--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -7,56 +7,39 @@ import { closeHistory } from "../actions/history";
 import { getTracks } from "../selectors";
 
 import DefaultTrackModifier from "./defaultTrackModifier";
+import TrackDropdown from "./trackDropdown";
 
 class ReleasesHeading extends Component {
-  onTrackChange(event) {
-    this.props.setCurrentTrack(event.target.value);
-    this.props.closeHistoryPanel();
-  }
-
-  renderTrackDropdown(tracks) {
-    const { currentTrack, defaultTrack } = this.props;
-    return (
-      <form className="p-form p-form--inline">
-        <select
-          id="track-dropdown"
-          onChange={this.onTrackChange.bind(this)}
-          value={currentTrack}
-        >
-          {tracks.map((track) => (
-            <option key={`${track}`} value={track}>
-              {track}{" "}
-              {defaultTrack === track && track !== "latest" && "(default)"}
-            </option>
-          ))}
-        </select>
-      </form>
-    );
-  }
-
   render() {
-    const { tracks } = this.props;
+    const { tracks, currentTrack, defaultTrack, setCurrentTrack } = this.props;
+    const options = tracks.map((track) => ({ value: track, label: track }));
 
-    const Wrap = tracks.length > 1 ? "label" : "span";
+    const handleTrackChange = (track) => {
+      setCurrentTrack(track);
+    };
+
     return (
       <section className="p-strip is-shallow u-no-padding--bottom">
         <div className="row">
           <div className="col-6">
-            <h4>
-              <Wrap htmlFor="track-dropdown">
-                {tracks.length > 1 ? (
-                  <>
-                    Track &nbsp;
-                    {this.renderTrackDropdown(tracks)}
-                  </>
-                ) : (
-                  <>Releases available to install</>
-                )}
-              </Wrap>
+            <h4 className="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+              Releases available to install
             </h4>
+            <h5 className="p-strip is-shallow u-no-padding--top">
+              <label htmlFor="track-dropdown">
+                Track: &nbsp;
+                <TrackDropdown
+                  options={options}
+                  label={currentTrack}
+                  defaultTrack={defaultTrack}
+                  currentTrack={currentTrack}
+                  onChange={handleTrackChange}
+                />
+              </label>
+            </h5>
           </div>
           <div className="col-6" style={{ marginTop: "0.25rem" }}>
-            {tracks.length > 1 && <DefaultTrackModifier />}
+            {<DefaultTrackModifier />}
           </div>
         </div>
       </section>

--- a/static/js/publisher/release/components/trackDropdown.js
+++ b/static/js/publisher/release/components/trackDropdown.js
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+
+const TrackDropdown = ({
+  options,
+  label,
+  onChange,
+  defaultTrack,
+  currentTrack,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleSelect = (value) => {
+    onChange(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="track-dropdown">
+      <div className="dropdown-toggle" onClick={handleToggle}>
+        {label}
+        <i className="p-icon--chevron-down u-float-right"></i>
+      </div>
+      {isOpen && (
+        <div className="dropdown-menu">
+          {options.map((option, index) => (
+            <div
+              key={index}
+              className="dropdown-item"
+              onClick={() => handleSelect(option.value)}
+            >
+              {option.label}
+              {option.value === defaultTrack && (
+                <div className="p-status-label">Default</div>
+              )}
+              {option.value === currentTrack && (
+                <i className="p-icon--task-outstanding u-float-right"></i>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+TrackDropdown.propTypes = {
+  options: PropTypes.array.isRequired,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  currentTrack: PropTypes.string.isRequired,
+  defaultTrack: PropTypes.string,
+};
+
+export default TrackDropdown;

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -1,4 +1,5 @@
 @import "snapcraft_patterns_icons";
+@include vf-p-icon-task-outstanding;
 
 @mixin snapcraft-release {
   $color-highlighted: #e9ffec;
@@ -11,6 +12,58 @@
     .is-pinned & {
       border-bottom: none;
     }
+  }
+
+  // CUSTOM TRACK DROPDOWN
+
+  .track-dropdown {
+    background-color: $color-mid-light;
+    border-bottom: 1px solid $color-mid-dark;
+    display: inline-block;
+    height: 40px;
+    min-width: 150px;
+    width: auto;
+  }
+    
+  .dropdown-toggle {
+      align-items: center;
+      cursor: pointer;
+      display: flex;
+      height: inherit;
+      justify-content: space-between;
+      padding: $sp-small;
+  }
+    
+  .dropdown-menu {
+      background-color: $color-x-light;
+      box-shadow: 0 3px 3px rgba(51, 51, 51, 0.2);
+      margin-top: $sp-small;
+      max-height: 400px;
+      min-width: 150px;
+      overflow-y: auto;
+      padding: $sp-small;
+      position: absolute;
+      width: auto;
+      z-index: 1000;
+  }
+
+  .dropdown-item {
+      align-items: center;
+      cursor: pointer;
+      display: flex;
+      height: inherit;
+      justify-content: space-between;
+      padding: $sp-small;
+      width: 100%;
+      
+      &:hover {
+          background-color: $color-mid-light;
+          border-radius: 4px;
+      }
+  }
+
+  .p-status-label {
+      margin: 0 $sp-small 0 $sp-small;
   }
 
   // RELEASES CONFIRM


### PR DESCRIPTION
## Done
Adds custom dropdown box to view tracks for all Snaps, even if they only have one. Displays Default label to show Default track, and tick icon to show which track the user is currently viewing.

## How to QA
https://snapcraft-io-4573.demos.haus/fran-snap/releases and check Tracks dropdown. 
Alternatively, navigate to any Snap release page and check Tracks dropdown.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10009
