### PR TITLE
WD-9998 show 0% instead of NaN% on Snapcraft metrics graph

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
+++ b/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.js
@@ -79,7 +79,7 @@ export function tooltips() {
               `</span>`,
               `<span class="snapcraft-graph-tooltip__series-value">${commaValue(
                 item.value,
-              )} (${((item.value / total) * 100).toFixed(2)}%)</span>`,
+              )} (${total !== 0 ? ((item.value / total) * 100).toFixed(2) : 0}%)</span>`,
               `</span>`,
             ].join("");
           }


### PR DESCRIPTION
## Done
- add a ternary operator to show `0%` instead of `NaN%` on Snapcraft metrics graph

## How to QA
- Go to https://snapcraft-io-4579.demos.haus/snaps
- Check if you see `0%` instead of `NaN%` on a tooltip on a metrics graph.

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-9998

## Screenshots
Before: 
<img width="60" alt="Screenshot 2024-04-05 at 3 20 19 PM" src="https://github.com/canonical/snapcraft.io/assets/90341644/4b06c8e7-5882-43c3-91bc-351b4a4ce25e">
After: 
<img width="49" alt="Screenshot 2024-04-05 at 3 20 07 PM" src="https://github.com/canonical/snapcraft.io/assets/90341644/1987cbc2-72cf-4d01-b396-a961fe45cd0f">


