### PR TITLE
Disable promote to promote option for devrel releases

### DIFF
--- a/static/js/publisher/release/components/releasesTable/releaseMenuItem.js
+++ b/static/js/publisher/release/components/releasesTable/releaseMenuItem.js
@@ -4,16 +4,19 @@ import { connect } from "react-redux";
 
 import { promoteRevision } from "../../actions/pendingReleases";
 import { getPendingChannelMap } from "../../selectors";
-import { canBeReleased } from "../../helpers";
+import { canBeReleased, isInDevmode } from "../../helpers";
 
 function ReleaseMenuItem(props) {
   const risk = `latest/${props.risk}`;
+  const devModeRisk = props.risk === "stable" || props.risk === "candidate";
+  const hasDevmodeRevisions =
+    Object.values(props.item.revisions).some(isInDevmode) && devModeRisk;
 
   return (
     <span
       key={props.risk}
       className={`p-contextual-menu__link ${
-        props.current === risk ? "is-disabled" : ""
+        props.current === risk || hasDevmodeRevisions ? "is-disabled" : ""
       }`}
       onClick={() => {
         props.item.revisions.forEach((r) => {


### PR DESCRIPTION
## Done
Disabled option to promote a release to stable or candidate if in `devmode` or grade `devrel`

## How to QA
- https://snapcraft-io-4594.demos.haus/emacs/releases
- Hover over any of the cells in the "Releases available to install" with an `*` next to the revision number
- Click "Promote" and check that the `stable` and `candidate` options are disabled
- Check that they are not disabled in the other cells (unless the cell is in that track)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10317