### PR TITLE
Adds "Add track" functionality

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -1,58 +1,56 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { Row, Col, Button } from "@canonical/react-components";
+import {
+  Row,
+  Col,
+  Button,
+  Icon,
+  Form,
+  Notification,
+  Accordion,
+} from "@canonical/react-components";
 
 import { setCurrentTrack } from "../actions/currentTrack";
 import { closeHistory } from "../actions/history";
 import { getTracks } from "../selectors";
+import {
+  validatePhasingPercentage,
+  resizeAsidePanel,
+  numericalSort,
+} from "../helpers";
 
 import DefaultTrackModifier from "./defaultTrackModifier";
 import ReleasesTable from "./releasesTable";
 
 function ReleasesHeading(props) {
-  useEffect(() => {
-    function adjustAsidePanelHeight() {
-      const targetComponent = document.querySelector("#main-content");
-      const asidePanel = document.querySelector("#aside-panel");
-
-      if (targetComponent && asidePanel) {
-        const targetRect = targetComponent.getBoundingClientRect();
-        const targetTop = targetRect.top;
-        const targetBottom = targetRect.bottom;
-        const viewportHeight = window.innerHeight;
-
-        if (targetBottom > viewportHeight) {
-          asidePanel.style.position = "fixed";
-          asidePanel.style.top = `${targetTop}px`;
-          asidePanel.style.bottom = "0";
-        } else {
-          asidePanel.style.position = "sticky";
-          asidePanel.style.top = `${targetTop}px`;
-        }
-      }
-    }
-
-    adjustAsidePanelHeight();
-
-    window.addEventListener("resize", adjustAsidePanelHeight);
-    window.addEventListener("scroll", adjustAsidePanelHeight);
-
-    return () => {
-      window.removeEventListener("resize", adjustAsidePanelHeight);
-      window.removeEventListener("scroll", adjustAsidePanelHeight);
-    };
-  }, []);
-
-  const [sidePanelOpen, setSidePanelOpen] = useState(false);
+  resizeAsidePanel(props.tracks);
   const [isOpen, setIsOpen] = useState(false);
 
-  const openSidePanel = () => {
-    setSidePanelOpen(true);
+  const [requestTrackSidePanelOpen, setRequestTrackSidePanelOpen] =
+    useState(false);
+
+  const [addTrackSidePanelOpen, setAddTrackSidePanelOpen] = useState(false);
+
+  const openRequestTrackSidePanel = () => {
+    setRequestTrackSidePanelOpen(true);
   };
 
-  const closeSidePanel = () => {
-    setSidePanelOpen(false);
+  const closeRequestTrackSidePanel = () => {
+    setRequestTrackSidePanelOpen(false);
+  };
+
+  const openAddTrackSidePanel = () => {
+    setAddTrackSidePanelOpen(true);
+  };
+
+  const closeAddTrackSidePanel = () => {
+    setTrackName("");
+    setVersionPattern("");
+    setPhasingPercentage("");
+    setPhasingPercentageError("");
+    setTrackNameError("");
+    setAddTrackSidePanelOpen(false);
   };
 
   const handleToggle = () => {
@@ -65,7 +63,87 @@ function ReleasesHeading(props) {
   };
 
   const { tracks, currentTrack, defaultTrack } = props;
+  tracks.sort(numericalSort);
   const options = tracks.map((track) => ({ value: track, label: track }));
+
+  // add new track form
+
+  const [trackName, setTrackName] = useState("");
+  const [versionPattern, setVersionPattern] = useState("");
+  const [phasingPercentage, setPhasingPercentage] = useState("");
+  const [phasingPercentageError, setPhasingPercentageError] = useState("");
+
+  const [isTrackNameFilled, setIsTrackNameFilled] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [notification, setNotification] = useState(null);
+
+  const handleTrackNameChange = (event) => {
+    const { value } = event.target;
+    setTrackName(value);
+    setIsTrackNameFilled(value.trim().length > 0);
+  };
+
+  const handleVersionPatternChange = (event) => {
+    setVersionPattern(event.target.value);
+  };
+
+  const handlePhasingPercentageChange = (event) => {
+    const { value } = event.target;
+    setPhasingPercentage(value);
+    const error = validatePhasingPercentage(value);
+    setPhasingPercentageError(error);
+  };
+
+  const showNotification = (type, message) => {
+    setNotification({ type, message });
+  };
+
+  const [successNotification, setSuccessNotification] = useState(null);
+  const [trackNameError, setTrackNameError] = useState("");
+
+  const handleAddTrack = async () => {
+    try {
+      setIsLoading(true);
+
+      const formData = new URLSearchParams();
+      formData.append("track-name", trackName);
+
+      if (versionPattern.trim() !== "") {
+        formData.append("version-pattern", versionPattern);
+      }
+
+      if (phasingPercentage.trim() !== "" && !phasingPercentageError) {
+        formData.append("automatic-phasing-percentage", phasingPercentage);
+      }
+
+      const response = await fetch(`/${props.snapName}/create-track`, {
+        method: "POST",
+        body: formData,
+      });
+
+      const responseData = await response.json();
+
+      if (response.ok) {
+        props.setCurrentTrack(trackName);
+        closeAddTrackSidePanel();
+        setSuccessNotification(`Track ${trackName} created successfully`);
+      } else {
+        let errorMessage = responseData.error;
+        if (responseData && responseData["error-list"]) {
+          const error = responseData["error-list"][0];
+          if (error && error.message) {
+            errorMessage = error.message;
+          }
+        }
+        setTrackNameError(errorMessage);
+      }
+    } catch (error) {
+      console.error("Error:", error.message);
+      showNotification("Error", error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <div>
@@ -87,44 +165,66 @@ function ReleasesHeading(props) {
                       </div>
                       {isOpen && (
                         <div className="dropdown-menu">
-                          {options.map((option, index) => (
-                            <div
-                              key={index}
-                              className="dropdown-item"
-                              onClick={() => handleSelect(option.value)}
-                            >
-                              {option.label}
-                              {option.value === defaultTrack && (
-                                <div className="p-status-label">Default</div>
-                              )}
-                              {option.value === currentTrack && (
-                                <i className="p-icon--task-outstanding u-float-right"></i>
+                          <div className="options-container">
+                            {options.map((option, index) => (
+                              <div
+                                key={index}
+                                className="dropdown-item"
+                                onClick={() => handleSelect(option.value)}
+                              >
+                                {option.label}
+                                {option.value === defaultTrack && (
+                                  <div className="p-status-label">Default</div>
+                                )}
+                                {option.value === currentTrack && (
+                                  <i className="p-icon--task-outstanding u-float-right"></i>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                          <div className="track-button-wrapper">
+                            <div className="track-button">
+                              {options.length <= 1 ? (
+                                <Button
+                                  className="p-button has-icon new-track-button"
+                                  onClick={() => {
+                                    openRequestTrackSidePanel();
+                                    if (isOpen) {
+                                      handleToggle();
+                                    }
+                                  }}
+                                >
+                                  <i className="p-icon--plus"></i>
+                                  <span>Request track</span>
+                                </Button>
+                              ) : (
+                                <Button
+                                  className="p-button has-icon new-track-button"
+                                  onClick={() => {
+                                    openAddTrackSidePanel();
+                                    if (isOpen) {
+                                      handleToggle();
+                                    }
+                                  }}
+                                >
+                                  <i className="p-icon--plus"></i>
+                                  <span>Add track</span>
+                                </Button>
                               )}
                             </div>
-                          ))}
-                          <div className="track-button">
-                            {options.length <= 1 ? (
-                              <Button
-                                className="p-button has-icon new-track-button"
-                                onClick={() => {
-                                  openSidePanel();
-                                  if (isOpen) {
-                                    handleToggle();
-                                  }
-                                }}
-                              >
-                                <i className="p-icon--plus"></i>
-                                <span>Request track</span>
-                              </Button>
-                            ) : (
-                              ""
-                            )}
                           </div>
                         </div>
                       )}
                     </div>
                   </label>
                 </h5>
+                <div className="success-notification">
+                  {successNotification && (
+                    <Notification severity="positive">
+                      {successNotification}
+                    </Notification>
+                  )}
+                </div>
               </Col>
               <div className="col-6" style={{ marginTop: "0.25rem" }}>
                 {<DefaultTrackModifier />}
@@ -133,13 +233,16 @@ function ReleasesHeading(props) {
           </div>
           <ReleasesTable />
         </main>
+
+        {/* Request track aside panel */}
+
         <div
-          className={`l-aside__overlay ${sidePanelOpen ? "" : "u-hide"}`}
-          onClick={closeSidePanel}
+          className={`l-aside__overlay ${requestTrackSidePanelOpen ? "" : "u-hide"}`}
+          onClick={closeRequestTrackSidePanel}
         ></div>
         <aside
-          className={`l-aside ${sidePanelOpen ? "" : "is-collapsed"}`}
-          id="aside-panel"
+          className={`l-aside ${requestTrackSidePanelOpen ? "" : "is-collapsed"}`}
+          id="request-track-aside-panel"
         >
           <div className="p-panel is-flex-column">
             <div className="p-panel__header">
@@ -147,7 +250,7 @@ function ReleasesHeading(props) {
             </div>
             <div className="p-panel__content u-no-padding--top u-no-padding--bottom u-fixed-width">
               <h5 className="p-heading--5 u-no-margin--bottom">
-                <b>What is a track?</b>
+                What is a track?
               </h5>
               <p>
                 A track contains a series of compatible releases. <br />
@@ -176,7 +279,7 @@ function ReleasesHeading(props) {
                 </a>
               </p>
               <h5 className="p-heading--5 u-no-padding--top u-no-margin--bottom">
-                <b>What to expect</b>
+                What to expect
               </h5>
               <p>
                 After the Forum request, we will be in touch with you to
@@ -187,7 +290,7 @@ function ReleasesHeading(props) {
                 track creation service.
               </p>
               <h5 className="p-heading--5 u-no-padding--top u-no-margin--bottom">
-                <b>Request a new track</b>
+                Request a new track
               </h5>
               <p className="u-no-padding--bottom">
                 To request a new track, follow the link below to go to the
@@ -200,7 +303,7 @@ function ReleasesHeading(props) {
                 <div className="u-fixed-width">
                   <Button
                     className="u-no-margin--bottom"
-                    onClick={closeSidePanel}
+                    onClick={closeAddTrackSidePanel}
                   >
                     Cancel
                   </Button>
@@ -220,6 +323,180 @@ function ReleasesHeading(props) {
             </div>
           </div>
         </aside>
+
+        {/* Add track aside panel */}
+
+        <div
+          className={`l-aside__overlay ${addTrackSidePanelOpen ? "" : "u-hide"}`}
+          onClick={closeAddTrackSidePanel}
+        ></div>
+        <aside
+          className={`l-aside ${addTrackSidePanelOpen ? "" : "is-collapsed"}`}
+          id="add-track-aside-panel"
+        >
+          <div className="p-panel is-flex-column">
+            <div className="p-panel__header">
+              <h4 className="p-panel__title p-heading--4">ADD TRACK</h4>
+            </div>
+            <div className="p-panel__content u-no-padding--top u-no-padding--bottom u-fixed-width">
+              <Form>
+                <div>
+                  <div
+                    className={`p-form__group p-form-validation ${trackNameError ? " is-error" : ""}`}
+                  >
+                    <label htmlFor="trackName" className="p-form__label">
+                      <strong>* Track name</strong>
+                    </label>
+                    <div className="p-form__control">
+                      <input
+                        type="text"
+                        id="trackName"
+                        className="p-form-validation__input"
+                        required={true}
+                        placeholder="display-name123"
+                        aria-invalid="true"
+                        aria-describedby="trackName"
+                        name="trackName"
+                        value={trackName}
+                        onChange={handleTrackNameChange}
+                      />
+                      <p
+                        className="p-form-validation__message"
+                        id="trackNameErrorMessage"
+                      >
+                        {trackNameError}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <p className="p-form-help-text" id="trackNameHelpMessage">
+                  Name should follow the track creation guardrails (TCG)
+                </p>
+
+                {/* Optional Properties */}
+                <Accordion
+                  className="add-track-accordion"
+                  sections={[
+                    {
+                      key: "optional properties",
+                      title: "Optional Properties",
+                      content: (
+                        <div>
+                          <div>
+                            <label htmlFor="versionPattern">
+                              <strong>Version pattern</strong>
+                            </label>
+                            <input
+                              type="text"
+                              id="versionPattern"
+                              name="versionPattern"
+                              placeholder="?.v.*"
+                              value={versionPattern}
+                              onChange={handleVersionPatternChange}
+                            />
+                          </div>
+                          <p
+                            className="p-form-help-text"
+                            id="versionPatternHelpMessage"
+                          >
+                            Version pattern should follow glob pattern
+                          </p>
+
+                          <div
+                            className={`p-form__group p-form-validation ${phasingPercentageError ? " is-error" : ""}`}
+                          >
+                            <label
+                              htmlFor="phasingPercentage"
+                              className="p-form__label"
+                            >
+                              <strong>Automatic phasing percentage</strong>
+                            </label>
+                            <div className="p-form__control">
+                              <input
+                                type="text"
+                                id="phasingPercentage"
+                                className="p-form-validation__input"
+                                placeholder="10.15"
+                                aria-invalid="true"
+                                aria-describedby="phasingPercentageErrorMessage"
+                                name="phasingPercentage"
+                                value={phasingPercentage}
+                                onChange={handlePhasingPercentageChange}
+                              />
+                              <p
+                                className="p-form-validation__message"
+                                id="phasingPercentageErrorMessage"
+                              >
+                                {phasingPercentageError}
+                              </p>
+                            </div>
+                          </div>
+                          <p
+                            className="p-form-help-text"
+                            id="phasingPercentageHelpMessage"
+                          >
+                            The percentage is a value from 0 to 100
+                          </p>
+                        </div>
+                      ),
+                    },
+                  ]}
+                />
+              </Form>
+              <p>* Mandatory field</p>
+              <p>
+                <a href="https://snapcraft.io/docs/channels">
+                  Learn about tracks
+                </a>{" "}
+                or <a href="https://discourse.canonical.com/">contact us</a> for
+                help.
+              </p>
+              {notification && (
+                <Notification
+                  severity={
+                    notification.type === "Error" ? "negative" : "positive"
+                  }
+                >
+                  {notification.message}
+                </Notification>
+              )}
+            </div>
+            <div className="aside-panel-footer">
+              <div className="p-panel__footer u-align--right">
+                <div className="u-fixed-width">
+                  <Button
+                    className="u-no-margin--bottom"
+                    onClick={() => {
+                      closeAddTrackSidePanel();
+                      setNotification(null);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    className="u-no-margin--bottom p-button--positive"
+                    onClick={() => {
+                      handleAddTrack();
+                      setNotification(null);
+                    }}
+                    disabled={
+                      !isTrackNameFilled || phasingPercentageError || isLoading
+                    }
+                  >
+                    {isLoading ? (
+                      <div>
+                        <Icon name="spinner" className="u-animation--spin" />
+                        &nbsp;Loading...
+                      </div>
+                    ) : (
+                      <div>Add track</div>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </aside>
       </div>
     </div>
   );
@@ -231,6 +508,7 @@ ReleasesHeading.propTypes = {
   closeHistoryPanel: PropTypes.func.isRequired,
   currentTrack: PropTypes.string.isRequired,
   defaultTrack: PropTypes.string,
+  snapName: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = (state) => {

--- a/static/js/publisher/release/helpers.js
+++ b/static/js/publisher/release/helpers.js
@@ -1,5 +1,6 @@
 import { AVAILABLE, REVISION_STATUS } from "./constants";
 import { getChannelString } from "../../libs/channels";
+import { useEffect } from "react";
 
 export function isInDevmode(revision) {
   return revision.confinement === "devmode" || revision.grade === "devel";
@@ -71,4 +72,72 @@ export function canBeReleased(revision) {
   const allowed = [REVISION_STATUS.PUBLISHED, REVISION_STATUS.UNPUBLISHED];
 
   return revision && allowed.includes(revision.status);
+}
+
+export function validatePhasingPercentage(value) {
+  if (value.trim()) {
+    if (isNaN(value)) {
+      return "Phasing percentage must be a number";
+    } else {
+      const percentage = parseFloat(value);
+      if (percentage < 0 || percentage > 100) {
+        return "Phasing percentage must be between 0 and 100";
+      }
+    }
+  }
+  return "";
+}
+
+export function resizeAsidePanel(tracks) {
+  useEffect(() => {
+    function adjustAsidePanelHeight() {
+      const targetComponent = document.querySelector("#main-content");
+      const asidePanel =
+        tracks.length > 1
+          ? document.querySelector("#add-track-aside-panel")
+          : document.querySelector("#request-track-aside-panel");
+      if (targetComponent && asidePanel) {
+        const targetRect = targetComponent.getBoundingClientRect();
+        const targetTop = targetRect.top;
+        const targetBottom = targetRect.bottom;
+        const viewportHeight = window.innerHeight;
+
+        if (targetBottom > viewportHeight) {
+          asidePanel.style.position = "fixed";
+          asidePanel.style.top = `${targetTop}px`;
+          asidePanel.style.bottom = "0";
+        } else {
+          asidePanel.style.position = "sticky";
+          asidePanel.style.top = `${targetTop}px`;
+        }
+      }
+    }
+
+    adjustAsidePanelHeight();
+
+    window.addEventListener("resize", adjustAsidePanelHeight);
+    window.addEventListener("scroll", adjustAsidePanelHeight);
+
+    return () => {
+      window.removeEventListener("resize", adjustAsidePanelHeight);
+      window.removeEventListener("scroll", adjustAsidePanelHeight);
+    };
+  }, [tracks]);
+}
+
+export function numericalSort(a, b) {
+  const regex = /\d+/g;
+  const numSeqA = (a.match(regex) || []).map(Number);
+  const numSeqB = (b.match(regex) || []).map(Number);
+
+  for (let i = 0; i < Math.max(numSeqA.length, numSeqB.length); i++) {
+    const numA = numSeqA[i] || 0;
+    const numB = numSeqB[i] || 0;
+
+    if (numA !== numB) {
+      return numA - numB;
+    }
+  }
+
+  return a.localeCompare(b);
 }

--- a/static/js/publisher/release/releasesController.js
+++ b/static/js/publisher/release/releasesController.js
@@ -86,7 +86,7 @@ const ReleasesController = ({
               </div>
             </div>
           </div>
-          <ReleasesHeading />
+          <ReleasesHeading snapName={snapName} />
           {showModal && <Modal />}
         </Fragment>
       )}

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -38,12 +38,14 @@
   .dropdown-menu {
       background-color: $color-x-light;
       box-shadow: 0 3px 3px rgba(51, 51, 51, 0.2);
+      display: flex;
+      flex-direction: column;
       margin: $sp-small 0 $sp-small 0;
-      max-height: 400px;
+      max-height: 250px;
       min-width: 150px;
       order: 1;
       overflow-y: auto;
-      padding: $sp-small;
+      padding: $sp-small $sp-small 0 $sp-small;
       position: absolute;
       width: auto;
       z-index: 1000;
@@ -53,6 +55,7 @@
       align-items: center;
       cursor: pointer;
       display: flex;
+      flex: 1;
       height: inherit;
       justify-content: space-between;
       padding: $sp-small;
@@ -64,9 +67,14 @@
       }
   }
 
+  .options-container {
+    flex-grow: 1;
+  }
+
   .new-track-button {
     border: none;
-    margin: $sp-small 0 0 0;
+    height: 100%;
+    margin: 0;
     width: 100%;
 
     &:hover {
@@ -76,17 +84,30 @@
   }
 
   .track-button {
+    background-color: $color-x-light;
     border-top: $border;
+    bottom: 0;
+    height: 100%;
     margin-top: $spv--x-small;
-    padding: $sp-x-small;
+    padding: $sp-small 0 $sp-small 0;
+    position: sticky;
+    width: 100%;
+  }
+
+  .track-button-wrapper {
+    background-color: $color-x-light;
+    bottom: 0;
+    margin-top: auto;
+    padding: none;
+    position: sticky;
   }
 
   .p-status-label {
       margin: 0 $sp-small 0 $sp-small;
   }
 
-  // REQUEST / CREATE TRACK ASIDE COMPONENT
-  
+  // REQUEST / ADD TRACK ASIDE COMPONENT
+
   .aside-panel-footer {
     background-color: $color-x-light;
     border-top: $border;


### PR DESCRIPTION
## Done

Allows users to add a new track to a snap that already has more than one track. Users will receive a successful or unsuccessful message depending on the outcome.

## How to QA

- Go to a Snap release page that already has more than one track (e.g. https://snapcraft-io-4596.demos.haus/fran-snap/releases)
- Verify that the side panel opens with add track options
- If you have permissions to add a track to the Snap, try and add a new track and verify that it works
- Otherwise, see screenshots below

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10155

## Screenshots

![Screenshot from 2024-04-15 10-44-14](https://github.com/canonical/snapcraft.io/assets/74302970/687e03fc-4e58-4661-bf8a-b5bff1d3ee0b)
![Screenshot from 2024-04-15 10-44-32](https://github.com/canonical/snapcraft.io/assets/74302970/2cc9d1ac-c73b-4bc9-b6c4-9d43a8394b2a)
![Screenshot from 2024-04-15 10-48-28](https://github.com/canonical/snapcraft.io/assets/74302970/0dadec66-81e9-4add-ad07-69e1bba2917e)
![Screenshot from 2024-04-15 10-50-46](https://github.com/canonical/snapcraft.io/assets/74302970/253379b8-5419-48a3-88ab-7adc7121150e)
![Screenshot from 2024-04-15 10-50-57](https://github.com/canonical/snapcraft.io/assets/74302970/92fedc05-d190-4f37-9c82-418ff4855105)
