### PR TITLE
Add column sorting to brand store

### DIFF
--- a/static/js/brand-store/components/Snaps/PublishedSnapsTable.tsx
+++ b/static/js/brand-store/components/Snaps/PublishedSnapsTable.tsx
@@ -1,45 +1,48 @@
 import React from "react";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 
 import type { Snap } from "../../types/shared";
+import { MainTable } from "@canonical/react-components";
 
 type Props = {
   snapsInStore: Array<Snap>;
 };
 
 function PublishedSnapsTable({ snapsInStore }: Props) {
+
   return (
     <>
       {snapsInStore.length > 0 ? (
-        <table>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Latest release</th>
-              <th>Release date</th>
-              <th>Publisher</th>
-            </tr>
-          </thead>
-          <tbody>
-            {snapsInStore.map((snap: Snap) => (
-              <tr key={snap.id}>
-                <td className="u-truncate">{snap.name}</td>
-                <td className="u-truncate">
-                  {snap["latest-release"] && snap["latest-release"].version
-                    ? snap["latest-release"].version
-                    : "-"}
-                </td>
-                <td className="u-truncate">
-                  {format(
-                    new Date(snap["latest-release"].timestamp),
-                    "dd/MM/yyyy"
-                  )}
-                </td>
-                <td className="u-truncate">{snap.users[0].displayname}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <MainTable
+          sortable
+          headers={[
+            { content: "Name", sortKey: "name" },
+            { content: "Latest release", sortKey: "latestRelease" },
+            { content: "Release date", sortKey: "releaseDate" },
+            { content: "Publisher", sortKey: "publisher" },
+          ]}
+          rows={snapsInStore.map((snap: Snap) => {
+            let releaseDate = null;
+            if (snap["latest-release"] && snap["latest-release"].timestamp) {
+              releaseDate = parseISO(snap["latest-release"].timestamp);
+            }
+            
+            return {
+              columns: [
+                { content: snap.name },
+                { content: snap["latest-release"] && snap["latest-release"].version ? snap["latest-release"].version : "-" },
+                { content: releaseDate ? format(releaseDate, "dd/MM/yyyy") : "-" },                
+                { content: snap.users[0].displayname }
+              ],
+              sortData: {
+                name: snap.name,
+                latestRelease: snap["latest-release"].version,
+                releaseDate: releaseDate || "-",
+                publisher: snap.users[0].displayname,
+              },
+            };
+          })}
+        />
       ) : (
         <p>There are currently no snaps in this store</p>
       )}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -528,6 +528,18 @@ dl {
   }
 }
 
+.brand-store-table-header {
+  padding: 21px 0 0;
+}
+
+.brand-store-table-content {
+  padding: 17px 0 0;
+}
+
+.brand-store-table-no-checkbox {
+  padding-top: 7px;
+}
+
 .accordion-actions {
   position: relative;
 }


### PR DESCRIPTION
## Done
Changes `<table>` to React `<MainTable>` and adds sortable columns to the brand store.

## How to QA
- Go to brand store (https://snapcraft-io-4600.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps)
- Check that columns in both tables are sortable and that they sort correctly

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10420
