### PR TITLE
Fix Releases table line wrap

### DIFF
--- a/static/js/publisher/release/components/revisionsListRow.js
+++ b/static/js/publisher/release/components/revisionsListRow.js
@@ -104,7 +104,12 @@ const RevisionsListRow = (props) => {
           </span>
         )}
       </td>
-      <td data-heading="Version">{revision.version}</td>
+      <td 
+        data-heading="Version" 
+        style={{ whiteSpace: "normal", wordWrap: "break-word" }}
+      >
+        {revision.version}
+      </td>
       {showBuildRequest && (
         <td data-heading="Build request">
           {buildRequestId && <>{buildRequestId}</>}


### PR DESCRIPTION
## Done
Fixes https://github.com/canonical/snapcraft.io/issues/4601.
Ensures long version numbers wrap onto a new line in the Releases table.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10673

## Screenshots
![Screenshot from 2024-04-23 17-55-07](https://github.com/canonical/snapcraft.io/assets/74302970/4102c8fc-d3d2-41b2-a46f-fdf63106cc1e)
