### PR TITLE
Show notification and set private to true

### DIFF
--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -70,6 +70,16 @@ Register new Snap name
       {% endfor %}
     </div>
   {% endif %}
+ 
+  <div class="u-fixed-width toggle-nofication">
+    <div class="p-notification--information">
+      <div class="p-notification__content">
+        <p class="p-notification__message">
+          Snap name registrations are subject to manual review. You will be able to upload your snap and update its metadata, but you will not be able to make the Snap public until the review has been completed. We aim to review all registrations within 30 days
+        </p>
+      </div>
+    </div>
+  </div>
 
   <form method="POST" action="/account/register-snap" class="u-no-margin--top">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
@@ -80,7 +90,7 @@ Register new Snap name
           <label for="snap-store">Store</label>
           <div class="p-form-validation__field">
             <select name="store" id="snap-store">
-              <option value="ubuntu" {% if store=="ubuntu" %} selected {% endif %}>Global</option> 
+              <option value="ubuntu" {% if store=="ubuntu" %} selected {% endif %}>Global</option>
               {% for available_store in available_stores %}
                 <option value="{{ available_store.id }}" {% if store==available_store.id %} selected {% endif %}>{{ available_store.name }}</option>
               {% endfor %}
@@ -89,7 +99,7 @@ Register new Snap name
         </div>
       </div>
     {% endif %}
-
+    
     <div class="row">
       <div class="col-8">
         <div class="p-form-validation">
@@ -98,25 +108,25 @@ Register new Snap name
             <input class="p-form-validation__input" type="text" name="snap-name" id="snap-name" required maxlength="40" value="{{ snap_name }}" />
           </div>
         </div>
-        <div class="p-form-validation">
-          <label for="public">Snap privacy</label>
-          <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
-          <div class="p-form-validation__field">
-            <div>
-              <label>
-                <input type="radio" name="is_private" value="public" class="p-form-validation__input" id="public" aria-labelledby="register-snap-public" {% if not is_private %} checked {% endif %}>
-                <span id="register-snap-public">Public</span>
-              </label>
-            </div>
-            <div>
-              <label>
-                <input type="radio" name="is_private" value="private" class="p-form-validation__input" id="private" aria-labelledby="register-snap-private" {% if is_private %} checked {% endif %}>
-                <span id="register-snap-private">Private</span>
-              </label>
-              <p class="p-form-help-text" style="margin-left: 1.5rem;">Snap is hidden in stores and only accessible by the publisher and collaborators</p>
+          <div class="p-form-validation">
+            <label for="public">Snap privacy</label>
+            <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
+            <div class="p-form-validation__field">
+              <div>
+                <label>
+                  <input type="radio" name="is_private" value="public" class="p-form-validation__input" id="public" aria-labelledby="register-snap-public" {% if not is_private %} checked {% endif %}>
+                  <span id="register-snap-public">Public</span>
+                </label>
+              </div>
+              <div>
+                <label>
+                  <input type="radio" name="is_private" value="private" class="p-form-validation__input" id="private" aria-labelledby="register-snap-private" {% if is_private %} checked {% endif %}>
+                  <span id="register-snap-private">Private</span>
+                </label>
+                <p class="p-form-help-text" style="margin-left: 1.5rem;">Snap is hidden in stores and only accessible by the publisher and collaborators</p>
+              </div>
             </div>
           </div>
-        </div>
       </div>
     </div>
 
@@ -132,4 +142,16 @@ Register new Snap name
     </div>
   </form>
 </div>
+
+<script>
+  let isPrivate = true
+  store = document.querySelector("#snap-store")
+  let selectedStore = store.value
+  store.addEventListener("change", function() {
+    selectedStore = store.value
+    selectedStore == "ubuntu" ? isPrivate = true : isPrivate = false
+    toggleNotification = document.querySelector(".toggle-nofication")
+    isPrivate ? toggleNotification.style.display = "block" : toggleNotification.style.display = "none"
+  })
+</script>
 {% endblock %}

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -149,7 +149,7 @@ Register new Snap name
   let privateRadioButton = document.querySelector("#private")
   let publicRadioButton = document.querySelector("#public")
   let toggleNotification = document.querySelector(".toggle-nofication")
-  let selectedStore = store.value
+  let selectedStore = store?.value
 
   if (isPrivate) {
     privateRadioButton.checked = true
@@ -160,7 +160,7 @@ Register new Snap name
     publicRadioButton.checked = true
   }
 
-  store.addEventListener("change", function() {
+  store?.addEventListener("change", function() {
     selectedStore = store.value
     selectedStore == "ubuntu" ? isPrivate = true : isPrivate = false
     if (isPrivate) {

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -114,13 +114,13 @@ Register new Snap name
             <div class="p-form-validation__field">
               <div>
                 <label>
-                  <input type="radio" name="is_private" value="public" class="p-form-validation__input" id="public" aria-labelledby="register-snap-public" {% if not is_private %} checked {% endif %}>
+                  <input type="radio" name="is_private" value="public" class="p-form-validation__input" id="public" aria-labelledby="register-snap-public">
                   <span id="register-snap-public">Public</span>
                 </label>
               </div>
               <div>
                 <label>
-                  <input type="radio" name="is_private" value="private" class="p-form-validation__input" id="private" aria-labelledby="register-snap-private" {% if is_private %} checked {% endif %}>
+                  <input type="radio" name="is_private" value="private" class="p-form-validation__input" id="private" aria-labelledby="register-snap-private">
                   <span id="register-snap-private">Private</span>
                 </label>
                 <p class="p-form-help-text" style="margin-left: 1.5rem;">Snap is hidden in stores and only accessible by the publisher and collaborators</p>
@@ -145,13 +145,36 @@ Register new Snap name
 
 <script>
   let isPrivate = true
-  store = document.querySelector("#snap-store")
+  let store = document.querySelector("#snap-store")
+  let privateRadioButton = document.querySelector("#private")
+  let publicRadioButton = document.querySelector("#public")
+  let toggleNotification = document.querySelector(".toggle-nofication")
   let selectedStore = store.value
+
+  if (isPrivate) {
+    privateRadioButton.checked = true
+    publicRadioButton.disabled = true
+    privateRadioButton.disabled = true
+  }
+  else {
+    publicRadioButton.checked = true
+  }
+
   store.addEventListener("change", function() {
     selectedStore = store.value
     selectedStore == "ubuntu" ? isPrivate = true : isPrivate = false
-    toggleNotification = document.querySelector(".toggle-nofication")
-    isPrivate ? toggleNotification.style.display = "block" : toggleNotification.style.display = "none"
+    if (isPrivate) {
+      toggleNotification.style.display = "block"
+      privateRadioButton.checked = true
+      publicRadioButton.disabled = true
+      privateRadioButton.disabled = true
+
+    } else {
+      toggleNotification.style.display = "none"
+      publicRadioButton.disabled = false
+      privateRadioButton.disabled = false
+    
+    }
   })
 </script>
 {% endblock %}


### PR DESCRIPTION
## Done
- show notification to inform user that registering a snap requires manual review when a user selects global store (notification is hidden for other stores)
- set the default private value to true when global store is selected
- Disable the privacy buttons when global store is selected
## How to QA
- Go to https://snapcraft-io-4603.demos.haus/register-snap
- Select the global store
- Check that the notification displays
- Check that the privacy options are disabled
- Select any other store and check that notification is not displayed and you can select any privacy option of your choice
- Also, QA with an account that has access to only global store.
## Issue / Card 
https://warthogs.atlassian.net/browse/WD-10620
https://warthogs.atlassian.net/browse/WD-10618
Fixes #

## Screenshots
