### PR TITLE
redirect to snapcraft dashboard register snap page

### DIFF
--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -358,9 +358,9 @@ def post_register_name():
     store = flask.request.form.get("store")
     registrant_comment = flask.request.form.get("registrant_comment")
 
-    if store =="ubuntu" or store == None:
+    if store == "ubuntu" or store is None:
         return flask.redirect("https://dashboard.snapcraft.io/register-snap")
-        
+
     try:
         publisher_api.post_register_name(
             session=flask.session,

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -358,6 +358,9 @@ def post_register_name():
     store = flask.request.form.get("store")
     registrant_comment = flask.request.form.get("registrant_comment")
 
+    if store =="ubuntu" or store == None:
+        return flask.redirect("https://dashboard.snapcraft.io/register-snap")
+        
     try:
         publisher_api.post_register_name(
             session=flask.session,


### PR DESCRIPTION
## Done
- Redirects to https://dashboard.snapcraft.io/register-snap when user tries to register
## How to QA
- Go to register-snap, select global store,enter a snap name and click register, it should redirect to https://dashboard.snapcraft.io/register-snap
## Issue / Card
https://warthogs.atlassian.net/browse/WD-10674
Fixes #

## Screenshots
