### PR TITLE
Modify breakpoint-navigation-threshold

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -13,7 +13,7 @@ $color-paper: #f3f3f3;
 }
 
 // navigation variables
-$breakpoint-navigation-threshold: 1036px;
+$breakpoint-navigation-threshold: 1175px;
 $font-display-option: swap;
 
 // responsive


### PR DESCRIPTION
## Done
Modifies the `$breakpoint-navigation-threshold` to avoid the nav bar wrapping onto a new line on smaller screens. The nav bar now switches to mobile version at this new breakpoint instead.

## How to QA
Go to demo and make screen size smaller to ensure the top navigation bar does not wrap onto two lines at any point.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-10735

## Screenshots
BEFORE:
![Screenshot from 2024-04-24 15-08-21](https://github.com/canonical/snapcraft.io/assets/74302970/23b8d355-524e-4338-8daf-206f1811bb03)

AFTER:
![Screenshot from 2024-04-24 15-10-05](https://github.com/canonical/snapcraft.io/assets/74302970/a3399145-cd32-4dfe-9f02-6fde9b8abe70)

