### PR TITLE
Add some attempt to reduce spam on report snap form

### DIFF
--- a/static/js/public/snap-details/reportSnap.js
+++ b/static/js/public/snap-details/reportSnap.js
@@ -47,6 +47,9 @@ export default function initReportSnap(
   const modal = document.querySelector(modalSelector);
   const reportForm = modal.querySelector("form");
 
+  const honeypotField = reportForm.querySelector("#report-snap-confirm");
+  const commentField = reportForm.querySelector("#report-snap-comment");
+
   toggle.addEventListener("click", (event) => {
     event.preventDefault();
     toggleModal(modal);
@@ -66,6 +69,14 @@ export default function initReportSnap(
       reportForm.querySelector("button[type=submit]"),
       "Submitting…",
     );
+
+    if (
+      honeypotField.checked ||
+      (commentField.value && commentField.value.includes("http"))
+    ) {
+      showSuccess(modal);
+      return;
+    }
 
     fetch(formURL, {
       method: "POST",

--- a/templates/store/snap-details/_report_snap_modal.html
+++ b/templates/store/snap-details/_report_snap_modal.html
@@ -8,7 +8,8 @@
 
       {# report snap form submits to a Google Forms #}
       {# names of the inputs need to be consistend with the original form #}
-      <form id="report-snap-form" action="https://docs.google.com/forms/d/e/1FAIpQLSc5w1Ow6hRGs-VvBXmDtPOZaadYHEpsqCl2RbKEenluBvaw3Q/formResponse" method="POST">
+      <form id="report-snap-form" action="/report" method="POST">
+        <input name="csrf_token" type="hidden" value="{{csrf_token()}}" />
         <input type="hidden" name="entry.718227286" value="{{package_name}}" />
         <label for="report-snap-reason">Choose a reason for reporting this snap</label>
         <select id="report-snap-reason" name="entry.340540050" required>
@@ -21,6 +22,8 @@
 
         <label for="report-snap-email">Your email (optional)</label>
         <input id="report-snap-email" type="email" name="entry.1624813972" placeholder="email@example.com" />
+        <label for="report-snap-confirm" style="position: absolute; top: -9999999px;">I agree</label>
+        <input id="report-snap-confirm" type="checkbox" name="entry.13371337" style="position: absolute; top: -9999999px;" />
         <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.</p>
         <div class="u-align--right">
           <button type="button" class="js-modal-close u-no-margin--bottom">Cancel</button>

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -1,5 +1,6 @@
 import flask
 import humanize
+import requests
 
 import webapp.helpers as helpers
 import webapp.metrics.helper as metrics_helper
@@ -400,3 +401,31 @@ def snap_details_views(store, api):
         return flask.render_template(
             "store/snap-distro-install.html", **context
         )
+
+    @store.route("/report", methods=["POST"])
+    def report_snap():
+        form_url = "/".join(
+            [
+                "https://docs.google.com",
+                "forms",
+                "d",
+                "e",
+                "1FAIpQLSc5w1Ow6hRGs-VvBXmDtPOZaadYHEpsqCl2RbKEenluBvaw3Q",
+                "formResponse",
+            ]
+        )
+
+        fields = flask.request.form
+
+        # If the honeypot is activated or a URL is included in the message,
+        # say "OK" to avoid spam
+        if (
+            "entry.13371337" in fields and fields["entry.13371337"] == "on"
+        ) or "http" in fields["entry.1974584359"]:
+            return "", 200
+
+        try:
+            requests.post(form_url, data=fields)
+            return "", 200
+        except Exception as e:
+            return e, 500


### PR DESCRIPTION
## Done
- Added a honeypot for bots,
- Added a simple check for urls included in the comment
- Moved the actual form submission to the backend so as to implement server-side checks too

## How to QA
- Visit a snap page
- Submit a report with a url in it - let me know what you submitted
- Refresh the page
- Inspect the page and set "#report-snap-confirm" to `checked` to `true`.
- Submit again
- Let me know what you submitted
- Refresh the page
- Submit a "normal" report
- Let me know what you submitted

## Issue / Card
Fixes #

## Screenshots
