### PR TITLE
make link clickable in error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint-js": "eslint static/js",
     "lint-scss": "stylelint static/**/*.scss",
-    "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
+    "lint-python": "flake8 webapp tests && black --diff --check --line-length 79 webapp tests",
     "test": "yarn run test-python && yarn run test-js-all && yarn run lint-scss",
     "test-js": "jest",
     "test-js-all": "yarn run lint-js && yarn run test-js",

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -64,7 +64,7 @@ Register new Snap name
       {% for error in errors %}
         <div class="p-notification--caution">
           <div class="p-notification__content">
-            <p class="p-notification__message">{{ error.message }}</p>
+            <p class="p-notification__message">{{ error.message | safe }}</p>
           </div>
         </div>
       {% endfor %}

--- a/templates/publisher/register-snap.html
+++ b/templates/publisher/register-snap.html
@@ -108,6 +108,8 @@ Register new Snap name
             <input class="p-form-validation__input" type="text" name="snap-name" id="snap-name" required maxlength="40" value="{{ snap_name }}" />
           </div>
         </div>
+
+        {% if available_stores %}
           <div class="p-form-validation">
             <label for="public">Snap privacy</label>
             <p class="p-form-help-text">This can be changed at any time after the initial upload</p>
@@ -127,6 +129,8 @@ Register new Snap name
               </div>
             </div>
           </div>
+        {% endif %}
+
       </div>
     </div>
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -407,7 +407,11 @@ def post_register_name():
                         )
                     )
                 elif error["code"] == "name-review-required":
-                    formatted_error = re.sub(r'(https?://\S+)', r'<a href="\1">\1</a>', error["message"])
+                    formatted_error = re.sub(
+                        r"(https?://\S+)",
+                        r'<a href="\1">\1</a>',
+                        error["message"],
+                    )
                     error["message"] = formatted_error
 
         context = {

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1,6 +1,7 @@
 # Packages
 import bleach
 import flask
+import re
 from canonicalwebteam.store_api.stores.snapstore import (
     SnapPublisher,
     SnapStoreAdmin,
@@ -405,6 +406,9 @@ def post_register_name():
                             reserved=True,
                         )
                     )
+                elif error["code"] == "name-review-required":
+                    formatted_error = re.sub(r'(https?://\S+)', r'<a href="\1">\1</a>', error["message"])
+                    error["message"] = formatted_error
 
         context = {
             "snap_name": snap_name,


### PR DESCRIPTION
## Done
- Make links in register error message clickable
## How to QA
- Go to https://snapcraft-io-4610.demos.haus/register-snap and try to register a snap name in global store
- Check that the links in the error message returned are clickable
## Issue / Card https://warthogs.atlassian.net/browse/WD-10674
Fixes #

## Screenshots
