### PR TITLE
Update snap settings page

### DIFF
--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -198,6 +198,7 @@ function App() {
                     type="radio"
                     className="p-radio__input"
                     value="public"
+                    disabled={settingsData?.visibility_locked}
                     {...register("visibility")}
                   />
                   <span className="p-radio__label">Public</span>
@@ -214,6 +215,7 @@ function App() {
                     type="radio"
                     className="p-radio__input"
                     value="unlisted"
+                    disabled={settingsData?.visibility_locked}
                     {...register("visibility")}
                   />
                   <span className="p-radio__label">Unlisted</span>
@@ -231,6 +233,7 @@ function App() {
                     type="radio"
                     className="p-radio__input"
                     value="private"
+                    disabled={settingsData?.visibility_locked}
                     {...register("visibility")}
                   />
                   <span className="p-radio__label">Private</span>

--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -136,6 +136,16 @@ function App() {
         activeTab="settings"
       />
 
+      {settingsData?.visibility_locked && (
+        <div className="u-fixed-width">
+          <Notification
+            severity="information"
+            title=""
+          >
+            Your Snap is in the queue for manual review. When approved, you will receive an email, and you will be able to change the visibility of your Snap.
+          </Notification>
+          </div>
+      )}
       <Form onSubmit={handleSubmit(onSubmit)} stacked={true}>
         <SaveAndPreview
           snapName={settingsData?.snap_name}

--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -71,7 +71,7 @@ function App() {
     if (data.visibility === "unlisted") {
       data.private = false;
       data.unlisted = true;
-    } else if (data.visibility === "private") {
+    } else if (data.visibility === "private" || data.visibility_locked) {
       data.private = true;
       data.unlisted = false;
     } else if (data.visibility === "public") {

--- a/static/js/publisher/settings/components/App/App.tsx
+++ b/static/js/publisher/settings/components/App/App.tsx
@@ -68,12 +68,12 @@ function App() {
     setHasSaved(false);
     setSavedError(false);
 
-    if (data.visibility === "unlisted") {
-      data.private = false;
-      data.unlisted = true;
-    } else if (data.visibility === "private" || data.visibility_locked) {
+    if (data.visibility === "private" || data.visibility_locked) {
       data.private = true;
       data.unlisted = false;
+    } else if (data.visibility === "unlisted") {
+      data.private = false;
+      data.unlisted = true;
     } else if (data.visibility === "public") {
       data.private = false;
       data.unlisted = false;

--- a/static/js/publisher/settings/types/SettingsData.d.ts
+++ b/static/js/publisher/settings/types/SettingsData.d.ts
@@ -15,6 +15,7 @@ type SettingsData = {
   whitelist_country_keys: string;
   blacklist_country_keys: string;
   country_keys_status: string | null;
+  visibility_locked: boolean
 };
 
 export type { SettingsData };

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -22,6 +22,7 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
     unlisted: {{ unlisted|tojson }},
     whitelist_countries: {{ whitelist_country_codes|tojson }},
     blacklist_countries: {{ blacklist_country_codes|tojson }},
+    visibility_locked: {{ visibility_locked|tojson }},
   };
 </script>
 <script src="{{ static_url('js/dist/publisher-settings.js') }}"></script>

--- a/tests/publisher/snaps/tests_settings.py
+++ b/tests/publisher/snaps/tests_settings.py
@@ -59,6 +59,7 @@ class GetSettingsPage(BaseTestCases.EndpointLoggedInErrorHandling):
             "publisher": {"display-name": "test"},
             "update_metadata_on_release": True,
             "license": "",
+            "visibility_locked": False,
         }
 
         responses.add(responses.GET, self.api_url, json=payload, status=200)

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -71,6 +71,7 @@ def get_settings(snap_name, return_json=False):
         "update_metadata_on_release": snap_details[
             "update_metadata_on_release"
         ],
+        "visibility_locked": snap_details["visibility_locked"],
     }
 
     if return_json:


### PR DESCRIPTION
## Done
- Add notification on snap settings page when `visibility_locked` is `true`
- Disable visibility inputs when `visibility_locked` is `true`
- Ensure `private` is `true` when `visibility_locked` is `true`
## How to QA
- QA can only be done on a snap that has visibility_locked set to true, presently all registered snaps have it set to `None`
## Issue / Card
https://warthogs.atlassian.net/browse/WD-10614
https://warthogs.atlassian.net/browse/WD-10617
Fixes #

## Screenshots
![image](https://github.com/canonical/snapcraft.io/assets/47438585/2fe9fa0f-6df2-4da8-970d-6390857db94d)

