### PR TITLE
Add delete package endpoint

### DIFF
--- a/webapp/authentication.py
+++ b/webapp/authentication.py
@@ -10,6 +10,7 @@ LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")
 PERMISSIONS = [
     "edit_account",
     "package_access",
+    "package_manage",
     "package_metrics",
     "package_register",
     "package_release",


### PR DESCRIPTION
## Done
Verifies that the backend API endpoint works correctly to unregister a snap name
*Links to https://github.com/canonical/canonicalwebteam.store-api/pull/118*

## How to QA
Check video below where I use Postman to delete `abbie-global-test-snap-3`
(I will add the front-end in a different PR for proper testing)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-6772

## Video
[Screencast from 06-05-24 14:34:39.webm](https://github.com/canonical/snapcraft.io/assets/74302970/d4758495-9951-46d7-8b7b-af25232a0b5b)

