### PR TITLE
fix: Remove featured category query param for search queries

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,8 +4,10 @@ module.exports = {
     url: "http://localhost.test",
   },
   collectCoverage: true,
-  transformIgnorePatterns: ["node_modules/@canonical/(?!react-components)"],
+  transformIgnorePatterns: [
+    "node_modules/@canonical/(?!(react-components|store-components))",
+  ],
   moduleNameMapper: {
-    "\\.(scss|sass|css)$": "identity-obj-proxy"
+    "\\.(scss|sass|css)$": "identity-obj-proxy",
   },
 };

--- a/static/js/store/components/Packages/Packages.tsx
+++ b/static/js/store/components/Packages/Packages.tsx
@@ -24,10 +24,6 @@ function Packages() {
       queryString = "?categories=featured";
     }
 
-    if (search && !search.includes("categories=")) {
-      queryString += "&categories=featured";
-    }
-
     const response = await fetch(`/beta/store.json${queryString}`);
     const data = await response.json();
     const packagesWithId = data.packages.map((item: Package) => {
@@ -215,7 +211,7 @@ function Packages() {
             </div>
           </Col>
           <Col size={9}>
-            {status === "success" && data.packages.length && (
+            {status === "success" && data.packages.length > 0 && (
               <div ref={searchSummaryRef}>
                 {isFeatured ? (
                   <h2>Featured snaps</h2>

--- a/static/js/store/components/Packages/__tests__/Packages.test.tsx
+++ b/static/js/store/components/Packages/__tests__/Packages.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { BrowserRouter } from "react-router-dom";
+import { render, waitFor, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import Packages from "../Packages";
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        categories: [
+          { display_name: "Development", name: "development" },
+          { display_name: "Social", name: "social" },
+        ],
+        packages: [],
+      }),
+  })
+) as jest.Mock;
+
+const queryClient = new QueryClient();
+
+const renderComponent = () =>
+  render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <Packages />
+      </QueryClientProvider>
+    </BrowserRouter>
+  );
+
+describe("Packages", () => {
+  test("featured categories are called by deafult", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/beta/store.json?categories=featured"
+      );
+    });
+  });
+
+  test("selected categories are appended to the API call", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.click(screen.getByLabelText("Development"));
+    await user.type(screen.getByLabelText("Search Snapcraft"), "code");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/beta/store.json?categories=development"
+      );
+    });
+  });
+
+  test("selected categories and search query are appended to the API call", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.click(screen.getByLabelText("Development"));
+    await user.type(screen.getByLabelText("Search Snapcraft"), "code");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/beta/store.json?categories=development&q=code"
+      );
+    });
+  });
+
+  test("no categories are appended to the API call if none are selected and there is a search query", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.type(screen.getByLabelText("Search Snapcraft"), "code");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/beta/store.json?q=code");
+    });
+  });
+});


### PR DESCRIPTION
## Done
- Fixed `0` being displayed if there are no search results
- Fixed packages not being returned for a search with no categories
- Added tests

## How to QA
- Go to https://snapcraft-io-4624.demos.haus/store?q=nonsensequery
- Check that there isn't a `0` displayed above the "No packages match this filter" heading
- Go to https://snapcraft-io-4624.demos.haus/store?q=code
- Check that there are more than 2 search results and that VS Code is in the results

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-11332
