### PR TITLE
fix: Fix compiler warnings in channel map JS

### DIFF
--- a/static/js/public/snap-details/channelMap.ts
+++ b/static/js/public/snap-details/channelMap.ts
@@ -134,6 +134,8 @@ class ChannelMap {
       .join("");
 
     this.arch = this.channelMapData["amd64"] ? "amd64" : architectures[0];
+
+    return;
   }
 
   bindEvents() {


### PR DESCRIPTION
## Done
Fixed compiler warnings in channelMap.js (no return)

## How to QA
All checks should pass

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes