### PR TITLE
feat: Add separators to brand store navigation

### DIFF
--- a/static/js/brand-store/components/Navigation/Navigation.tsx
+++ b/static/js/brand-store/components/Navigation/Navigation.tsx
@@ -102,7 +102,10 @@ function Navigation({ sectionName }: { sectionName: string | null }) {
               </div>
             </div>
             <div className="p-panel__content">
-              <div className="p-side-navigation--icons is-dark">
+              <div className="nav-list-separator">
+                <hr />
+              </div>
+              <div className="p-side-navigation--icons hide-collapsed is-dark">
                 <ul className="p-side-navigation__list">
                   <li className="p-side-navigation__item--title p-muted-heading">
                     <span className="p-side-navigation__link">
@@ -122,7 +125,10 @@ function Navigation({ sectionName }: { sectionName: string | null }) {
                 !brandIsLoading &&
                 brandIsSuccess && (
                   <>
-                    <div className="p-side-navigation--icons is-dark">
+                    <div className="nav-list-separator">
+                      <hr />
+                    </div>
+                    <div className="p-side-navigation--icons hide-collapsed is-dark">
                       <ul className="p-side-navigation__list u-no-margin--bottom">
                         <li className="p-side-navigation__item--title p-muted-heading">
                           <span className="p-side-navigation__link">
@@ -227,7 +233,7 @@ function Navigation({ sectionName }: { sectionName: string | null }) {
                         </li>
                       </ul>
                     </div>
-                    <div className="p-side-navigation--icons is-dark">
+                    <div className="p-side-navigation--icons hide-collapsed is-dark">
                       <ul className="p-side-navigation__list">
                         {sectionName && (
                           <>
@@ -306,26 +312,33 @@ function Navigation({ sectionName }: { sectionName: string | null }) {
                 )}
               <div className="p-side-navigation--icons is-dark">
                 {publisherData && publisherData.publisher && (
-                  <ul className="p-side-navigation__list sidenav-bottom-ul">
-                    <li className="p-side-navigation__item">
-                      <NavLink
-                        to="/admin/account"
-                        className="p-side-navigation__link"
-                        aria-selected={sectionName === "account"}
-                      >
-                        <i className="p-icon--user is-light p-side-navigation__icon"></i>
-                        <span className="p-side-navigation__label">
-                          {publisherData.publisher.fullname}
-                        </span>
-                      </NavLink>
-                    </li>
-                    <li className="p-side-navigation__item">
-                      <a href="/logout" className="p-side-navigation__link">
-                        <i className="p-icon--begin-downloading is-light p-side-navigation__icon"></i>
-                        <span className="p-side-navigation__label">Logout</span>
-                      </a>
-                    </li>
-                  </ul>
+                  <div className="sidenav-bottom">
+                    <div className="nav-list-separator">
+                      <hr />
+                    </div>
+                    <ul className="p-side-navigation__list">
+                      <li className="p-side-navigation__item">
+                        <NavLink
+                          to="/admin/account"
+                          className="p-side-navigation__link"
+                          aria-selected={sectionName === "account"}
+                        >
+                          <i className="p-icon--user is-light p-side-navigation__icon"></i>
+                          <span className="p-side-navigation__label">
+                            {publisherData.publisher.fullname}
+                          </span>
+                        </NavLink>
+                      </li>
+                      <li className="p-side-navigation__item">
+                        <a href="/logout" className="p-side-navigation__link">
+                          <i className="p-icon--begin-downloading is-light p-side-navigation__icon"></i>
+                          <span className="p-side-navigation__label">
+                            Logout
+                          </span>
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
                 )}
               </div>
             </div>

--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -58,7 +58,7 @@
       width: 100%;
     }
 
-    .sidenav-bottom-ul {
+    .sidenav-bottom {
       bottom: 1.5rem;
       position: absolute;
       width: 15rem;
@@ -226,6 +226,59 @@
 
       .p-side-navigation--icons .p-side-navigation__list {
         opacity: 1 !important;
+      }
+    }
+  }
+
+  // Overrides to add separators and hide icons in side nav when collapsed
+  .nav-list-separator {
+    padding-left: 4rem;
+  }
+
+  .is-collapsed {
+    .hide-collapsed {
+      .p-side-navigation__icon {
+        display: none !important;
+      }
+
+      [aria-current="page"] {
+        &.p-side-navigation__link {
+          background-color: inherit !important;
+
+          &:hover {
+            background-color: inherit !important;
+            cursor: default !important;
+          }
+
+          &::before {
+            display: none !important;
+          }
+        }
+      }
+    }
+  }
+
+  @media (min-width: $breakpoint-small) and (max-width: $breakpoint-large) {
+    .l-navigation:not(.is-pinned, :hover) {
+      .hide-collapsed {
+        .p-side-navigation__icon {
+          display: none !important;
+        }
+
+        [aria-current="page"] {
+          &.p-side-navigation__link {
+            background-color: inherit !important;
+
+            &:hover {
+              background-color: inherit !important;
+              cursor: default !important;
+            }
+
+            &::before {
+              display: none !important;
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Done
Added separators to the brand store navigation and hidden icons when nav bar is collapsed

## How to QA
- Go to https://snapcraft-io-4704.demos.haus/admin
- Check that there are horizontal separators between sections in the side navigation
- Collapse the side navigation
- Check that there are no icons other than the logout/account ones at the very bottom of the nav bar
- Resize to smaller screens and check that there are no icons unless sidebar is hovered/expanded

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual changes only

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-11687