### PR TITLE
webapp/store/content/distros: update instructions to mention installation of the snapd snap

### DIFF
--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -10,4 +10,7 @@ install:
     command: |
       sudo apt update
       sudo apt install snapd
-      sudo snap install core
+  - action: |
+      After this, install the snapd snap in order to get the latest snapd:
+    command: |
+      sudo snap install snapd

--- a/webapp/store/content/distros/raspbian.yaml
+++ b/webapp/store/content/distros/raspbian.yaml
@@ -14,6 +14,6 @@ install:
     command: |
       sudo reboot
   - action: |
-      After this, install the core snap in order to get the latest snapd:
+      After this, install the snapd snap in order to get the latest snapd:
     command: |
-      sudo snap install core
+      sudo snap install snapd


### PR DESCRIPTION
In general, the preferred source of newer snapd is either the distro package, or on distributions where reexecution is enabled and supported (Debian derivatives), the snapd snap, . The core snap will be automatically pulled in by snapd when installing snaps that need it, but in most cases, the snaps have already migrated to using the leaner core18/20/22/24 bases.

## Done

## How to QA

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): snap store snap installation instructions content update

## Issue / Card
Fixes #

## Screenshots
