### PR TITLE
fix: use p-navigation__row--25-75 and add highlights on Snapcraft.io navigation

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -8,7 +8,7 @@
         <div class="l-docs__sidebar">
       {% endif %}
         {% if not docs %}
-        <div class="p-navigation__row {% if full_width_nav %}is-full-width{% endif %}">
+        <div class="p-navigation__row--25-75 {% if full_width_nav %}is-full-width{% endif %}">
         {% endif %}
           <div class="p-navigation__banner">
             <div class="p-navigation__tagged-logo">

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -32,7 +32,7 @@
             <nav class="p-navigation__nav">
               <ul class="p-navigation__items" role="menu">
                 <li
-                  class="p-navigation__item {% if page_slug == 'store' %}is-selected{% endif %}"
+                  class="p-navigation__item {% if request.path == '/store' %}is-selected{% endif %}"
                   role="menuitem"
                 >
                   <a class="p-navigation__link" href="/store">
@@ -40,7 +40,7 @@
                   </a>
                 </li>
                 <li
-                  class="p-navigation__item- {% if page_slug == 'about' %}is-selected{% endif %}"
+                  class="p-navigation__item {% if request.path == '/about' %}is-selected{% endif %}"
                   role="menuitem"
                 >
                   <a class="p-navigation__link" href="/about">
@@ -48,7 +48,7 @@
                   </a>
                 </li>
                 <li
-                class="p-navigation__item--dropdown-toggle {% if page_slug == 'blog' %}is-selected{% endif %}"
+                class="p-navigation__item--dropdown-toggle {% if request.path == '/blog' %}is-selected{% endif %}"
                 id="learn-link"
                 role="menuitem"
                 >
@@ -79,7 +79,7 @@
                   </ul>
                 </li>
                 <li
-                  class="p-navigation__item {% if page_slug == 'iot' %}is-selected{% endif %}"
+                  class="p-navigation__item {% if request.path == '/iot' %}is-selected{% endif %}"
                   role="menuitem"
                 >
                   <a class="p-navigation__link" href="/iot">


### PR DESCRIPTION
## Done
- Change the main navigation to`p-navigation__row--25-75 `
- Add highlight on the navigation tab when it's selected 

## How to QA
- Go to https://snapcraft-io-4709.demos.haus/store and check if `snap store` is highlighted when the tab selected
- Check there is spacing between the logo and navigation items

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): This PR primarily focused on improving the layout (e.g., using p-navigation__row--25-75).

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-12307
Fixes #https://warthogs.atlassian.net/browse/WD-12308

## Screenshots
<img width="1398" alt="Screenshot 2024-06-21 at 9 57 36 AM" src="https://github.com/canonical/snapcraft.io/assets/90341644/bb90320a-ddb3-4b8e-ba41-473d6afa5b1c">
