### PR TITLE
feat: Add helper to generate DNS verification token

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -81,6 +81,11 @@ env: &env
       key: discourse-api-username
       name: snapcraft-io
 
+  - name: DNS_VERIFICATION_SALT
+    secureKeyRef:
+      key: dns-verification-salt
+      name: snapcraft-io
+
 memoryLimit: 256Mi
 
 extraHosts:

--- a/tests/tests_helpers.py
+++ b/tests/tests_helpers.py
@@ -1,0 +1,16 @@
+import unittest
+import os
+import hashlib
+
+from webapp import helpers
+
+
+class GetDnsVerificationTokenTest(unittest.TestCase):
+    def test_get_dns_verification_token(self):
+        salt = os.getenv("DNS_VERIFICATION_SALT")
+        token_string = f"spotify.com:spotify:{salt}"
+        test_hash = hashlib.sha256(token_string.encode("utf-8")).hexdigest()
+        self.assertEqual(
+            helpers.get_dns_verification_token("spotify", "spotify.com"),
+            test_hash,
+        )

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 
 import flask
 from canonicalwebteam.launchpad import Launchpad
@@ -136,3 +137,10 @@ def get_publisher_data():
     context = {"publisher": flask_user}
 
     return context
+
+
+def get_dns_verification_token(snap_name, domain):
+    salt = os.getenv("DNS_VERIFICATION_SALT")
+    token_string = f"{domain}:{snap_name}:{salt}"
+    token = hashlib.sha256(token_string.encode("utf-8")).hexdigest()
+    return token


### PR DESCRIPTION
## Done
Added a helper to generate the token to be used for DNS verification

## How to QA
- There is no way to check other than the test passing

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-12520