### PR TITLE
feat: Create endpoint to verify domain

### DIFF
--- a/konf/staging-api.snapcraft.io.yaml
+++ b/konf/staging-api.snapcraft.io.yaml
@@ -63,6 +63,11 @@ env:
       key: discourse-api-username
       name: snapcraft-io
 
+  - name: DNS_VERIFICATION_SALT
+    secureKeyRef:
+      key: dns-verification-salt
+      name: snapcraft-io
+
 memoryLimit: 256Mi
 
 nginxConfigurationSnippet: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ responses==0.22.0
 ruamel.yaml==0.18.5
 vcrpy-unittest==0.1.7
 user-agents==2.2.0
+dnspython==2.6.1
 
 # Development dependencies
 Flask-Testing==0.8.1


### PR DESCRIPTION
## Done
Created an endpoint to verify a domain

## How to QA
- Go to https://snapcraft-io-4716.demos.haus/api/steve-test-snap/verify
- Check that the value in the response is `false` - this is because the secret isn't on staging

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Unable to test real DNS records. Front-end testing should cover this when the UI is built.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-12520