### PR TITLE
feat: Separate primary domain from other domains

### DIFF
--- a/static/js/publisher/listing/components/ListingFormInput/ListingFormInput.tsx
+++ b/static/js/publisher/listing/components/ListingFormInput/ListingFormInput.tsx
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { Row, Col } from "@canonical/react-components";
+import { Row, Col, ColSize } from "@canonical/react-components";
 
 type Props = {
   label: string;
@@ -12,7 +12,8 @@ type Props = {
   placeholder?: string;
   getFieldState: Function;
   pattern?: RegExp;
-  tourLabel: string;
+  tourLabel?: string;
+  colSize?: ColSize;
 };
 
 function ListingFormInput({
@@ -27,6 +28,7 @@ function ListingFormInput({
   getFieldState,
   pattern,
   tourLabel,
+  colSize,
 }: Props) {
   const id = nanoid();
   const fieldState = getFieldState ? getFieldState(name) : "";
@@ -42,7 +44,7 @@ function ListingFormInput({
           {label}:
         </label>
       </Col>
-      <Col size={8}>
+      <Col size={colSize || 8}>
         <div className="p-form__control">
           <input
             data-tour={tourLabel}

--- a/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
+++ b/static/js/publisher/listing/sections/ContactInformationSection/ContactInformationSection.tsx
@@ -1,4 +1,5 @@
 import MultipleInputs from "../../components/MultipleInputs";
+import ListingFormInput from "../../components/ListingFormInput";
 
 type Props = {
   getFieldState: Function;
@@ -18,9 +19,18 @@ function ContactInformationSection({
         <h2 className="p-heading--4">Contact information</h2>
       </div>
 
+      <ListingFormInput
+        label="Primary website"
+        name="primary_website"
+        register={register}
+        getFieldState={getFieldState}
+        type="url"
+        colSize={5}
+      />
+
       <MultipleInputs
         fieldName="websites"
-        label="Websites"
+        label="Other websites"
         register={register}
         control={control}
         getFieldState={getFieldState}

--- a/static/js/publisher/listing/utils/__tests__/getChanges.test.ts
+++ b/static/js/publisher/listing/utils/__tests__/getChanges.test.ts
@@ -19,6 +19,19 @@ describe("getChanges", () => {
     expect(changes.snap_name).not.toBeDefined();
   });
 
+  test("handles website changes in data", () => {
+    const changedFields = {
+      primary_website: true,
+    };
+    const data = {
+      primary_website: "https://example.com",
+      websites: [{ url: "https://test.com" }],
+    };
+    const changes = getChanges(changedFields, data);
+
+    expect(changes.links.website[0]).toBe("https://example.com");
+  });
+
   test("doesn't return changes for forbidden keys", () => {
     const changedFields = {
       "primary-category": true,

--- a/static/js/publisher/listing/utils/__tests__/getListingData.test.ts
+++ b/static/js/publisher/listing/utils/__tests__/getListingData.test.ts
@@ -67,5 +67,6 @@ describe("getListingData", () => {
     expect(listingData.images).toBeDefined();
     expect(listingData.snap_categories).toBeDefined();
     expect(listingData.links).toBeDefined();
+    expect(listingData.primary_website).toBeDefined();
   });
 });

--- a/static/js/publisher/listing/utils/getChanges.ts
+++ b/static/js/publisher/listing/utils/getChanges.ts
@@ -69,7 +69,15 @@ function getChanges(
     return urls.filter((url) => url.url !== "");
   };
 
+  const combineWebsites = (
+    primaryWebsite: string,
+    websites: Array<{ url: string }>
+  ) => {
+    return [{ url: primaryWebsite }].concat(websites);
+  };
+
   if (
+    dirtyFields.primary_website ||
     dirtyFields.contacts ||
     dirtyFields.donations ||
     dirtyFields.issues ||
@@ -77,6 +85,7 @@ function getChanges(
     dirtyFields["source-code"] ||
     dirtyFields.website
   ) {
+    combineWebsites(data.primary_website, data.websites);
     changes.links = {
       contact: data.contacts
         ? removeEmptyUrls(data.contacts).map((url: { url: string }) => url.url)
@@ -88,7 +97,9 @@ function getChanges(
         ? removeEmptyUrls(data.issues).map((url: { url: string }) => url.url)
         : [],
       website: data.websites
-        ? removeEmptyUrls(data.websites).map((url: { url: string }) => url.url)
+        ? removeEmptyUrls(
+            combineWebsites(data.primary_website, data.websites)
+          ).map((url: { url: string }) => url.url)
         : [],
       source: data["source-code"]
         ? removeEmptyUrls(data["source-code"]).map(

--- a/static/js/publisher/listing/utils/getListingData.ts
+++ b/static/js/publisher/listing/utils/getListingData.ts
@@ -3,6 +3,16 @@ type License = {
   name: string;
 };
 
+const getOtherWebsites = (websites: Array<string>) => {
+  if (websites.length > 1) {
+    return websites.slice(1, websites.length).map((url) => ({ url })) as Array<{
+      url: string;
+    }>;
+  }
+
+  return [] as [];
+};
+
 const licenseSort = (a: License, b: License) => {
   if (a.name < b.name) {
     return -1;
@@ -101,13 +111,13 @@ function getListingData(listingData: { [key: string]: any }) {
             };
           })
         : [],
+    primary_website:
+      listingData.links && listingData.links.website
+        ? listingData.links.website[0]
+        : "",
     websites:
       listingData.links && listingData.links.website
-        ? listingData.links.website.map((link: string) => {
-            return {
-              url: link,
-            };
-          })
+        ? getOtherWebsites(listingData.links.website)
         : [],
     banner_urls: window?.listingData?.banner_urls,
     icon_url: window?.listingData?.icon_url,


### PR DESCRIPTION
## Done
Separated the primary domain from the other domains on the snap publisher listing page

## How to QA
- Go to a snap listing page (https://snapcraft-io-4722.demos.haus/<SNAP_NAME>/listing)
- Check that the "Primary website" field has the first website value (compare to live)
- Check that the remaining domains are in the "Other websites" field
- Check that you can edit and save domains

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-12522