### PR TITLE
feat: Show domain verified status on snap page

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "topojson-client": "3.1.0",
     "ts-loader": "9.5.1",
     "typescript": "5.3.3",
-    "vanilla-framework": "4.9.0",
+    "vanilla-framework": "4.13.0",
     "watch-cli": "0.2.3",
     "webpack": "5.89.0",
     "webpack-cli": "5.1.4",

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -24,7 +24,7 @@
     <h5 class="p-muted-heading">Websites</h5>
     <ul class="p-list">
       {% for link in links["website"] %}
-        <li>
+        <li {% if loop.index == 1 %}data-js="primary-domain"{% endif %}>
           <a class="js-external-link" title="{{ link }}" href="{{ link }}" aria-controls="modal">{{ format_link(link) }}</a>
         </li>
       {% endfor %}
@@ -108,7 +108,47 @@
   </section>
 </div>
 
+<template id="verified-status">
+  (Verified ownership) 
+  <span class="p-tooltip--btm-right" aria-describedby="verified-explanation">
+    <i class="p-icon--information"></i>
+    <span class="p-tooltip__message" role="tooltip" id="verified-explanation">The publisher has verified that they own this domain. 
+It does not guarantee the Snap is an official upload from the 
+upstream project.</span>
+  </span>
+</template>
+
 <script>
+  // Handle verified domain status
+  const primaryDomainListItem = document.querySelector("[data-js='primary-domain']");
+  
+  function renderVerificationStatus() {
+    if ("content" in document.createElement("template")) {
+      const template = document.querySelector("#verified-status");
+      const clone = template.content.cloneNode(true);
+      primaryDomainListItem.appendChild(clone);
+    }
+  }
+  
+  if (primaryDomainListItem) {
+    async function getVerifiedStatus() {
+      const response = await fetch("/api/{{ snap_title }}/verify");
+      
+      if (!response.ok) {
+        return;
+      }
+
+      const responseData = await response.json();
+
+      if (responseData.primary_domain) {
+        renderVerificationStatus();
+      }
+    }
+
+    getVerifiedStatus();
+  }
+
+  // Handle external links
   const externalLinks = document.querySelectorAll(".js-external-link");
   const externalLinkModal = document.querySelector(".js-exeternal-link-modal");
   const externalLinkModalCloseButton = externalLinkModal.querySelector(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,6 +7828,11 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
+vanilla-framework@4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.13.0.tgz#3901952faf819be42b24d2efc719c73de384a8ab"
+  integrity sha512-mUSJqs56ycxpEZwplTOiy4SfihjWsPiAddnQZ9b0s0ak8mLHVxnJF1aNIpPixPWK/NvhD9jVACn5qa2pGabRMQ==
+
 vanilla-framework@4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"


### PR DESCRIPTION
## Done
Added the verification notification to the primary domain on the snap page

## How to QA
- Go to https://snapcraft-io-4724.demos.haus/steve-test-snap
- Check that there is a verified domain icon and tooltip next to the first domain under "Websites"
- Go to https://snapcraft-io-4724.demos.haus/code (or any other snap)
- Check that there is NOT a verified domain icon and tooltip next to the first domain under "Websites"

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Small UI change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-12525