### PR TITLE
feat: adds get_package_metadata flask endpoint

### DIFF
--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -1,0 +1,52 @@
+import responses
+from unittest.mock import patch
+from tests.publisher.endpoint_testing import BaseTestCases
+
+# Make sure tests fail on stray responses.
+responses.mock.assert_all_requests_are_fired = True
+
+
+class TestGetPackageMetadata(BaseTestCases):
+    def setUp(self):
+        super().setUp()
+
+    @responses.activate
+    @patch(
+        "canonicalwebteam.store_api.stores.snapstore."
+        "SnapPublisher.get_package_metadata"
+    )
+    def test_get_package_metadata(self, mock_get_package_metadata):
+        # testing for track guardrails
+        mock_metadata = {
+            "track-guardrails": {
+                "created-at": "2024-03-26T11:54:50.062999",
+                "pattern": "^v\\.[0-9]+",
+            }
+        }
+        mock_get_package_metadata.return_value = mock_metadata
+
+        self.client.set_session_data(
+            {"publisher": {"nickname": "test_username"}}
+        )
+
+        snap_name = "test_snap"
+        api_response = {"metadata": mock_metadata}
+        responses.add(
+            responses.GET,
+            f"https://api.charmhub.io/v1/snap/{snap_name}",
+            json=api_response,
+            status=200,
+        )
+
+        response = self.client.get(f"/api/packages/{snap_name}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json,
+            {"data": mock_metadata, "success": True},
+        )
+        mock_get_package_metadata.assert_called_once_with(
+            self.client.session,
+            "snap",
+            snap_name,
+        )

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -446,6 +446,17 @@ def post_register_name():
     return flask.redirect(flask.url_for("account.get_account"))
 
 
+@publisher_snaps.route("/api/packages/<snap_name>", methods=["GET"])
+@login_required
+@exchange_required
+def get_package_metadata(snap_name):
+    package_metadata = publisher_api.get_package_metadata(
+        flask.session, "snap", snap_name
+    )
+
+    return jsonify({"data": package_metadata, "success": True})
+
+
 @publisher_snaps.route("/packages/<package_name>", methods=["DELETE"])
 @login_required
 @exchange_required


### PR DESCRIPTION
## Done
Adds `get_package_metadata` flask endpoint to be able to query for track guardrails. 
Links to [this StoreAPI PR](https://github.com/canonical/canonicalwebteam.store-api/pull/126)

## How to QA
See screenshots below for functioning endpoint (tested locally with Postman)

## Testing
- [X] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-11398

## Screenshots
![tcg](https://github.com/canonical/snapcraft.io/assets/74302970/4bf11199-dd46-4b42-90b9-bc5dbcf96b78)
![no tcg](https://github.com/canonical/snapcraft.io/assets/74302970/1a3382f9-21f8-448f-8fa6-452f862d7d45)

