### PR TITLE
feat(snapReporting): Update reporting snap violation flow

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -253,17 +253,6 @@
     </div>
   {% endif %}
 
-  {# REPORT SNAP SECTION - hidden in preview #}
-  {% if not is_preview and not IS_BRAND_STORE %}
-    <div class="p-strip--light">
-      <div class="u-fixed-width">
-        <p>Is there a problem with {{snap_title}}? <a class="js-modal-open">Report this app</a></p>
-      </div>
-    </div>
-
-    {% include "store/snap-details/_report_snap_modal.html" %}
-  {% endif %}
-
   {% if has_publisher_page %}
   <div class="p-strip is-shallow">
       <div class="u-fixed-width u-clearfix">

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -80,6 +80,19 @@
     <hr>
   {% endif %}
 
+  {# REPORT SNAP SECTION - hidden in preview #}
+    {% if not is_preview and not IS_BRAND_STORE %}
+      <h5 class="p-muted-heading">Report a Snap Store violation</h5>
+      <ul class="p-list">
+        <li>
+          <a class="js-modal-open">Report this app</a>
+        </li>
+      </ul>
+
+      {% include "store/snap-details/_report_snap_modal.html" %}
+      <hr>
+    {% endif %}
+
 <div class="p-modal js-exeternal-link-modal u-hide" id="modal">
   <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header">

--- a/templates/store/snap-details/_details.html
+++ b/templates/store/snap-details/_details.html
@@ -85,7 +85,7 @@
       <h5 class="p-muted-heading">Report a Snap Store violation</h5>
       <ul class="p-list">
         <li>
-          <a class="js-modal-open">Report this app</a>
+          <a class="js-modal-open">Report this Snap</a>
         </li>
       </ul>
 

--- a/templates/store/snap-details/_report_snap_modal.html
+++ b/templates/store/snap-details/_report_snap_modal.html
@@ -18,7 +18,7 @@
             </h5>
             {% if links and links["contact"] %}
               <p class="p-notification__message">
-                The Snap developer has provided the following contact information:</p>
+                The Snap developer has provided the following <b>contact information</b>:</p>
               <ul>
                 {% if links["contact"] %}
                   {% for link in links["contact"] %}
@@ -29,7 +29,7 @@
             {% endif %}
             {% if links and links["issues"] %}
               <p class="p-notification__message">
-                The Snap developer has provided the following links that issues can be reported through:</p>
+                The Snap developer has provided the following links for <b>reporting issues</b>:</p>
               <ul>
                 {% if links["issues"] %}
                   {% for link in links["issues"] %}

--- a/templates/store/snap-details/_report_snap_modal.html
+++ b/templates/store/snap-details/_report_snap_modal.html
@@ -2,7 +2,7 @@
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <div class="js-report-snap-form">
       <header class="p-modal__header">
-        <h2 class="p-modal__title" id="modal-title">Report {{snap_title}}</h2>
+        <h2 class="p-modal__title" id="modal-title">Report {{snap_title}} for a Snap Store violation</h2>
         <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
       </header>
 
@@ -11,6 +11,35 @@
       <form id="report-snap-form" action="/report" method="POST">
         <input name="csrf_token" type="hidden" value="{{csrf_token()}}" />
         <input type="hidden" name="entry.718227286" value="{{package_name}}" />
+        <div class="p-notification--negative">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">
+              Reports submitted through this form go to the Snap team, not the Snap Developer.
+            </h5>
+            {% if links and links["contact"] %}
+              <p class="p-notification__message">
+                The Snap developer has provided the following contact information:</p>
+              <ul>
+                {% if links["contact"] %}
+                  {% for link in links["contact"] %}
+                    <li><a href="{{link}}" target="_blank" rel="noopener">{{ format_link(link) }}</a></li>
+                  {% endfor %}
+                {% endif %}
+              </ul>
+            {% endif %}
+            {% if links and links["issues"] %}
+              <p class="p-notification__message">
+                The Snap developer has provided the following links that issues can be reported through:</p>
+              <ul>
+                {% if links["issues"] %}
+                  {% for link in links["issues"] %}
+                    <li><a href="{{link}}" target="_blank" rel="noopener">{{ format_link(link) }}</a></li>
+                  {% endfor %}
+                {% endif %}
+              </ul>
+            {% endif %}
+          </div>
+        </div>
         <label for="report-snap-reason">Choose a reason for reporting this snap</label>
         <select id="report-snap-reason" name="entry.340540050" required>
           <option value="" selected>Select an option</option>
@@ -35,10 +64,10 @@
 
     <div class="js-report-snap-success u-hide">
       <header class="p-modal__header">
-        <h2 class="p-modal__title" id="modal-title">Report submitted successfully</h2>
+        <h2 class="p-modal__title" id="modal-title">Snap Store Violation Report submitted successfully</h2>
         <button class="p-modal__close js-modal-close" aria-label="Close dialog">Close</button>
       </header>
-      <p>Thanks for bringing this to our attention. Information you provided will help us investigate further.</p>
+      <p>Thank you for your report. Information you provided will help us investigate further.</p>
       <div class="u-align--right">
         <button type="button" class="p-button--positive js-modal-close u-no-margin--bottom">Close</button>
       </div>

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -260,7 +260,7 @@ class TemplateUtilsTest(unittest.TestCase):
         for domain in [
             "github.com",
             "gitlab.com",
-            "bithucket.org",
+            "bitbucket.org",
             "launchpad.net",
             "sourceforge.net",
         ]:

--- a/tests/tests_templates_utils.py
+++ b/tests/tests_templates_utils.py
@@ -256,3 +256,26 @@ class TemplateUtilsTest(unittest.TestCase):
             "http://example.com/path/path/?foo=bar&bar=foo"
         )
         self.assertEqual(result, "example.com")
+
+        for domain in [
+            "github.com",
+            "gitlab.com",
+            "bithucket.org",
+            "launchpad.net",
+            "sourceforge.net",
+        ]:
+            result = template_utils.format_link(f"https://{domain}/test/test")
+            self.assertEqual(result, f"{domain}/test/test")
+
+            result = template_utils.format_link(
+                f"http://{domain}/test/test?foo=bar"
+            )
+            self.assertEqual(result, f"{domain}/test/test")
+
+            result = template_utils.format_link(f"http://{domain}/test/test")
+            self.assertEqual(result, f"{domain}/test/test")
+
+            result = template_utils.format_link(
+                f"http://{domain}/test/test?foo=bar"
+            )
+            self.assertEqual(result, f"{domain}/test/test")

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -172,4 +172,13 @@ def format_link(url):
         url_parts_no_query = url_parts_no_slashes.split("?")[0]
         url_parts_no_path = url_parts_no_query.split("/")[0]
 
+        if url_parts_no_path in [
+                "github.com",
+                "gitlab.com",
+                "bitbucket.org",
+                "launchpad.net",
+                "sourceforge.net"
+        ]:
+            return url_parts_no_query
+
         return url_parts_no_path

--- a/webapp/template_utils.py
+++ b/webapp/template_utils.py
@@ -173,11 +173,11 @@ def format_link(url):
         url_parts_no_path = url_parts_no_query.split("/")[0]
 
         if url_parts_no_path in [
-                "github.com",
-                "gitlab.com",
-                "bitbucket.org",
-                "launchpad.net",
-                "sourceforge.net"
+            "github.com",
+            "gitlab.com",
+            "bitbucket.org",
+            "launchpad.net",
+            "sourceforge.net",
         ]:
             return url_parts_no_query
 


### PR DESCRIPTION
## Done
- Moved report this snap to be under the rest of the links on the page
- Updated the heading to be more explicit "Report a Snap Store violation"
- Updated report violation modal title to be more explicit
- Added notification to the top of the modal to reiterate what the form is for
- If available provide signposting for the user to contact information and report an issue with the snap directly
- Simplified the thank you message

Also:
Updated the formatting of urls for links:
If the link is github.com, gitlab.com, bitbucket.org, launchpad.net, or sourceforge.net also include the path in the display.

## How to QA
Visit multiple snaps with differnent available links

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Screenshots

![image](https://github.com/canonical/snapcraft.io/assets/479384/a41652ab-b93f-4932-94d5-65e66bc56dc7)

![image](https://github.com/canonical/snapcraft.io/assets/479384/6746fbf4-350b-4d5f-92cc-e33eefa27fcc)

