### PR TITLE
fix: refactor add track logic with track guardrails

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import {
@@ -18,6 +18,7 @@ import {
   validatePhasingPercentage,
   resizeAsidePanel,
   numericalSort,
+  hasTrackGuardrails,
 } from "../helpers";
 
 import DefaultTrackModifier from "./defaultTrackModifier";
@@ -72,10 +73,24 @@ function ReleasesHeading(props) {
   const [versionPattern, setVersionPattern] = useState("");
   const [phasingPercentage, setPhasingPercentage] = useState("");
   const [phasingPercentageError, setPhasingPercentageError] = useState("");
+  const [hasGuardrails, setHasGuardrails] = useState(false);
 
   const [isTrackNameFilled, setIsTrackNameFilled] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [notification, setNotification] = useState(null);
+
+  useEffect(() => {
+    hasTrackGuardrails(props.snapName)
+      .then((response) => {
+        setHasGuardrails(response);
+      })
+      .catch(
+        (error) => {
+          console.error("Error:", error.message);
+        },
+        [props.snapName],
+      );
+  });
 
   const handleTrackNameChange = (event) => {
     const { value } = event.target;
@@ -184,7 +199,7 @@ function ReleasesHeading(props) {
                           </div>
                           <div className="track-button-wrapper">
                             <div className="track-button">
-                              {options.length <= 1 ? (
+                              {!hasGuardrails ? (
                                 <Button
                                   className="p-button has-icon new-track-button"
                                   onClick={() => {

--- a/static/js/publisher/release/helpers.test.js
+++ b/static/js/publisher/release/helpers.test.js
@@ -5,7 +5,10 @@ import {
   getRevisionsArchitectures,
   isSameVersion,
   jsonClone,
+  hasTrackGuardrails,
 } from "./helpers";
+
+global.fetch = jest.fn();
 
 describe("getChannelName", () => {
   it("should return track/risk pair as a name", () => {
@@ -109,5 +112,41 @@ describe("jsonClone", () => {
     };
 
     expect(jsonClone(testJson)).toEqual({ string: "string" });
+  });
+});
+
+describe("hasTrackGuardrails", () => {
+  beforeEach(() => {
+    fetch.mockClear();
+  });
+
+  it("should return true when track-guardrails are present", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            "track-guardrails": ["example-guardrail"],
+          },
+        }),
+    });
+
+    const result = await hasTrackGuardrails("test-snap");
+    expect(result).toBe(true);
+  });
+
+  it("should return false when track-guardrails are not present", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            "track-guardrails": [],
+          },
+        }),
+    });
+
+    const result = await hasTrackGuardrails("test-snap");
+    expect(result).toBe(false);
   });
 });

--- a/static/js/publisher/release/helpers.ts
+++ b/static/js/publisher/release/helpers.ts
@@ -159,3 +159,26 @@ export function numericalSort(a: string, b: string) {
 
   return a.localeCompare(b);
 }
+
+export async function hasTrackGuardrails(snap: string) {
+  const url = `/api/packages/${snap}`;
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("There was a problem fetching the snap's metadata");
+    }
+
+    const data = await response.json();
+
+    return data.data["track-guardrails"].length > 0;
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+}


### PR DESCRIPTION
## Done

- Refactors Releases page track dropdown
    - Instead of checking if a snap has > 1 track, we now query for track guardrails and based on this result:
       - If there are track guardrails: shows "Add track" aside panel
       - If there are **no** track guardrails: shows "Request track" aside panel

## How to QA
- Tricky to QA as you need to have a snap with > 1 track but NO guardrails, and a snap with guardrails to show the differentiation
- Tests should pass
- Check your published snaps (or snaps that you are a collaborator on)
    - If there are guardrails, the track dropdown should show "Add track"
    - If there are no guardrails, the track dropdown should show "Request track"

## Testing
- [X] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-11361

## Screenshots
