### PR TITLE
chore: Bump canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "topojson-client": "3.1.0",
     "ts-loader": "9.5.1",
     "typescript": "5.3.3",
-    "vanilla-framework": "4.13.0",
+    "vanilla-framework": "4.14.0",
     "watch-cli": "0.2.3",
     "webpack": "5.89.0",
     "webpack-cli": "5.1.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # App dependencies
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.candid==0.9.0
-canonicalwebteam.discourse==5.4.9
+canonicalwebteam.discourse==5.6.0
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -8,7 +8,7 @@
         <div class="l-docs__sidebar">
       {% endif %}
         {% if not docs %}
-        <div class="p-navigation__row--25-75 {% if full_width_nav %}is-full-width{% endif %}">
+        <div class="p-navigation__row {% if full_width_nav %}is-full-width{% endif %}">
         {% endif %}
           <div class="p-navigation__banner">
             <div class="p-navigation__tagged-logo">

--- a/yarn.lock
+++ b/yarn.lock
@@ -7828,10 +7828,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.13.0.tgz#3901952faf819be42b24d2efc719c73de384a8ab"
-  integrity sha512-mUSJqs56ycxpEZwplTOiy4SfihjWsPiAddnQZ9b0s0ak8mLHVxnJF1aNIpPixPWK/NvhD9jVACn5qa2pGabRMQ==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Bumps canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0
- Removes `p-navigation__row--25-75` as "Sign In" / user's account name wrapped onto a new line with the new Vanilla changes

## QA

- Check the changes in Vanilla have not broken anything
- Go to docs (e.g. https://snapcraft-io-4735.demos.haus/docs/managing-updates) and hover over a h2 heading, see the [vanilla anchor link](https://vanillaframework.io/docs/patterns/links#anchor-link) works as expected
- Inspect the heading and see there are no trailing numbers on the heading 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12931

## Testing
- [X] No testing required (explain why): no logic change
