### PR TITLE
fix: Self-serve track creation bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.6.1
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==4.11.3
+canonicalwebteam.store-api==4.12.2
 canonicalwebteam.launchpad==0.9.0
 canonicalwebteam.store-base==0.5.0
 django-openid-auth==0.17

--- a/static/js/publisher/release/helpers.test.js
+++ b/static/js/publisher/release/helpers.test.js
@@ -132,7 +132,7 @@ describe("hasTrackGuardrails", () => {
     });
 
     const result = await hasTrackGuardrails("test-snap");
-    expect(result).toBe(true);
+    expect(result).toStrictEqual({ "track-guardrails": ["example-guardrail"] });
   });
 
   it("should return false when track-guardrails are not present", async () => {
@@ -147,6 +147,6 @@ describe("hasTrackGuardrails", () => {
     });
 
     const result = await hasTrackGuardrails("test-snap");
-    expect(result).toBe(false);
+    expect(result).toStrictEqual({ "track-guardrails": [] });
   });
 });

--- a/static/js/publisher/release/helpers.ts
+++ b/static/js/publisher/release/helpers.ts
@@ -98,20 +98,16 @@ export function validatePhasingPercentage(value: string) {
   return "";
 }
 
-export function resizeAsidePanel(tracks: Array<any>) {
+export function resizeAsidePanel(panelType: string) {
   useEffect(() => {
     function adjustAsidePanelHeight() {
       const targetComponent = document.querySelector("#main-content");
       let asidePanel;
 
-      if (tracks.length > 1) {
-        asidePanel = document.querySelector(
-          "#add-track-aside-panel"
-        ) as HTMLElement;
+      if (panelType === "add") {
+        asidePanel = document.querySelector("#add-track-aside-panel") as HTMLElement;
       } else {
-        asidePanel = document.querySelector(
-          "#request-track-aside-panel"
-        ) as HTMLElement;
+        asidePanel = document.querySelector("#request-track-aside-panel") as HTMLElement;
       }
 
       if (targetComponent && asidePanel) {
@@ -140,7 +136,7 @@ export function resizeAsidePanel(tracks: Array<any>) {
       window.removeEventListener("resize", adjustAsidePanelHeight);
       window.removeEventListener("scroll", adjustAsidePanelHeight);
     };
-  }, [tracks]);
+  });
 }
 
 export function numericalSort(a: string, b: string) {
@@ -173,12 +169,9 @@ export async function hasTrackGuardrails(snap: string) {
     if (!response.ok) {
       throw new Error("There was a problem fetching the snap's metadata");
     }
-
     const data = await response.json();
-
-    return data.data["track-guardrails"].length > 0;
+    return { "track-guardrails": data.data["track-guardrails"] };
   } catch (e) {
-    console.error(e);
-    return false;
+    return { "error": e };
   }
 }

--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -45,10 +45,17 @@
       min-width: 150px;
       order: 1;
       overflow-y: auto;
-      padding: $sp-small $sp-small 0 $sp-small;
       position: absolute;
       width: auto;
       z-index: 1000;
+  }
+
+  .dropdown-menu.padding-bottom {
+    padding: $sp-small;
+  }
+  
+  .dropdown-menu.no-padding-bottom {
+    padding: $sp-small $sp-small 0 $sp-small;
   }
 
   .dropdown-item {

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -453,8 +453,13 @@ def get_package_metadata(snap_name):
     package_metadata = publisher_api.get_package_metadata(
         flask.session, "snap", snap_name
     )
-
-    return jsonify({"data": package_metadata, "success": True})
+    if "metadata" in package_metadata and package_metadata["metadata"]:
+        return jsonify({"data": package_metadata["metadata"], "success": True})
+    else:
+        return (
+            jsonify({"error": "Package metadata not found", "success": False}),
+            404,
+        )
 
 
 @publisher_snaps.route("/packages/<package_name>", methods=["DELETE"])


### PR DESCRIPTION
## Done
Fixed the bugs listed here: https://warthogs.atlassian.net/browse/WD-13131

## Change of logic following further team discussion
We now will only show "Add" or "Request" track in the dropdown when a user is the publisher or a collaborator of the snap. Otherwise, we will show:
- If you are a collaborator / publisher:
    - if the snap has track guardrails > we show "Add track"
    - if the snap has no guardrails > we show "Request track"
- If you are not a collaborator / publisher:
    - we show the list of tracks only

## How to QA
1. Open a snap's release page that has no track guardrails - this must be a snap that you are a collaborator or publisher of
    1. Open the request track side panel, click cancel, ensure the side panel closes
1. Open https://snapcraft-io-4749.demos.haus/fran-snap/releases and try and click on the track dropdown straight away
    1. You will see a brief "Loading" state before Add Track should appear
1. Check the alignment of the aside panels for both add and request track stick to the top navigation
    1.  e.g. https://snapcraft-io-4749.demos.haus/fran-snap/releases (Add track) and one of your own snaps with no guardrails for the Request Track side panel
1. Go to https://snapcraft-io-4749.demos.haus/fran-snap/releases and open the "Add track" panel
    1. Try and add a new track name that doesn't fit the guardrails (i.e. abcdefg)
    1. Clear the input and verify that the error disappears
1. Go to https://snapcraft-io-4749.demos.haus/lxd/releases and ensure there is no "Add"/"Request" in the track dropdown 
(you should only see the list of tracks)

## Testing
- [ ] This PR has tests
- [X] No testing required (explain why): bug fixes (tests to follow later when improving TICS dashboard)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-13131

## Screenshots
`fran-snap` - showing "Add track"
![image](https://github.com/canonical/snapcraft.io/assets/74302970/78d26d01-bebc-44c4-9036-6c7538523800)

`test-flight-tracker` - showing "Request track"
![image](https://github.com/canonical/snapcraft.io/assets/74302970/7cb47a0d-694a-46bd-a4a4-6bde50bf6654)

`lxd` - showing list of tracks only as I am not a collaborator
![image](https://github.com/canonical/snapcraft.io/assets/74302970/c9157fe2-421a-4eeb-b49f-a05a742a6fb1)

