### PR TITLE
fix: Fix padding issue on brand store status bar

### DIFF
--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -88,6 +88,10 @@
       z-index: 110;
     }
 
+    .l-status {
+      padding: 1rem 0;
+    }
+
     .p-side-navigation__item--title .p-side-navigation__link {
       color: #a8a8a8 !important;
     }


### PR DESCRIPTION
## Done
Fixed a padding issue with the status bar in the brand store

## How to QA
- Go to https://snapcraft-io-4753.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Make a change (check or uncheck a checkbox)
- The "Save changes" bar at the bottom of the screen should have padding above and below the button

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-13134