### PR TITLE
fix: Fix base JS coding standards warnings from TiCS dashboard

### DIFF
--- a/static/js/base/ga.ts
+++ b/static/js/base/ga.ts
@@ -13,12 +13,6 @@ const events: Events = {
   ".p-strip .p-button--positive": "content-cta-0",
   "#main-content .p-button": "content-cta-1",
   ".p-strip .p-button": "content-cta-1",
-  // @ts-expect-error
-  // eslint-disable-next-line no-dupe-keys
-  "#main-content .p-button": "content-cta-1",
-  // @ts-expect-error
-  // eslint-disable-next-line no-dupe-keys
-  ".p-strip .p-button": "content-cta-1",
   "#main-content .p-card": "content-card",
   ".p-strip .p-card": "content-card",
   "#main-content .p-media-object--snap": "content-card-snap",


### PR DESCRIPTION
## Done
Fixed coding standards warnings in base JS from TiCS dashboard

## How to QA
All checks should pass

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes
