### PR TITLE
fix: Only show members and settings pages in user has admin role

### DIFF
--- a/static/js/brand-store/components/App/App.tsx
+++ b/static/js/brand-store/components/App/App.tsx
@@ -24,7 +24,6 @@ import SigningKeys from "../SigningKeys";
 import StoreNotFound from "../StoreNotFound";
 
 import type { StoresList, StoresSlice } from "../../types/shared";
-import { AnyAction } from "redux";
 
 function App(): ReactNode {
   const isLoading = useSelector(

--- a/static/js/brand-store/components/Model/Model.test.tsx
+++ b/static/js/brand-store/components/Model/Model.test.tsx
@@ -11,7 +11,14 @@ import { store } from "../../store";
 
 jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
-  useSelector: jest.fn(),
+  useSelector: jest.fn().mockReturnValue([
+    { id: "test-id", name: "Test store", roles: ["admin"] },
+    {
+      id: "non-admin-store",
+      name: "Non-admin store",
+      roles: ["review", "view", "access"],
+    },
+  ]),
 }));
 
 const queryClient = new QueryClient({

--- a/static/js/brand-store/components/Model/Policies.test.tsx
+++ b/static/js/brand-store/components/Model/Policies.test.tsx
@@ -21,7 +21,14 @@ jest.mock("react-router-dom", () => {
 
 jest.mock("react-redux", () => ({
   ...jest.requireActual("react-redux"),
-  useSelector: jest.fn(),
+  useSelector: jest.fn().mockReturnValue([
+    { id: "test-id", name: "Test store", roles: ["admin"] },
+    {
+      id: "non-admin-store",
+      name: "Non-admin store",
+      roles: ["review", "view", "access"],
+    },
+  ]),
 }));
 
 const queryClient = new QueryClient({

--- a/static/js/brand-store/components/Navigation/Navigation.tsx
+++ b/static/js/brand-store/components/Navigation/Navigation.tsx
@@ -45,6 +45,8 @@ function Navigation({
     return;
   };
 
+  const currentStore = brandStoresList.find((store) => store.id === id);
+
   useEffect(() => {
     setFilteredBrandstores(brandStoresList);
   }, [brandStoresList]);
@@ -284,30 +286,36 @@ function Navigation({
                                 </li>
                               </>
                             )}
-                            <li className="p-side-navigation__item">
-                              <NavLink
-                                className="p-side-navigation__link"
-                                to={`/admin/${id}/members`}
-                                aria-selected={sectionName === "members"}
-                              >
-                                <i className="p-icon--user-group is-light p-side-navigation__icon"></i>
-                                <span className="p-side-navigation__label">
-                                  Members
-                                </span>
-                              </NavLink>
-                            </li>
-                            <li className="p-side-navigation__item">
-                              <NavLink
-                                className="p-side-navigation__link"
-                                to={`/admin/${id}/settings`}
-                                aria-selected={sectionName === "settings"}
-                              >
-                                <i className="p-icon--settings is-light p-side-navigation__icon"></i>
-                                <span className="p-side-navigation__label">
-                                  Settings
-                                </span>
-                              </NavLink>
-                            </li>
+                            {currentStore &&
+                              currentStore.roles &&
+                              currentStore.roles.includes("admin") && (
+                                <>
+                                  <li className="p-side-navigation__item">
+                                    <NavLink
+                                      className="p-side-navigation__link"
+                                      to={`/admin/${id}/members`}
+                                      aria-selected={sectionName === "members"}
+                                    >
+                                      <i className="p-icon--user-group is-light p-side-navigation__icon"></i>
+                                      <span className="p-side-navigation__label">
+                                        Members
+                                      </span>
+                                    </NavLink>
+                                  </li>
+                                  <li className="p-side-navigation__item">
+                                    <NavLink
+                                      className="p-side-navigation__link"
+                                      to={`/admin/${id}/settings`}
+                                      aria-selected={sectionName === "settings"}
+                                    >
+                                      <i className="p-icon--settings is-light p-side-navigation__icon"></i>
+                                      <span className="p-side-navigation__label">
+                                        Settings
+                                      </span>
+                                    </NavLink>
+                                  </li>
+                                </>
+                              )}
                           </>
                         )}
                       </ul>

--- a/static/js/brand-store/components/Navigation/__tests__/Navigation.test.tsx
+++ b/static/js/brand-store/components/Navigation/__tests__/Navigation.test.tsx
@@ -2,17 +2,61 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Provider } from "react-redux";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { BrowserRouter } from "react-router-dom";
+import { RecoilRoot } from "recoil";
 import { store } from "../../../store";
 import Navigation from "../Navigation";
 
 const queryClient = new QueryClient();
 
+jest.mock("react-query", () => ({
+  ...jest.requireActual("react-query"),
+  useQuery: jest.fn().mockReturnValue({
+    data: {
+      publisher: {
+        email: "test@example.com",
+        fullname: "John Doe",
+        has_stores: true,
+        indentity_url: "https://example.com",
+        image: null,
+        is_canonical: false,
+        nickname: "johndoe",
+      },
+    },
+    isLoading: false,
+    isSuccess: true,
+  }),
+}));
+
+const mockRouterReturnValue = { id: "test-id" };
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: () => mockRouterReturnValue,
+}));
+
+jest.mock("react-redux", () => ({
+  ...jest.requireActual("react-redux"),
+  useSelector: jest.fn().mockReturnValue([
+    { id: "test-id", name: "Test store", roles: ["admin"] },
+    {
+      id: "non-admin-store",
+      name: "Non-admin store",
+      roles: ["review", "view", "access"],
+    },
+  ]),
+}));
+
 const renderComponent = (sectionName: string) => {
   render(
     <Provider store={store}>
-      <QueryClientProvider client={queryClient}>
-        <Navigation sectionName={sectionName} />
-      </QueryClientProvider>
+      <RecoilRoot>
+        <BrowserRouter>
+          <QueryClientProvider client={queryClient}>
+            <Navigation sectionName={sectionName} />
+          </QueryClientProvider>
+        </BrowserRouter>
+      </RecoilRoot>
     </Provider>
   );
 };
@@ -23,5 +67,33 @@ describe("Navigation", () => {
     expect(screen.getAllByRole("img", { name: "Snapcraft logo" })).toHaveLength(
       2
     );
+  });
+
+  test("members link is visible if user has admin role", () => {
+    mockRouterReturnValue.id = "test-id";
+    renderComponent("snaps");
+    expect(screen.getByRole("link", { name: /Members/ })).toBeInTheDocument();
+  });
+
+  test("members link is not visible if user does not have admin role", () => {
+    mockRouterReturnValue.id = "non-admin-store";
+    renderComponent("snaps");
+    expect(
+      screen.queryByRole("link", { name: /Members/ })
+    ).not.toBeInTheDocument();
+  });
+
+  test("settings link is visible if user has admin role", () => {
+    mockRouterReturnValue.id = "test-id";
+    renderComponent("snaps");
+    expect(screen.getByRole("link", { name: /Settings/ })).toBeInTheDocument();
+  });
+
+  test("settings link is not visible if user does not have admin role", () => {
+    mockRouterReturnValue.id = "non-admin-store";
+    renderComponent("snaps");
+    expect(
+      screen.queryByRole("link", { name: /Settings/ })
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done
Only show members and settings in side navigation if the user is an admin

## How to QA
- Go to https://snapcraft-io-4763.demos.haus/admin
- Choose any store that you are an admin of
- Check that you can see "Members" and "Settings" links in the side navigation
- Choose any store that you are not an admin of, e.g. Reviewer, Publisher or both
- Check that you do not see "Members" and "Settings" links in the side navigation

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-13135