### PR TITLE
chore: update URL for request track to pre-fill new forum request

### DIFF
--- a/static/js/publisher/release/components/releasesHeading.js
+++ b/static/js/publisher/release/components/releasesHeading.js
@@ -357,7 +357,7 @@ function ReleasesHeading(props) {
                     className="u-no-margin--bottom p-button--positive"
                     onClick={() =>
                       window.open(
-                        "https://forum.snapcraft.io/c/store-requests",
+                        'https://forum.snapcraft.io/new-topic?title=Create+new+track+for+"snap+name"&category=store-requests',
                         "_blank",
                       )
                     }


### PR DESCRIPTION
## Done
- Updates URL for track request to pre-fill the new topic post on forum.snapcraft.io

## How to QA
- Go to one of your tracks that does not have track guardrails (one where you can see "Request track" in the track dropdown)
- Click "Request track" and ensure you are taken to forum.snapcraft.io with the new topic request pre-filled with the title and category type

- If you have no snaps with "request track", just go to the URL and check that the fields are pre-filled