### PR TITLE
fix: Update model routes to use account ID

### DIFF
--- a/static/js/brand-store/components/Navigation/Navigation.tsx
+++ b/static/js/brand-store/components/Navigation/Navigation.tsx
@@ -260,7 +260,7 @@ function Navigation({
                               <>
                                 <li className="p-tabs__item">
                                   <NavLink
-                                    to={`/admin/${id}/models`}
+                                    to={`/admin/${brandData.data["account-id"]}/models`}
                                     className="p-side-navigation__link"
                                     aria-selected={sectionName === "models"}
                                   >
@@ -272,7 +272,7 @@ function Navigation({
                                 </li>
                                 <li className="p-tabs__item">
                                   <NavLink
-                                    to={`/admin/${id}/signing-keys`}
+                                    to={`/admin/${brandData.data["account-id"]}/signing-keys`}
                                     className="p-side-navigation__link"
                                     aria-selected={
                                       sectionName === "signing-keys"


### PR DESCRIPTION
## Done
Changed the navigation so models links use brand ID

## How to QA
- Go to https://snapcraft-io-4782.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- Check that models load
- Go to another store and check that the snaps load

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Behaviour doesn't change
