### PR TITLE
fix: Refactor models service to use account ID

### DIFF
--- a/static/js/brand-store/atoms/index.ts
+++ b/static/js/brand-store/atoms/index.ts
@@ -62,6 +62,11 @@ const publisherState = atom({
   default: null as Publisher,
 });
 
+const brandIdState = atom({
+  key: "brandId",
+  default: "",
+});
+
 export {
   brandStoresState,
   modelsListState,
@@ -73,4 +78,5 @@ export {
   signingKeysListFilterState,
   newSigningKeyState,
   publisherState,
+  brandIdState,
 };

--- a/static/js/brand-store/components/Model/CreatePolicyForm.tsx
+++ b/static/js/brand-store/components/Model/CreatePolicyForm.tsx
@@ -13,7 +13,11 @@ import { Button, Icon } from "@canonical/react-components";
 import { setPageTitle } from "../../utils";
 
 import { useSigningKeys } from "../../hooks";
-import { signingKeysListState, newSigningKeyState } from "../../atoms";
+import {
+  signingKeysListState,
+  newSigningKeyState,
+  brandIdState,
+} from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
 type Props = {
@@ -28,9 +32,10 @@ function CreatePolicyForm({
   refetchPolicies,
 }: Props): ReactNode {
   const { id, model_id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const navigate = useNavigate();
   const location = useLocation();
-  const { isLoading, isError, error, data }: any = useSigningKeys(id);
+  const { isLoading, isError, error, data }: any = useSigningKeys(brandId);
   const [signingKeys, setSigningKeys] = useRecoilState(signingKeysListState);
   const [newSigningKey, setNewSigningKey] = useRecoilState(newSigningKeyState);
   const brandStore = useRecoilValue(brandStoreState(id));
@@ -58,7 +63,7 @@ function CreatePolicyForm({
 
       setNewSigningKey({ name: "" });
 
-      return fetch(`/admin/store/${id}/models/${model_id}/policies`, {
+      return fetch(`/admin/store/${brandId}/models/${model_id}/policies`, {
         method: "POST",
         body: formData,
       });

--- a/static/js/brand-store/components/Model/Policies.tsx
+++ b/static/js/brand-store/components/Model/Policies.tsx
@@ -22,6 +22,7 @@ import {
   policiesListState,
   signingKeysListState,
   newSigningKeyState,
+  brandIdState,
 } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
@@ -31,13 +32,14 @@ import type { Policy, SigningKey } from "../../types/shared";
 
 function Policies(): ReactNode {
   const { id, model_id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const location = useLocation();
   const navigate = useNavigate();
   const { isLoading, isError, error, refetch, data }: any = usePolicies(
-    id,
+    brandId,
     model_id
   );
-  const signingKeys = useSigningKeys(id);
+  const signingKeys = useSigningKeys(brandId);
   const setPoliciesList = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(policiesListFilterState);
   const setNewSigningKey = useSetRecoilState(newSigningKeyState);

--- a/static/js/brand-store/components/Model/PoliciesTable.tsx
+++ b/static/js/brand-store/components/Model/PoliciesTable.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, SetStateAction, useState, Dispatch } from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { useParams } from "react-router-dom";
 import { format } from "date-fns";
 import { MainTable, Button, Modal, Icon } from "@canonical/react-components";
@@ -7,6 +7,7 @@ import { MainTable, Button, Modal, Icon } from "@canonical/react-components";
 import AppPagination from "../AppPagination";
 
 import { usePolicies } from "../../hooks";
+import { brandIdState } from "../../atoms";
 import { filteredPoliciesListState } from "../../selectors";
 
 import type { Policy } from "../../types/shared";
@@ -20,7 +21,8 @@ function ModelsTable({
   setShowDeletePolicyNotification,
   setShowDeletePolicyErrorNotification,
 }: Props): ReactNode {
-  const { id, model_id } = useParams();
+  const { model_id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const [policiesList, setPoliciesList] = useRecoilState(
     filteredPoliciesListState
   );
@@ -28,7 +30,7 @@ function ModelsTable({
   const [showModal, setShowModal] = useState<boolean>(false);
   const [selectedPolicy, setSelectedPolicy] = useState<number | undefined>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { refetch }: any = usePolicies(id, model_id);
+  const { refetch }: any = usePolicies(brandId, model_id);
 
   const deletePolicy = async (policyRevision: number | undefined) => {
     if (policyRevision === undefined) {
@@ -45,7 +47,7 @@ function ModelsTable({
     formData.set("csrf_token", window.CSRF_TOKEN);
 
     const response = await fetch(
-      `/admin/store/${id}/models/${model_id}/policies/${policyRevision}`,
+      `/admin/store/${brandId}/models/${model_id}/policies/${policyRevision}`,
       {
         method: "DELETE",
         body: formData,

--- a/static/js/brand-store/components/Models/CreateModelForm.tsx
+++ b/static/js/brand-store/components/Models/CreateModelForm.tsx
@@ -7,7 +7,12 @@ import randomstring from "randomstring";
 
 import { checkModelNameExists, setPageTitle } from "../../utils";
 
-import { brandStoresState, modelsListState, newModelState } from "../../atoms";
+import {
+  brandStoresState,
+  modelsListState,
+  newModelState,
+  brandIdState,
+} from "../../atoms";
 import { filteredModelsListState, brandStoreState } from "../../selectors";
 
 import type { Store, Model } from "../../types/shared";
@@ -24,6 +29,7 @@ function CreateModelForm({
   const navigate = useNavigate();
   const location = useLocation();
   const { id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const [newModel, setNewModel] = useRecoilState(newModelState);
   const stores = useRecoilState(brandStoresState);
   const currentStore = stores[0].find((store: Store) => store.id === id);
@@ -70,7 +76,7 @@ function CreateModelForm({
         ];
       });
 
-      return fetch(`/admin/store/${id}/models`, {
+      return fetch(`/admin/store/${brandId}/models`, {
         method: "POST",
         body: formData,
       });

--- a/static/js/brand-store/components/Models/Models.tsx
+++ b/static/js/brand-store/components/Models/Models.tsx
@@ -9,12 +9,12 @@ import {
 } from "react-router-dom";
 import { Row, Col, Notification, Icon } from "@canonical/react-components";
 
-import { useModels } from "../../hooks";
 import {
   modelsListFilterState,
   modelsListState,
   policiesListState,
   newModelState,
+  brandIdState,
 } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
@@ -23,15 +23,24 @@ import ModelsTable from "./ModelsTable";
 import CreateModelForm from "./CreateModelForm";
 import Navigation from "../Navigation";
 
+import { useModels } from "../../hooks";
 import { isClosedPanel, setPageTitle, getPolicies } from "../../utils";
 
 import type { Model, Policy } from "../../types/shared";
 
 function Models(): ReactNode {
   const { id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
+
+  const {
+    data: models,
+    isLoading: modelsIsLoading,
+    error: modelsError,
+    isError: modelsIsError,
+  }: any = useModels(brandId);
+
   const location = useLocation();
   const navigate = useNavigate();
-  const { isLoading, isError, error, data }: any = useModels(id);
   const setModelsList = useSetRecoilState<Array<Model>>(modelsListState);
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
   const setNewModel = useSetRecoilState(newModelState);
@@ -47,12 +56,12 @@ function Models(): ReactNode {
     : setPageTitle("Models");
 
   useEffect(() => {
-    if (!isLoading && !error) {
-      setModelsList(data);
+    if (!modelsIsLoading && !modelsError && models) {
+      setModelsList(models);
       setFilter(searchParams.get("filter") || "");
-      getPolicies(data, id, setPolicies);
+      getPolicies(models, id, setPolicies);
     }
-  }, [isLoading, error, data]);
+  }, [modelsIsLoading, modelsError, models]);
 
   return (
     <div className="l-application" role="presentation">
@@ -106,12 +115,12 @@ function Models(): ReactNode {
             </Row>
             <div className="u-fixed-width u-flex-column u-flex-grow">
               <div>
-                {isError && error && (
+                {modelsIsError && modelsError && (
                   <Notification severity="negative">
-                    Error: {error.message}
+                    Error: {modelsError.message}
                   </Notification>
                 )}
-                {isLoading ? (
+                {modelsIsLoading ? (
                   <p>
                     <Icon name="spinner" className="u-animation--spin" />
                     &nbsp;Fetching models...

--- a/static/js/brand-store/components/Navigation/Navigation.tsx
+++ b/static/js/brand-store/components/Navigation/Navigation.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, ReactNode } from "react";
 import { useSelector } from "react-redux";
-import { useSetRecoilState } from "recoil";
+import { useRecoilState } from "recoil";
 import { useParams, NavLink } from "react-router-dom";
 
 import Logo from "./Logo";
 
-import { publisherState } from "../../atoms";
+import { publisherState, brandIdState } from "../../atoms";
 import { brandStoresListSelector } from "../../selectors";
 import { useBrand, usePublisher } from "../../hooks";
 
@@ -18,18 +18,15 @@ function Navigation({
 }): ReactNode {
   const brandStoresList = useSelector(brandStoresListSelector);
   const { id } = useParams();
-  const {
-    isLoading: brandIsLoading,
-    isSuccess: brandIsSuccess,
-    data: brandData,
-  } = useBrand(id);
+  const { data: brand } = useBrand(id);
   const { data: publisherData } = usePublisher();
   const [pinSideNavigation, setPinSideNavigation] = useState<boolean>(false);
   const [collapseNavigation, setCollapseNavigation] = useState<boolean>(false);
   const [showStoreSelector, setShowStoreSelector] = useState<boolean>(false);
   const [filteredBrandStores, setFilteredBrandstores] =
     useState<Array<Store>>(brandStoresList);
-  const setPublisher = useSetRecoilState(publisherState);
+  const [publisher, setPublisher] = useRecoilState(publisherState);
+  const [brandId, setBrandId] = useRecoilState(brandIdState);
 
   const getStoreName = (id: string | undefined) => {
     if (!id) {
@@ -46,6 +43,12 @@ function Navigation({
   };
 
   const currentStore = brandStoresList.find((store) => store.id === id);
+
+  useEffect(() => {
+    if (brand) {
+      setBrandId(brand?.["account-id"]);
+    }
+  }, [brand]);
 
   useEffect(() => {
     setFilteredBrandstores(brandStoresList);
@@ -126,202 +129,193 @@ function Navigation({
                   </li>
                 </ul>
               </div>
-              {publisherData &&
-                publisherData?.publisher?.has_stores &&
-                !brandIsLoading &&
-                brandIsSuccess && (
-                  <>
-                    <div className="nav-list-separator">
-                      <hr />
-                    </div>
-                    <div className="p-side-navigation--icons hide-collapsed is-dark">
-                      <ul className="p-side-navigation__list u-no-margin--bottom">
-                        <li className="p-side-navigation__item--title p-muted-heading">
-                          <span className="p-side-navigation__link">
-                            <i className="p-icon--pods is-light p-side-navigation__icon"></i>
-                            <span className="p-side-navigation__label">
-                              My stores
-                            </span>
+              {publisher?.has_stores && (
+                <>
+                  <div className="nav-list-separator">
+                    <hr />
+                  </div>
+                  <div className="p-side-navigation--icons hide-collapsed is-dark">
+                    <ul className="p-side-navigation__list u-no-margin--bottom">
+                      <li className="p-side-navigation__item--title p-muted-heading">
+                        <span className="p-side-navigation__link">
+                          <i className="p-icon--pods is-light p-side-navigation__icon"></i>
+                          <span className="p-side-navigation__label">
+                            My stores
                           </span>
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="p-side-navigation is-dark">
-                      <ul className="p-side-navigation__list">
-                        <li className="p-side-navigation__item">
-                          <span className="p-side-navigation__link">
-                            <span className="p-side-navigation__label">
-                              <div className="store-selector">
-                                <button
-                                  className="store-selector__button u-no-margin--bottom"
-                                  onClick={() => {
-                                    setShowStoreSelector(!showStoreSelector);
-                                  }}
-                                >
-                                  {getStoreName(id)}
-                                </button>
-                                {showStoreSelector && (
-                                  <div className="store-selector__panel">
-                                    <div className="p-search-box u-no-margin--bottom">
-                                      <label
-                                        htmlFor="search-stores"
-                                        className="u-off-screen"
-                                      >
-                                        Search stores
-                                      </label>
-                                      <input
-                                        type="search"
-                                        className="p-search-box__input"
-                                        id="search-stores"
-                                        name="search-stores"
-                                        placeholder="Search"
-                                        onInput={(e) => {
-                                          const value = (
-                                            e.target as HTMLInputElement
-                                          ).value;
-
-                                          if (value.length > 0) {
-                                            setFilteredBrandstores(
-                                              brandStoresList.filter(
-                                                (store) => {
-                                                  const storeName =
-                                                    store.name.toLowerCase();
-                                                  return storeName.includes(
-                                                    value.toLowerCase()
-                                                  );
-                                                }
-                                              )
-                                            );
-                                          } else {
-                                            setFilteredBrandstores(
-                                              brandStoresList
-                                            );
-                                          }
-                                        }}
-                                      />
-                                      <button
-                                        type="reset"
-                                        className="p-search-box__reset"
-                                      >
-                                        <i className="p-icon--close">Close</i>
-                                      </button>
-                                      <button
-                                        type="submit"
-                                        className="p-search-box__button"
-                                      >
-                                        <i className="p-icon--search">Search</i>
-                                      </button>
-                                    </div>
-                                    <ul className="store-selector__list">
-                                      {filteredBrandStores.map(
-                                        (store: Store) => (
-                                          <li
-                                            key={store.id}
-                                            className="store-selector__item"
-                                          >
-                                            <NavLink
-                                              to={`/admin/${store.id}/snaps`}
-                                              onClick={() => {
-                                                setShowStoreSelector(false);
-                                              }}
-                                            >
-                                              {store.name}
-                                            </NavLink>
-                                          </li>
-                                        )
-                                      )}
-                                    </ul>
-                                  </div>
-                                )}
-                              </div>
-                            </span>
-                          </span>
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="p-side-navigation--icons hide-collapsed is-dark">
-                      <ul className="p-side-navigation__list">
-                        {sectionName && (
-                          <>
-                            <li className="p-side-navigation__item">
-                              <NavLink
-                                className="p-side-navigation__link"
-                                to={`/admin/${id}/snaps`}
-                                aria-selected={sectionName === "snaps"}
+                        </span>
+                      </li>
+                    </ul>
+                  </div>
+                  <div className="p-side-navigation is-dark">
+                    <ul className="p-side-navigation__list">
+                      <li className="p-side-navigation__item">
+                        <span className="p-side-navigation__link">
+                          <span className="p-side-navigation__label">
+                            <div className="store-selector">
+                              <button
+                                className="store-selector__button u-no-margin--bottom"
+                                onClick={() => {
+                                  setShowStoreSelector(!showStoreSelector);
+                                }}
                               >
-                                <i className="p-icon--pods is-light p-side-navigation__icon"></i>
-                                <span className="p-side-navigation__label">
-                                  Store snaps
-                                </span>
-                              </NavLink>
-                            </li>
-                            {/* If success then models and signing keys are available */}
-                            {brandData.success && !brandData.data?.Code && (
+                                {getStoreName(id)}
+                              </button>
+                              {showStoreSelector && (
+                                <div className="store-selector__panel">
+                                  <div className="p-search-box u-no-margin--bottom">
+                                    <label
+                                      htmlFor="search-stores"
+                                      className="u-off-screen"
+                                    >
+                                      Search stores
+                                    </label>
+                                    <input
+                                      type="search"
+                                      className="p-search-box__input"
+                                      id="search-stores"
+                                      name="search-stores"
+                                      placeholder="Search"
+                                      onInput={(e) => {
+                                        const value = (
+                                          e.target as HTMLInputElement
+                                        ).value;
+
+                                        if (value.length > 0) {
+                                          setFilteredBrandstores(
+                                            brandStoresList.filter((store) => {
+                                              const storeName =
+                                                store.name.toLowerCase();
+                                              return storeName.includes(
+                                                value.toLowerCase()
+                                              );
+                                            })
+                                          );
+                                        } else {
+                                          setFilteredBrandstores(
+                                            brandStoresList
+                                          );
+                                        }
+                                      }}
+                                    />
+                                    <button
+                                      type="reset"
+                                      className="p-search-box__reset"
+                                    >
+                                      <i className="p-icon--close">Close</i>
+                                    </button>
+                                    <button
+                                      type="submit"
+                                      className="p-search-box__button"
+                                    >
+                                      <i className="p-icon--search">Search</i>
+                                    </button>
+                                  </div>
+                                  <ul className="store-selector__list">
+                                    {filteredBrandStores.map((store: Store) => (
+                                      <li
+                                        key={store.id}
+                                        className="store-selector__item"
+                                      >
+                                        <NavLink
+                                          to={`/admin/${store.id}/snaps`}
+                                          onClick={() => {
+                                            setShowStoreSelector(false);
+                                          }}
+                                        >
+                                          {store.name}
+                                        </NavLink>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                </div>
+                              )}
+                            </div>
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                  </div>
+                  <div className="p-side-navigation--icons hide-collapsed is-dark">
+                    <ul className="p-side-navigation__list">
+                      {sectionName && (
+                        <>
+                          <li className="p-side-navigation__item">
+                            <NavLink
+                              className="p-side-navigation__link"
+                              to={`/admin/${id}/snaps`}
+                              aria-selected={sectionName === "snaps"}
+                            >
+                              <i className="p-icon--pods is-light p-side-navigation__icon"></i>
+                              <span className="p-side-navigation__label">
+                                Store snaps
+                              </span>
+                            </NavLink>
+                          </li>
+                          {/* If success then models and signing keys are available */}
+                          {brandId && (
+                            <>
+                              <li className="p-tabs__item">
+                                <NavLink
+                                  to={`/admin/${id}/models`}
+                                  className="p-side-navigation__link"
+                                  aria-selected={sectionName === "models"}
+                                >
+                                  <i className="p-icon--models is-light p-side-navigation__icon"></i>
+                                  <span className="p-side-navigation__label">
+                                    Models
+                                  </span>
+                                </NavLink>
+                              </li>
+                              <li className="p-tabs__item">
+                                <NavLink
+                                  to={`/admin/${id}/signing-keys`}
+                                  className="p-side-navigation__link"
+                                  aria-selected={sectionName === "signing-keys"}
+                                >
+                                  <i className="p-icon--security is-light p-side-navigation__icon"></i>
+                                  <span className="p-side-navigation__label">
+                                    Signing keys
+                                  </span>
+                                </NavLink>
+                              </li>
+                            </>
+                          )}
+                          {currentStore &&
+                            currentStore.roles &&
+                            currentStore.roles.includes("admin") && (
                               <>
-                                <li className="p-tabs__item">
+                                <li className="p-side-navigation__item">
                                   <NavLink
-                                    to={`/admin/${brandData.data["account-id"]}/models`}
                                     className="p-side-navigation__link"
-                                    aria-selected={sectionName === "models"}
+                                    to={`/admin/${id}/members`}
+                                    aria-selected={sectionName === "members"}
                                   >
-                                    <i className="p-icon--models is-light p-side-navigation__icon"></i>
+                                    <i className="p-icon--user-group is-light p-side-navigation__icon"></i>
                                     <span className="p-side-navigation__label">
-                                      Models
+                                      Members
                                     </span>
                                   </NavLink>
                                 </li>
-                                <li className="p-tabs__item">
+                                <li className="p-side-navigation__item">
                                   <NavLink
-                                    to={`/admin/${brandData.data["account-id"]}/signing-keys`}
                                     className="p-side-navigation__link"
-                                    aria-selected={
-                                      sectionName === "signing-keys"
-                                    }
+                                    to={`/admin/${id}/settings`}
+                                    aria-selected={sectionName === "settings"}
                                   >
-                                    <i className="p-icon--security is-light p-side-navigation__icon"></i>
+                                    <i className="p-icon--settings is-light p-side-navigation__icon"></i>
                                     <span className="p-side-navigation__label">
-                                      Signing keys
+                                      Settings
                                     </span>
                                   </NavLink>
                                 </li>
                               </>
                             )}
-                            {currentStore &&
-                              currentStore.roles &&
-                              currentStore.roles.includes("admin") && (
-                                <>
-                                  <li className="p-side-navigation__item">
-                                    <NavLink
-                                      className="p-side-navigation__link"
-                                      to={`/admin/${id}/members`}
-                                      aria-selected={sectionName === "members"}
-                                    >
-                                      <i className="p-icon--user-group is-light p-side-navigation__icon"></i>
-                                      <span className="p-side-navigation__label">
-                                        Members
-                                      </span>
-                                    </NavLink>
-                                  </li>
-                                  <li className="p-side-navigation__item">
-                                    <NavLink
-                                      className="p-side-navigation__link"
-                                      to={`/admin/${id}/settings`}
-                                      aria-selected={sectionName === "settings"}
-                                    >
-                                      <i className="p-icon--settings is-light p-side-navigation__icon"></i>
-                                      <span className="p-side-navigation__label">
-                                        Settings
-                                      </span>
-                                    </NavLink>
-                                  </li>
-                                </>
-                              )}
-                          </>
-                        )}
-                      </ul>
-                    </div>
-                  </>
-                )}
+                        </>
+                      )}
+                    </ul>
+                  </div>
+                </>
+              )}
               <div className="p-side-navigation--icons is-dark">
                 {publisherData && publisherData.publisher && (
                   <div className="sidenav-bottom">

--- a/static/js/brand-store/components/SigningKeys/CreateSigningKeyForm.tsx
+++ b/static/js/brand-store/components/SigningKeys/CreateSigningKeyForm.tsx
@@ -6,7 +6,11 @@ import { Input, Button, Icon } from "@canonical/react-components";
 
 import { checkSigningKeyExists, setPageTitle } from "../../utils";
 
-import { signingKeysListState, newSigningKeyState } from "../../atoms";
+import {
+  signingKeysListState,
+  newSigningKeyState,
+  brandIdState,
+} from "../../atoms";
 import { filteredSigningKeysListState, brandStoreState } from "../../selectors";
 
 import type { SigningKey } from "../../types/shared";
@@ -25,6 +29,7 @@ function CreateSigningKeyForm({
   const navigate = useNavigate();
   const location = useLocation();
   const { id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const [newSigningKey, setNewSigningKey] = useRecoilState(newSigningKeyState);
   const signingKeysList = useRecoilValue(filteredSigningKeysListState);
   const brandStore = useRecoilValue(brandStoreState(id));
@@ -69,7 +74,7 @@ function CreateSigningKeyForm({
         ];
       });
 
-      return fetch(`/admin/store/${id}/signing-keys`, {
+      return fetch(`/admin/store/${brandId}/signing-keys`, {
         method: "POST",
         body: formData,
       });

--- a/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
+++ b/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
@@ -15,6 +15,7 @@ import {
   signingKeysListFilterState,
   policiesListState,
   newSigningKeyState,
+  brandIdState,
 } from "../../atoms";
 import { brandStoreState } from "../../selectors";
 
@@ -34,9 +35,11 @@ import type { SigningKey, Policy } from "../../types/shared";
 
 function SigningKeys(): ReactNode {
   const { id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const location = useLocation();
   const navigate = useNavigate();
-  const { isLoading, isError, error, data, refetch }: any = useSigningKeys(id);
+  const { isLoading, isError, error, data, refetch }: any =
+    useSigningKeys(brandId);
   const setSigningKeysList =
     useSetRecoilState<Array<SigningKey>>(signingKeysListState);
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
@@ -54,18 +57,22 @@ function SigningKeys(): ReactNode {
     ? setPageTitle(`Signing keys in ${brandStore.name}`)
     : setPageTitle("Signing keys");
 
-  const models = useModels(id);
+  const {
+    data: models,
+    isLoading: modelsIsLoading,
+    isError: modelsIsError,
+  }: any = useModels(brandId);
 
   useEffect(() => {
     if (!isLoading && !error) {
-      setSigningKeysList(data.sort(sortByDateDescending));
+      setSigningKeysList([...data.sort(sortByDateDescending)]);
       setFilter(searchParams.get("filter") || "");
     }
   }, [isLoading, error, data]);
 
   useEffect(() => {
-    if (!models.isLoading && !models.isError) {
-      getPolicies(models.data, id, setPolicies, setEnableTableActions);
+    if (!modelsIsLoading && !modelsIsError && models) {
+      getPolicies(models, id, setPolicies, setEnableTableActions);
     }
   }, [models]);
 

--- a/static/js/brand-store/components/SigningKeys/SigningKeysTable.tsx
+++ b/static/js/brand-store/components/SigningKeys/SigningKeysTable.tsx
@@ -10,7 +10,7 @@ import DeactivateSigningKeyModal from "./DeactivateSigningKeyModal";
 import { sortByDateDescending } from "../../utils";
 
 import { filteredSigningKeysListState } from "../../selectors";
-import { signingKeysListState } from "../../atoms";
+import { signingKeysListState, brandIdState } from "../../atoms";
 
 import type { SigningKey } from "../../types/shared";
 
@@ -24,6 +24,7 @@ function SigningKeysTable({
   enableTableActions,
 }: Props): ReactNode {
   const { id } = useParams();
+  const brandId = useRecoilValue(brandIdState);
   const signingKeysList = useRecoilValue<Array<SigningKey>>(
     filteredSigningKeysListState
   );
@@ -50,7 +51,7 @@ function SigningKeysTable({
     formData.set("csrf_token", window.CSRF_TOKEN);
 
     const response = await fetch(
-      `/admin/store/${id}/signing-keys/${signingKey["sha3-384"]}`,
+      `/admin/store/${brandId}/signing-keys/${signingKey["sha3-384"]}`,
       {
         method: "DELETE",
         body: formData,

--- a/static/js/brand-store/hooks/index.ts
+++ b/static/js/brand-store/hooks/index.ts
@@ -1,87 +1,97 @@
 import { useQuery } from "react-query";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import type { AppDispatch, RootState } from "../store";
-import type { Model } from "../types/shared";
 
 export const useAppDispatch: () => AppDispatch = useDispatch;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
-export function useModels(id: string | undefined) {
-  return useQuery("models", async () => {
-    const response = await fetch(`/admin/store/${id}/models`);
-
-    if (!response.ok) {
-      throw new Error("There was a problem fetching models");
-    }
-
-    const modelsData = await response.json();
-
-    if (!modelsData.success) {
-      throw new Error(modelsData.message);
-    }
-
-    return modelsData.data.sort((a: Model, b: Model) => {
-      // Always show most recently created model first
-      return new Date(a["created-at"]) < new Date(b["created-at"]) ? 1 : -1;
-    });
-  });
-}
-
 export function usePolicies(
-  id: string | undefined,
+  brandId: string | undefined,
   modelId: string | undefined
 ) {
-  return useQuery("policies", async () => {
-    const response = await fetch(
-      `/admin/store/${id}/models/${modelId}/policies`
-    );
+  return useQuery({
+    queryKey: ["policies", brandId],
+    queryFn: async () => {
+      const response = await fetch(
+        `/admin/store/${brandId}/models/${modelId}/policies`
+      );
 
-    if (!response.ok) {
-      throw new Error("There was a problem fetching policies");
-    }
+      if (!response.ok) {
+        throw new Error("There was a problem fetching policies");
+      }
 
-    const policiesData = await response.json();
+      const policiesData = await response.json();
 
-    if (!policiesData.success) {
-      throw new Error(policiesData.message);
-    }
+      if (!policiesData.success) {
+        throw new Error(policiesData.message);
+      }
 
-    return policiesData.data;
+      return policiesData.data;
+    },
   });
 }
 
-export function useSigningKeys(id: string | undefined) {
-  return useQuery("signingKeys", async () => {
-    const response = await fetch(`/admin/store/${id}/signing-keys`);
+export function useSigningKeys(brandId: string | undefined) {
+  return useQuery({
+    queryKey: ["signingKeys", brandId],
+    queryFn: async () => {
+      const response = await fetch(`/admin/store/${brandId}/signing-keys`);
 
-    if (!response.ok) {
-      throw new Error("There was a problem fetching signing keys");
-    }
+      if (!response.ok) {
+        throw new Error("There was a problem fetching signing keys");
+      }
 
-    const signingKeysData = await response.json();
+      const signingKeysData = await response.json();
 
-    if (!signingKeysData.success) {
-      throw new Error(signingKeysData.message);
-    }
+      if (!signingKeysData.success) {
+        throw new Error(signingKeysData.message);
+      }
 
-    return signingKeysData.data;
+      return signingKeysData.data;
+    },
   });
 }
 
 export function useBrand(id: string | undefined) {
-  return useQuery("brand", async () => {
-    const response = await fetch(`/admin/store/${id}/brand`);
+  return useQuery({
+    queryKey: ["brand", id],
+    queryFn: async () => {
+      const response = await fetch(`/admin/store/${id}/brand`);
 
-    if (!response.ok) {
-      return {
-        success: false,
-        message: "Brand not found",
-      };
-    }
+      if (!response.ok) {
+        throw new Error("There was a problem fetching models");
+      }
 
-    const brand = await response.json();
+      const brandData = await response.json();
 
-    return brand;
+      if (!brandData.success) {
+        throw new Error(brandData.message);
+      }
+
+      return brandData.data;
+    },
+  });
+}
+
+export function useModels(brandId: string | undefined) {
+  return useQuery({
+    queryKey: ["models", brandId],
+    queryFn: async () => {
+      const response = await fetch(`/admin/store/${brandId}/models`);
+
+      if (!response.ok) {
+        throw new Error("There was a problem fetching models");
+      }
+
+      const modelsData = await response.json();
+
+      if (!modelsData.success) {
+        throw new Error(modelsData.message);
+      }
+
+      return modelsData.data;
+    },
+    enabled: !!brandId,
   });
 }
 


### PR DESCRIPTION
## Done
Refactored the brand store so that the model service uses the brand account ID to call the API rather than the store ID.

## How to QA
- Go to https://snapcraft-io-4783.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- Check that the models have loaded
- Go to https://snapcraft-io-4783.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/alimot_test_model_a
- Check that the model has loaded
- Go to https://snapcraft-io-4783.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models/alimot_test_model_a/policies
- Check that the polices have loaded
- Go to https://snapcraft-io-4783.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/signing-keys
- Check that the signing keys have loaded
- Go to any of your stores and check that they look and behave as expected

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-13713