### PR TITLE
fix: Cancel pending policy requests when leaving model view

### DIFF
--- a/static/js/brand-store/components/Models/Models.tsx
+++ b/static/js/brand-store/components/Models/Models.tsx
@@ -56,11 +56,18 @@ function Models(): ReactNode {
     : setPageTitle("Models");
 
   useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
     if (!modelsIsLoading && !modelsError && models) {
       setModelsList(models);
       setFilter(searchParams.get("filter") || "");
-      getPolicies(models, id, setPolicies);
+      getPolicies({ models, id, setPolicies, signal });
     }
+
+    return () => {
+      controller.abort();
+    };
   }, [modelsIsLoading, modelsError, models]);
 
   return (

--- a/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
+++ b/static/js/brand-store/components/SigningKeys/SigningKeys.tsx
@@ -71,8 +71,21 @@ function SigningKeys(): ReactNode {
   }, [isLoading, error, data]);
 
   useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
     if (!modelsIsLoading && !modelsIsError && models) {
-      getPolicies(models, id, setPolicies, setEnableTableActions);
+      getPolicies({
+        models,
+        id,
+        setPolicies,
+        signal,
+        setEnableTableActions,
+      });
+
+      return () => {
+        controller.abort();
+      };
     }
   }, [models]);
 

--- a/static/js/brand-store/utils/getPolicies.ts
+++ b/static/js/brand-store/utils/getPolicies.ts
@@ -1,14 +1,27 @@
-import type { Model } from "../types/shared";
+import { Dispatch, SetStateAction } from "react";
+import { SetterOrUpdater } from "recoil";
+import type { Model, Policy } from "../types/shared";
 
-const getPolicies = async (
-  modelsList: Array<Model>,
-  id: string | undefined,
-  setPolicies: Function,
-  setEnableTableActions?: Function
-) => {
+type Options = {
+  models: Model[];
+  id: string | undefined;
+  setPolicies: SetterOrUpdater<Policy[]>;
+  signal?: AbortSignal;
+  setEnableTableActions?: Dispatch<SetStateAction<boolean>>;
+};
+
+const getPolicies = async ({
+  models,
+  id,
+  setPolicies,
+  signal,
+  setEnableTableActions,
+}: Options) => {
   const data = await Promise.all(
-    modelsList.map((model) => {
-      return fetch(`/admin/store/${id}/models/${model.name}/policies`);
+    models.map((model) => {
+      return fetch(`/admin/store/${id}/models/${model.name}/policies`, {
+        signal,
+      });
     })
   );
 


### PR DESCRIPTION
## Done
Cancel pending requests to the policies endpoint when navigating away from the models view

## How to QA
- Go to https://snapcraft-io-4789.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- Open the network tab and see many requests to the `policies` endpoint
- Before they are all complete navigate to "Signing keys" using the side navigation
- Check that any pending requests are now showing as cancelled

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-13854