### PR TITLE
fix: add optional parameters functionality when adding a new track

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.6.1
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==4.12.2
+canonicalwebteam.store-api==4.13.2
 canonicalwebteam.launchpad==0.9.0
 canonicalwebteam.store-base==0.5.0
 django-openid-auth==0.17

--- a/static/js/publisher/release/components/TrackInfo.test.tsx
+++ b/static/js/publisher/release/components/TrackInfo.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import TrackInfo from "./TrackInfo";
+import { Tooltip } from "@canonical/react-components";
+import "@testing-library/jest-dom";
+
+describe("TrackInfo", () => {
+  it("should render null when both versionPattern and automaticPhasingPercentage are null", () => {
+    const { container } = render(
+      <TrackInfo versionPattern={null} automaticPhasingPercentage={null} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render version pattern when only versionPattern is provided", () => {
+    render(<TrackInfo versionPattern="v1.*" automaticPhasingPercentage={null} />);
+    expect(screen.getByText("Version pattern: v1.*")).toBeInTheDocument();
+  });
+
+  it("should render automatic phasing percentage when only automaticPhasingPercentage is provided", () => {
+    render(<TrackInfo versionPattern={null} automaticPhasingPercentage="88" />);
+    expect(screen.getByText("Auto. phasing %: 88")).toBeInTheDocument();
+  });
+
+  it("should render both version pattern and automatic phasing percentage when both are provided", () => {
+    render(<TrackInfo versionPattern="v1.*" automaticPhasingPercentage="88" />);
+    expect(screen.getByText("Version pattern: v1.* / Auto. phasing %: 88")).toBeInTheDocument();
+  });
+
+  it("should display the tooltip", () => {
+    render(<TrackInfo versionPattern="v1.*" automaticPhasingPercentage="88" />);
+    const tooltipIcon = document.querySelector(".p-icon--information");
+    expect(tooltipIcon).toBeInTheDocument();
+
+    render(
+      <Tooltip
+            autoAdjust
+            message={`The version pattern and the automatic phasing percentage are additional
+properties available as options when creating a new track.
+Releases will be done progressively on the track and 88% will be incremented automatically.`} children={undefined}      />
+    );
+
+    fireEvent.click(tooltipIcon!);
+
+    expect(
+      screen.getByText(/The version pattern and the automatic phasing percentage are additional/)
+    ).toBeInTheDocument();
+  });
+});

--- a/static/js/publisher/release/components/TrackInfo.tsx
+++ b/static/js/publisher/release/components/TrackInfo.tsx
@@ -1,0 +1,35 @@
+import { Tooltip } from "@canonical/react-components";
+
+type TrackInfoProps = {
+  versionPattern: string | null;
+  automaticPhasingPercentage: string | null;
+};
+
+export default function TrackInfo({
+  versionPattern,
+  automaticPhasingPercentage,
+}: TrackInfoProps) {
+
+  if (!versionPattern && !automaticPhasingPercentage) return null;
+
+  const progressiveReleases = automaticPhasingPercentage
+    ? `Releases will be done progressively on the track and ${automaticPhasingPercentage}% will be incremented automatically.`
+    : "";
+
+  return (
+    <p>
+      {versionPattern && `Version pattern: ${versionPattern}`}
+      {versionPattern && automaticPhasingPercentage && " / "}
+      {automaticPhasingPercentage &&
+        `Auto. phasing %: ${automaticPhasingPercentage}`}{" "}
+      <Tooltip
+        autoAdjust
+        message={`The version pattern and the automatic phasing percentage are additional
+properties available as options when creating a new track.
+${progressiveReleases}`}
+      >
+        <i className="p-icon--information" />
+      </Tooltip>
+    </p>
+  );
+}

--- a/static/js/publisher/release/helpers.test.js
+++ b/static/js/publisher/release/helpers.test.js
@@ -5,7 +5,7 @@ import {
   getRevisionsArchitectures,
   isSameVersion,
   jsonClone,
-  hasTrackGuardrails,
+  getTrackGuardrails,
 } from "./helpers";
 
 global.fetch = jest.fn();
@@ -115,7 +115,7 @@ describe("jsonClone", () => {
   });
 });
 
-describe("hasTrackGuardrails", () => {
+describe("getTrackGuardrails", () => {
   beforeEach(() => {
     fetch.mockClear();
   });
@@ -131,7 +131,7 @@ describe("hasTrackGuardrails", () => {
         }),
     });
 
-    const result = await hasTrackGuardrails("test-snap");
+    const result = await getTrackGuardrails("test-snap");
     expect(result).toStrictEqual({ "track-guardrails": ["example-guardrail"] });
   });
 
@@ -146,7 +146,7 @@ describe("hasTrackGuardrails", () => {
         }),
     });
 
-    const result = await hasTrackGuardrails("test-snap");
+    const result = await getTrackGuardrails("test-snap");
     expect(result).toStrictEqual({ "track-guardrails": [] });
   });
 });

--- a/static/js/publisher/release/helpers.ts
+++ b/static/js/publisher/release/helpers.ts
@@ -156,7 +156,7 @@ export function numericalSort(a: string, b: string) {
   return a.localeCompare(b);
 }
 
-export async function hasTrackGuardrails(snap: string) {
+export async function getPackageMetadata(snap: string) {
   const url = `/api/packages/${snap}`;
   try {
     const response = await fetch(url, {
@@ -170,8 +170,13 @@ export async function hasTrackGuardrails(snap: string) {
       throw new Error("There was a problem fetching the snap's metadata");
     }
     const data = await response.json();
-    return { "track-guardrails": data.data["track-guardrails"] };
+    return data.data;
   } catch (e) {
     return { "error": e };
   }
+}
+
+export async function getTrackGuardrails(snap: string) {
+  const snapMetadata: any = await getPackageMetadata(snap);
+  return { "track-guardrails": snapMetadata["track-guardrails"] };
 }

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -341,8 +341,20 @@ def store_blueprint(store_query=None):
     @exchange_required
     def post_create_track(snap_name):
         track_name = flask.request.form["track-name"]
+        version_pattern = flask.request.form["version-pattern"]
+        auto_phasing_percentage = flask.request.form[
+            "automatic-phasing-percentage"
+        ]
+
+        if auto_phasing_percentage:
+            auto_phasing_percentage = float(auto_phasing_percentage)
+
         response = publisher_api.create_track(
-            flask.session, snap_name, track_name
+            flask.session,
+            snap_name,
+            track_name,
+            version_pattern,
+            auto_phasing_percentage,
         )
         if response.status_code == 201:
             return response.json(), response.status_code


### PR DESCRIPTION
## Done
- Enables Version pattern and Automatic phasing percentage parameters when adding a new track
- Shows a track's version pattern and/or auto phasing percentage (if they have them)

## How to QA
- Go to [`fran-snap/releases`](https://snapcraft-io-4796.demos.haus/fran-snap/releases)
- The following tracks have version patterns or phasing percentages to QA:
    - v.09
    - v.101
    - v.102
    - v.104
- You can also create a new track on `fran-snap`, adding in your own version pattern and phasing percentage, then verify this information is displayed when you switch to this track

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-13857](https://warthogs.atlassian.net/browse/WD-13857)

[WD-13857]: https://warthogs.atlassian.net/browse/WD-13857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ