### PR TITLE
feat: Create validation sets endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.6.1
 canonicalwebteam.blog==6.4.2
 canonicalwebteam.search==1.3.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.store-api==4.12.2
+canonicalwebteam.store-api==4.14.0
 canonicalwebteam.launchpad==0.9.0
 canonicalwebteam.store-base==0.5.0
 django-openid-auth==0.17

--- a/tests/store/tests_validation_sets.py
+++ b/tests/store/tests_validation_sets.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+
+class GetValidationSetsTest:
+    @patch("webapp.store.get_validation_sets")
+    def test_get_validation_sets(self, mock_get_validation_sets):
+        mock_get_validation_sets.return_value = {"assertions": []}
+        response = self.client.get("/api/validation-sets")
+        data = response.json
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(data["data"])
+
+    @patch("webapp.store.get_validation_set")
+    def test_get_validation_set(self, mock_get_validation_set):
+        mock_get_validation_set.return_value = {"assertions": []}
+        response = self.client.get("/api/validation-sets/validation-set-id")
+        data = response.json
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(data["data"])


### PR DESCRIPTION
## Done
Added endpoints for validation sets

## How to QA
- Go to https://snapcraft-io-4802.demos.haus/api/validation-sets
- Check that there is a JSON response with `success` as `true` and `data` as `[]`
- Go to https://snapcraft-io-4802.demos.haus/api/validation-sets/test-set-id
- Check that there is a JSON response with `success` as `true` and `data` as `{}`

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-14110
Fixes https://warthogs.atlassian.net/browse/WD-14111