### PR TITLE
fix: Use ApplicationLayout component for validation sets

### DIFF
--- a/static/js/validation-sets/components/Logo/Logo.tsx
+++ b/static/js/validation-sets/components/Logo/Logo.tsx
@@ -1,0 +1,16 @@
+function Logo(): JSX.Element {
+  return (
+    <a href="/" className="p-panel__logo tag-logo">
+      <img
+        src="https://assets.ubuntu.com/v1/dae35907-Snapcraft%20tag.svg"
+        alt="Snapcraft"
+        className="p-panel__logo-image"
+      />
+      <div className="logo-text p-heading--4 is-fading-when-collapsed">
+        Snapcraft
+      </div>
+    </a>
+  );
+}
+
+export default Logo;

--- a/static/js/validation-sets/components/Logo/index.ts
+++ b/static/js/validation-sets/components/Logo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Logo";

--- a/static/js/validation-sets/components/PrimaryNav/PrimaryNav.tsx
+++ b/static/js/validation-sets/components/PrimaryNav/PrimaryNav.tsx
@@ -1,0 +1,94 @@
+import {
+  SideNavigation,
+  SideNavigationText,
+} from "@canonical/react-components";
+
+import { usePublisher } from "../../../brand-store/hooks";
+
+function PrimaryNav({
+  collapseNavigation,
+  setCollapseNavigation,
+}: {
+  collapseNavigation: boolean;
+  setCollapseNavigation: Function;
+}): JSX.Element {
+  const { data: publisherData } = usePublisher();
+
+  return (
+    <>
+      <SideNavigation
+        className="hide-collapsed"
+        dark={true}
+        items={[
+          {
+            items: [
+              <div className="nav-list-separator">
+                <hr />
+              </div>,
+              <SideNavigationText>
+                <div
+                  className="p-side-navigation__item--title p-muted-heading"
+                  style={{ color: "#a8a8a8" }}
+                >
+                  My snaps
+                </div>
+              </SideNavigationText>,
+              ,
+              {
+                label: "Overview",
+                href: "/snaps",
+                icon: "pods",
+              },
+              {
+                label: "My validation sets",
+                href: "/validation-sets",
+                icon: "pods",
+                "aria-current": "page",
+              },
+            ],
+          },
+        ]}
+      />
+
+      {publisherData && publisherData.publisher && (
+        <div className="p-side-navigation--icons is-dark">
+          <div className="sidenav-bottom">
+            <div className="nav-list-separator">
+              <hr />
+            </div>
+            <ul className="p-side-navigation__list">
+              <li className="p-side-navigation__item">
+                <a href="/admin/account" className="p-side-navigation__link">
+                  <i className="p-icon--user is-light p-side-navigation__icon"></i>
+                  <span className="p-side-navigation__label">
+                    {publisherData.publisher.fullname}
+                  </span>
+                </a>
+              </li>
+              <li className="p-side-navigation__item">
+                <a href="/logout" className="p-side-navigation__link">
+                  <i className="p-icon--begin-downloading is-light p-side-navigation__icon"></i>
+                  <span className="p-side-navigation__label">Logout</span>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      )}
+
+      <div className="sidenav-toggle-wrapper u-hide--small u-hide--medium">
+        <button
+          className="p-button--base has-icon is-dense sidenav-toggle is-dark u-no-margin l-navigation-collapse-toggle "
+          aria-label={`${collapseNavigation ? "Collapse" : "Expand"} main navigation`}
+          onClick={() => {
+            setCollapseNavigation(!collapseNavigation);
+          }}
+        >
+          <i className="p-icon--sidebar-toggle is-light"></i>
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default PrimaryNav;

--- a/static/js/validation-sets/components/PrimaryNav/index.ts
+++ b/static/js/validation-sets/components/PrimaryNav/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PrimaryNav";

--- a/static/js/validation-sets/routes/root.tsx
+++ b/static/js/validation-sets/routes/root.tsx
@@ -1,156 +1,40 @@
 import { useState } from "react";
 import { Outlet } from "react-router-dom";
-import { Row, Col } from "@canonical/react-components";
+import {
+  ApplicationLayout,
+  Panel,
+  Row,
+  Col,
+} from "@canonical/react-components";
 
-import Logo from "../../brand-store/components/Navigation/Logo";
-
-import { usePublisher } from "../../brand-store/hooks";
+import Logo from "../components/Logo";
+import PrimaryNav from "../components/PrimaryNav";
 
 function Root(): JSX.Element {
-  const { data: publisherData } = usePublisher();
-  const [pinSideNavigation, setPinSideNavigation] = useState<boolean>(false);
   const [collapseNavigation, setCollapseNavigation] = useState<boolean>(false);
 
   return (
-    <div className="l-application">
-      <header className="l-navigation-bar">
-        <div className="p-panel is-dark">
-          <div className="p-panel__header">
-            <Logo />
-            <div className="p-panel__controls">
-              <button
-                className="p-panel__toggle u-no-margin--bottom"
-                onClick={() => {
-                  setCollapseNavigation(!collapseNavigation);
-                }}
-              >
-                Menu
-              </button>
-            </div>
-          </div>
-        </div>
-      </header>
-
-      <nav
-        className={`l-navigation ${collapseNavigation ? "is-collapsed" : ""} ${pinSideNavigation ? "is-pinned" : ""}`}
-      >
-        <div className="l-navigation__drawer">
-          <div className="p-panel is-dark">
-            <div className="p-panel__header is-sticky">
-              <Logo />
-              <div className="p-panel__controls">
-                {pinSideNavigation && (
-                  <button
-                    className="p-button--base is-dark has-icon u-no-margin u-hide--small u-hide--large"
-                    onClick={() => {
-                      setPinSideNavigation(false);
-                    }}
-                  >
-                    <i className="is-light p-icon--close"></i>
-                  </button>
-                )}
-
-                {!pinSideNavigation && (
-                  <button
-                    className="p-button--base is-dark has-icon u-no-margin u-hide--small u-hide--large"
-                    onClick={() => {
-                      setPinSideNavigation(true);
-                    }}
-                  >
-                    <i className="is-light p-icon--pin"></i>
-                  </button>
-                )}
-              </div>
-            </div>
-            <div className="p-panel__content">
-              <div className="nav-list-separator">
-                <hr />
-              </div>
-              <div className="p-side-navigation--icons hide-collapsed is-dark">
-                <ul className="p-side-navigation__list">
-                  <li className="p-side-navigation__item--title p-muted-heading">
-                    <span className="p-side-navigation__link">
-                      <span className="p-side-navigation__label">My snaps</span>
-                    </span>
-                  </li>
-                  <li className="p-side-navigation__item">
-                    <a className="p-side-navigation__link" href="/snaps">
-                      <i className="p-icon--pods is-light p-side-navigation__icon"></i>
-                      <span className="p-side-navigation__label">Overview</span>
-                    </a>
-                  </li>
-                  <li className="p-side-navigation__item">
-                    <a
-                      className="p-side-navigation__link"
-                      href="/validation-sets"
-                      aria-current="page"
-                    >
-                      <i className="p-icon--pods is-light p-side-navigation__icon"></i>
-                      <span className="p-side-navigation__label">
-                        My validation sets
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-              <div className="p-side-navigation--icons is-dark">
-                {publisherData && publisherData.publisher && (
-                  <div className="sidenav-bottom">
-                    <div className="nav-list-separator">
-                      <hr />
-                    </div>
-                    <ul className="p-side-navigation__list">
-                      <li className="p-side-navigation__item">
-                        <a
-                          href="/admin/account"
-                          className="p-side-navigation__link"
-                        >
-                          <i className="p-icon--user is-light p-side-navigation__icon"></i>
-                          <span className="p-side-navigation__label">
-                            {publisherData.publisher.fullname}
-                          </span>
-                        </a>
-                      </li>
-                      <li className="p-side-navigation__item">
-                        <a href="/logout" className="p-side-navigation__link">
-                          <i className="p-icon--begin-downloading is-light p-side-navigation__icon"></i>
-                          <span className="p-side-navigation__label">
-                            Logout
-                          </span>
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
-                )}
-              </div>
-            </div>
-            <div className="sidenav-toggle-wrapper u-hide--small u-hide--medium">
-              <button
-                className="p-button--base has-icon is-dense sidenav-toggle is-dark u-no-margin l-navigation-collapse-toggle u-hide--small"
-                aria-label={`${collapseNavigation ? "Collapse" : "Expand"} main navigation`}
-                onClick={() => {
-                  setCollapseNavigation(!collapseNavigation);
-                }}
-              >
-                <i className="p-icon--sidebar-toggle is-light"></i>
-              </button>
-            </div>
-          </div>
-        </div>
-      </nav>
-
-      <main className="l-main">
-        <div className="p-panel">
-          <div className="p-panel__content">
-            <Row>
-              <Col size={12}>
-                <Outlet />
-              </Col>
-            </Row>
-          </div>
-        </div>
-      </main>
-    </div>
+    <ApplicationLayout
+      menuCollapsed={collapseNavigation}
+      onCollapseMenu={setCollapseNavigation}
+      logo={<Logo />}
+      sideNavigation={
+        <PrimaryNav
+          collapseNavigation={collapseNavigation}
+          setCollapseNavigation={setCollapseNavigation}
+        />
+      }
+    >
+      <div id="main-content">
+        <Panel>
+          <Row>
+            <Col size={12}>
+              <Outlet />
+            </Col>
+          </Row>
+        </Panel>
+      </div>
+    </ApplicationLayout>
   );
 }
 


### PR DESCRIPTION
## Done
Refactored validation sets to use `ApplicationLayout` from [React Components](https://canonical.github.io/react-components/?path=/docs/components-applicationlayout--docs)

## How to QA
- Go to https://snapcraft-io-4817.demos.haus/validation-sets
- Compare layout to https://snapcraft.io/validation-sets

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Layout component change
