### PR TITLE
feat:add missing csp

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -83,6 +83,7 @@ CSP = {
         "stats.g.doubleclick.net",
         "www.googletagmanager.com",
         "sentry.is.canonical.com",
+        "www.google-analytics.com",
     ],
     "frame-src": [
         "'self'",
@@ -105,6 +106,8 @@ CSP_SCRIPT_SRC_ELEM = [
     "www.youtube.com",
     "asciinema.org",
     "player.vimeo.com",
+    "plausible.io",
+    "script.crazyegg.com",
     "'unsafe-hashes'",
 ]
 


### PR DESCRIPTION
## Done
- Added missing csp that are used in the production

## How to QA
- Go to [HTTP header analyzer](https://dri.es/headers?url=https%3A%2F%2Fsnapcraft-io-4829.demos.haus%2F)
- Verify CSP header isnt missing
- Go to https://snapcraft-io-4829.demos.haus/
- Verify all the images, videos, resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)

## Testing
- [ ] This PR has tests
- [x ] No testing required (explain why): added security header

## Issue / Card
Fixes [#14413](https://warthogs.atlassian.net/browse/WD-14413)

## Screenshots
