### PR TITLE
feat: add missing csp Part 2

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -70,7 +70,18 @@ CSP = {
         # https://www.google.*/ads/ga-audiences to load.
         "*",
     ],
-    "script-src-elem": [],
+    "script-src-elem": [
+        "'self'",
+        "assets.ubuntu.com",
+        "www.googletagmanager.com",
+        "www.youtube.com",
+        "asciinema.org",
+        "player.vimeo.com",
+        "plausible.io",
+        "script.crazyegg.com",
+        # This is necessary for Google Tag Manager to function properly.
+        "'unsafe-inline'",
+    ],
     "font-src": [
         "'self'",
         "assets.ubuntu.com",
@@ -84,6 +95,8 @@ CSP = {
         "www.googletagmanager.com",
         "sentry.is.canonical.com",
         "www.google-analytics.com",
+        "plausible.io",
+        "script.crazyegg.com",
     ],
     "frame-src": [
         "'self'",
@@ -98,18 +111,6 @@ CSP = {
         "'unsafe-inline'",
     ],
 }
-
-CSP_SCRIPT_SRC_ELEM = [
-    "'self'",
-    "assets.ubuntu.com",
-    "www.googletagmanager.com",
-    "www.youtube.com",
-    "asciinema.org",
-    "player.vimeo.com",
-    "plausible.io",
-    "script.crazyegg.com",
-    "'unsafe-hashes'",
-]
 
 CSP_SCRIPT_SRC = [
     "'self'",
@@ -357,9 +358,6 @@ def set_handlers(app):
             "utf-8", errors="replace"
         )
 
-        CSP["script-src-elem"] = CSP_SCRIPT_SRC_ELEM + get_csp_directive(
-            decoded_content, r"<script>([\s\S]*?)<\/script>"
-        )
         CSP["script-src"] = CSP_SCRIPT_SRC + get_csp_directive(
             decoded_content, r'onclick\s*=\s*"(.*?)"'
         )


### PR DESCRIPTION
## Done
- Added missing csp that are used in the production

## How to QA
- Go to [HTTP header analyzer](https://dri.es/headers?url=https%3A%2F%2Fsnapcraft-io-4830.demos.haus%2F)
- Verify CSP header isnt missing
- Go to https://snapcraft-io-4830.demos.haus/
- Verify all the images, videos, resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): added security header

## Issue / Card
Fixes [#14413](https://warthogs.atlassian.net/browse/WD-14413)

## Screenshots
