### PR TITLE
feat:add missing csp - Part 3

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -79,6 +79,8 @@ CSP = {
         "player.vimeo.com",
         "plausible.io",
         "script.crazyegg.com",
+        "w.usabilla.com",
+        "connect.facebook.net",
         # This is necessary for Google Tag Manager to function properly.
         "'unsafe-inline'",
     ],
@@ -114,6 +116,7 @@ CSP = {
 
 CSP_SCRIPT_SRC = [
     "'self'",
+    "blob:",
     "'unsafe-eval'",
     "'unsafe-hashes'",
 ]


### PR DESCRIPTION
## Done
- Added missing csp that are used in the production

## How to QA
- Go to [HTTP header analyzer](https://dri.es/headers?url=https%3A%2F%2Fsnapcraft-io-4831.demos.haus%2F)
- Verify CSP header isnt missing
- Go to https://snapcraft-io-4831.demos.haus/
- Verify all the images, videos, resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): added security header

## Issue / Card
Fixes [#14413](https://warthogs.atlassian.net/browse/WD-14413)

## Screenshots
