### PR TITLE
chore: Add validation sets link to logged in navigation

### DIFF
--- a/templates/_header.html
+++ b/templates/_header.html
@@ -96,6 +96,9 @@
                     <li>
                       <a href="/account/snaps" class="p-navigation__dropdown-item">My published snaps</a>
                     </li>
+                    <li>
+                      <a href="/validation-sets" class="p-navigation__dropdown-item">Validation sets</a>
+                    </li>
                     <li class="js-nav-account--stores u-hide">
                       <a href="/admin" class="p-navigation__dropdown-item">My stores</a>
                     </li>


### PR DESCRIPTION
## Done
Added a link to validation sets to the logged in menu

## How to QA
- Go to https://snapcraft-io-4832.demos.haus/
- Log in
- Check that there is a link to validation sets in the account dropdown menu (top right of nav)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Adding a link

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-14117