### PR TITLE
feat:add missing csp - Part 4

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -98,7 +98,7 @@ CSP = {
         "sentry.is.canonical.com",
         "www.google-analytics.com",
         "plausible.io",
-        "script.crazyegg.com",
+        "*.crazyegg.com",
     ],
     "frame-src": [
         "'self'",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -81,6 +81,7 @@ CSP = {
         "script.crazyegg.com",
         "w.usabilla.com",
         "connect.facebook.net",
+        "snap.licdn.com",
         # This is necessary for Google Tag Manager to function properly.
         "'unsafe-inline'",
     ],
@@ -107,6 +108,8 @@ CSP = {
         "asciinema.org",
         "player.vimeo.com",
         "snapcraft.io",
+        "www.facebook.com",
+        "snap:",
     ],
     "style-src": [
         "'self'",


### PR DESCRIPTION
## Done
- Added missing csp that are used in the production

## How to QA
- Go to [HTTP header analyzer](https://dri.es/headers?url=https%3A%2F%2Fsnapcraft-io-4833.demos.haus%2F)
- Verify CSP header isnt missing
- Go to https://snapcraft-io-4833.demos.haus/
- Verify all the images, videos, resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): added security header

## Issue / Card
Fixes [#14413](https://warthogs.atlassian.net/browse/WD-14413)

## Screenshots
