### PR TITLE
feat:add missing csp Part 5

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -100,6 +100,8 @@ CSP = {
         "www.google-analytics.com",
         "plausible.io",
         "*.crazyegg.com",
+        "www.facebook.com",
+        "px.ads.linkedin.com"
     ],
     "frame-src": [
         "'self'",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -101,7 +101,7 @@ CSP = {
         "plausible.io",
         "*.crazyegg.com",
         "www.facebook.com",
-        "px.ads.linkedin.com"
+        "px.ads.linkedin.com",
     ],
     "frame-src": [
         "'self'",


### PR DESCRIPTION
## Done
- Added missing csp that are used in the production

## How to QA
- Go to [HTTP header analyzer](https://dri.es/headers?url=https%3A%2F%2Fsnapcraft-io-4835.demos.haus%2F)
- Verify CSP header isnt missing
- Go to https://snapcraft-io-4835.demos.haus/
- Verify all the images, videos, resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): added security header

## Issue / Card
Fixes [#14413](https://warthogs.atlassian.net/browse/WD-14413)

## Screenshots
