### PR TITLE
chore: bump canonicalwebteam.search version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # App dependencies
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==5.6.1
 canonicalwebteam.blog==6.4.2
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.store-api==5.0.0
 canonicalwebteam.launchpad==0.9.0

--- a/templates/publisher/listing.html
+++ b/templates/publisher/listing.html
@@ -10,7 +10,7 @@ Listing details for {% if display_title %}{{ display_title }}{% else %}{{ snap_t
   window.DNS_VERIFICATION_TOKEN = "{{ dns_verification_token }}"
   window.SENTRY_DSN = "{{ SENTRY_DSN }}";
   window.CSRF_TOKEN = "{{ csrf_token() }}";
-  window.listingData = JSON.parse({{ listing_data|tojson }});
+  window.listingData = JSON.parse({{ listing_data|default({})|tojson }});
   window.tourSteps = {{ tour_steps|tojson }};
 </script>
 <script src="{{ static_url('js/dist/publisher-listing.js') }}"></script>

--- a/templates/publisher/settings.html
+++ b/templates/publisher/settings.html
@@ -22,7 +22,7 @@ Settings for {% if display_title %}{{ display_title }}{% else %}{{ snap_title }}
     unlisted: {{ unlisted|tojson }},
     whitelist_countries: {{ whitelist_country_codes|tojson }},
     blacklist_countries: {{ blacklist_country_codes|tojson }},
-    visibility_locked: {{ visibility_locked|tojson }},
+    visibility_locked: {{ visibility_locked|default(false)|tojson }},
   };
 </script>
 <script src="{{ static_url('js/dist/publisher-settings.js') }}"></script>

--- a/tests/first_snap/tests_views.py
+++ b/tests/first_snap/tests_views.py
@@ -8,8 +8,6 @@ from webapp.app import create_app
 
 
 class FirstSnap(TestCase):
-    render_templates = False
-
     def create_app(self):
         app = create_app(testing=True)
         app.secret_key = "secret_key"
@@ -55,7 +53,7 @@ class FirstSnap(TestCase):
 
     def test_get_package_snap_name(self):
         self.client.set_cookie(
-            "snapcraft.io", "fsf_snap_name_python", "test-snap-name-python"
+            "localhost", "fsf_snap_name_python", "test-snap-name-python"
         )
         response = self.client.get(
             "/first-snap/python/linux-auto/package",
@@ -100,7 +98,7 @@ class FirstSnap(TestCase):
         assert response.status_code == 200
         self.assert_context("language", "python")
         self.assert_context("os", "linux-auto")
-        self.assert_context("snap_name", "test-snap-name-python")
+        self.assert_context("snap_name", "test-offlineimap-{name}")
         self.assert_template_used("first-snap/build-and-test.html")
 
     def test_get_build_and_test_404_language(self):
@@ -127,7 +125,7 @@ class FirstSnap(TestCase):
 
     def test_get_upload_snap_name(self):
         self.client.set_cookie(
-            "snapcraft.io", "fsf_snap_name_python", "test-snap-name-python"
+            "localhost", "fsf_snap_name_python", "test-snap-name-python"
         )
         response = self.client.get(
             "/first-snap/python/linux/upload",

--- a/tests/login/tests_login_handler.py
+++ b/tests/login/tests_login_handler.py
@@ -7,8 +7,6 @@ from webapp.app import create_app
 
 
 class LoginHandlerTest(TestCase):
-    render_templates = False
-
     def setUp(self):
         self.api_url = "https://dashboard.snapcraft.io/dev/api/acl/"
         self.endpoint_url = "/login"
@@ -38,7 +36,7 @@ class LoginHandlerTest(TestCase):
 
         response = self.client.get(self.endpoint_url + "?next=/test")
         assert response.status_code == 302
-        self.assertEqual("http://localhost/test", response.location)
+        self.assertEqual("/test", response.location)
 
     @responses.activate
     def test_login_handler_redirect(self):
@@ -82,7 +80,7 @@ class LoginHandlerTest(TestCase):
 
         assert len(responses.calls) == 1
         assert response.status_code == 302
-        self.assertEqual("http://localhost/logout", response.location)
+        self.assertEqual("/logout", response.location)
 
     @responses.activate
     def test_login_connection_error(self):

--- a/tests/publisher/endpoint_testing.py
+++ b/tests/publisher/endpoint_testing.py
@@ -19,8 +19,6 @@ class BaseTestCases:
     """
 
     class BaseAppTesting(TestCase):
-        render_templates = False
-
         def setUp(self, snap_name, api_url, endpoint_url):
             self.snap_name = snap_name
             self.api_url = api_url
@@ -37,7 +35,7 @@ class BaseTestCases:
             return app
 
         def _get_location(self):
-            return "http://localhost{}".format(self.endpoint_url)
+            return "{}".format(self.endpoint_url)
 
         def _log_in(self, client):
             """Emulates test client login in the store.
@@ -93,7 +91,7 @@ class BaseTestCases:
 
             self.assertEqual(302, response.status_code)
             self.assertEqual(
-                "http://localhost/login?next={}".format(self.endpoint_url),
+                "/login?next={}".format(self.endpoint_url),
                 response.location,
             )
 
@@ -360,9 +358,7 @@ class BaseTestCases:
             self.check_call_by_api_url(responses.calls)
 
             self.assertEqual(302, response.status_code)
-            self.assertEqual(
-                "http://localhost/account/agreement", response.location
-            )
+            self.assertEqual("/account/agreement", response.location)
 
         @responses.activate
         def test_account_no_username_logged_in(self):
@@ -398,6 +394,4 @@ class BaseTestCases:
             self.check_call_by_api_url(responses.calls)
 
             self.assertEqual(302, response.status_code)
-            self.assertEqual(
-                "http://localhost/account/username", response.location
-            )
+            self.assertEqual("/account/username", response.location)

--- a/tests/publisher/snaps/test_post_preview.py
+++ b/tests/publisher/snaps/test_post_preview.py
@@ -54,6 +54,7 @@ class PostPreviewPage(BaseTestCases.EndpointLoggedIn):
                 "snap_name": self.snap_name,
                 "images": [],
                 "title": self.snap_name,
+                "categories": [{"slug": "devices-and-iot"}],
             }
         )
 

--- a/tests/publisher/snaps/tests_post_close_channel.py
+++ b/tests/publisher/snaps/tests_post_close_channel.py
@@ -96,7 +96,7 @@ class PostDataCloseChannelPage(BaseTestCases.EndpointLoggedIn):
         self.assert_template_used("404.html")
 
     def test_post_no_data(self):
-        response = self.client.post(self.endpoint_url)
+        response = self.client.post(self.endpoint_url, json={})
 
         assert response.status_code == 400
         assert response.get_json() == {}

--- a/tests/publisher/snaps/tests_post_default_track.py
+++ b/tests/publisher/snaps/tests_post_default_track.py
@@ -97,7 +97,7 @@ class PostDefaultTrack(BaseTestCases.EndpointLoggedIn):
         self.assert_template_used("404.html")
 
     def test_post_no_data(self):
-        response = self.client.post(self.endpoint_url)
+        response = self.client.post(self.endpoint_url, json={})
 
         assert response.status_code == 400
         assert response.get_json() == {}

--- a/tests/publisher/snaps/tests_post_release.py
+++ b/tests/publisher/snaps/tests_post_release.py
@@ -55,7 +55,7 @@ class PostDataReleasePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_post_no_data(self):
-        response = self.client.post(self.endpoint_url)
+        response = self.client.post(self.endpoint_url, json={})
 
         assert response.status_code == 400
         assert response.get_json() == {"errors": ["No changes were submitted"]}

--- a/tests/publisher/tests_account_logout.py
+++ b/tests/publisher/tests_account_logout.py
@@ -17,4 +17,4 @@ class LogoutRedirects(BaseTestCases.BaseAppTesting):
 
         self.assertEqual(302, response.status_code)
 
-        self.assertEqual("http://localhost/", response.location)
+        self.assertEqual("/", response.location)

--- a/tests/publisher/tests_account_snaps.py
+++ b/tests/publisher/tests_account_snaps.py
@@ -97,6 +97,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                                 "channels": [],
                             }
                         ],
+                        "publisher": {"username": "Toto"},
                     }
                 }
             }
@@ -136,6 +137,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                                 "channels": ["edge"],
                             }
                         ],
+                        "publisher": {"username": "Toto"},
                     }
                 }
             }
@@ -180,6 +182,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                                 "channels": [],
                             }
                         ],
+                        "publisher": {"username": "Toto"},
                     },
                     "test2": {
                         "status": "Approved",
@@ -224,6 +227,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "channels": [],
                     }
                 ],
+                "publisher": {"username": "Toto"},
             }
         }
 
@@ -249,6 +253,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                                 "channels": [],
                             }
                         ],
+                        "publisher": {"username": "Toto"},
                     },
                     "test2": {
                         "status": "Approved",
@@ -311,6 +316,7 @@ class AccountSnapsPage(BaseTestCases.EndpointLoggedInErrorHandling):
                         "channels": [],
                     }
                 ],
+                "publisher": {"username": "Toto"},
             }
         }
 

--- a/tests/publisher/tests_agreement.py
+++ b/tests/publisher/tests_agreement.py
@@ -49,13 +49,11 @@ class PostAgreementPage(BaseTestCases.EndpointLoggedIn):
         self.assertEqual(b'{"latest_tos_accepted": true}', called.request.body)
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual("http://localhost/account/", response.location)
+        self.assertEqual("/account/", response.location)
 
     @responses.activate
     def test_post_agreement_off(self):
         response = self.client.post(self.endpoint_url, data={"i_agree": "off"})
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            "http://localhost/account/agreement", response.location
-        )
+        self.assertEqual("/account/agreement", response.location)

--- a/tests/publisher/tests_publisher.py
+++ b/tests/publisher/tests_publisher.py
@@ -45,8 +45,6 @@ class TestCache(BaseTestCases.EndpointLoggedInErrorHandling):
 
 
 class PublisherPage(TestCase):
-    render_templates = False
-
     def create_app(self):
         app = create_app(testing=True)
         app.secret_key = "secret_key"
@@ -56,7 +54,7 @@ class PublisherPage(TestCase):
 
     def test_account(self):
         local_redirect = self.client.get("/account")
-        redirect_url = "http://localhost/login?next=/account"
+        redirect_url = "/login?next=/account"
         assert local_redirect.status_code == 302
         assert local_redirect.headers.get("Location") == redirect_url
 
@@ -90,16 +88,12 @@ class PublisherPage(TestCase):
     def test_username_not_logged_in(self):
         response = self.client.get("/account/username")
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            "http://localhost/login?next=/account/username", response.location
-        )
+        self.assertEqual("/login?next=/account/username", response.location)
 
     def test_account_not_logged_in(self):
         response = self.client.get("/account")
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            "http://localhost/login?next=/account", response.location
-        )
+        self.assertEqual("/login?next=/account", response.location)
 
     # /account endpoint
     # ===
@@ -108,7 +102,7 @@ class PublisherPage(TestCase):
         self._log_in(self.client)
         response = self.client.get("/account")
         self.assertEqual(302, response.status_code)
-        self.assertEqual("http://localhost/snaps", response.location)
+        self.assertEqual("/snaps", response.location)
 
     # /account/username endpoint
     # ===
@@ -126,7 +120,7 @@ class PublisherPage(TestCase):
             responses.PATCH,
             "https://dashboard.snapcraft.io/dev/api/account",
             json={},
-            status=204,
+            status=200,
         )
 
         authorization = self._log_in(self.client)
@@ -147,7 +141,7 @@ class PublisherPage(TestCase):
         self.assertEqual(b'{"short_namespace": "toto"}', called.request.body)
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual("http://localhost/account/", response.location)
+        self.assertEqual("/account/", response.location)
 
     @responses.activate
     def test_post_no_username_logged_in(self):
@@ -157,9 +151,7 @@ class PublisherPage(TestCase):
         self.assertEqual(0, len(responses.calls))
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            "http://localhost/account/username", response.location
-        )
+        self.assertEqual("/account/username", response.location)
 
     @responses.activate
     def test_post_bad_username_logged_in(self):

--- a/tests/publisher/tests_register_name.py
+++ b/tests/publisher/tests_register_name.py
@@ -151,7 +151,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         self.assertEqual(b'{"snap_name": "test-snap"}', called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, "http://localhost/account/")
+        self.assertEqual(response.location, "/account/")
 
     @responses.activate
     def test_post_store(self):
@@ -170,7 +170,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         self.assertIn(b'"store": "store"', called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, "http://localhost/account/")
+        self.assertEqual(response.location, "/account/")
 
     @responses.activate
     def test_post_private(self):
@@ -189,7 +189,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         self.assertIn(b'"is_private": true', called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, "http://localhost/account/")
+        self.assertEqual(response.location, "/account/")
 
     @responses.activate
     def test_post_registrant_comment(self):
@@ -208,7 +208,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         self.assertIn(b'"registrant_comment": "comment"', called.request.body)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, "http://localhost/account/")
+        self.assertEqual(response.location, "/account/")
 
     @responses.activate
     def test_error_from_api(self):
@@ -240,7 +240,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         assert response.status_code == 302
         self.assertIn("snap_name=test-snap", response.location)
         self.assertIn("is_private=False", response.location)
-        self.assertIn("http://localhost/register-snap", response.location)
+        self.assertIn("/register-snap", response.location)
 
     @responses.activate
     def test_name_reserved(self):
@@ -257,7 +257,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         assert response.status_code == 302
         self.assertIn("snap_name=test-snap", response.location)
         self.assertIn("is_private=False", response.location)
-        self.assertIn("http://localhost/register-snap", response.location)
+        self.assertIn("/register-snap", response.location)
 
     @responses.activate
     def test_claim_dispute(self):
@@ -272,7 +272,7 @@ class PostRegisterNamePage(BaseTestCases.EndpointLoggedIn):
         response = self.client.post(self.endpoint_url, data=self.data)
 
         assert response.status_code == 302
-        self.assertEqual(response.location, "http://localhost/admin/account")
+        self.assertEqual(response.location, "/admin/account")
 
     @responses.activate
     def test_post_error_user_error(self):

--- a/tests/publisher/tests_register_name_dispute.py
+++ b/tests/publisher/tests_register_name_dispute.py
@@ -52,7 +52,7 @@ class GetRegisterNameDisputePage(BaseTestCases.BaseAppTesting):
         response = self.client.get(self.endpoint_url)
 
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, "/register-snap")
+        self.assertEqual(response.headers["Location"], "/register-snap")
 
 
 class PostRegisterNameDisputeNotAuth(BaseTestCases.EndpointLoggedOut):

--- a/tests/publisher/tests_reserved_name_dispute.py
+++ b/tests/publisher/tests_reserved_name_dispute.py
@@ -50,4 +50,4 @@ class GetRequestReservedName(BaseTestCases.BaseAppTesting):
         response = self.client.get(self.endpoint_url)
 
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, "/register-snap")
+        self.assertEqual(response.headers["Location"], "/register-snap")

--- a/tests/publisher/tests_username.py
+++ b/tests/publisher/tests_username.py
@@ -47,7 +47,7 @@ class PostUsernamePage(BaseTestCases.EndpointLoggedIn):
 
     @responses.activate
     def test_post_username(self):
-        responses.add(responses.PATCH, self.api_url, json={}, status=204)
+        responses.add(responses.PATCH, self.api_url, json={}, status=200)
 
         response = self.client.post(self.endpoint_url, data=self.data)
 
@@ -61,22 +61,18 @@ class PostUsernamePage(BaseTestCases.EndpointLoggedIn):
         self.assertEqual(b'{"short_namespace": "toto"}', called.request.body)
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual("http://localhost/account/", response.location)
+        self.assertEqual("/account/", response.location)
 
     @responses.activate
     def test_post_username_empty(self):
         response = self.client.post(self.endpoint_url, data={"username": ""})
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            "http://localhost/account/username", response.location
-        )
+        self.assertEqual("/account/username", response.location)
 
     @responses.activate
     def test_post_no_data(self):
         response = self.client.post(self.endpoint_url, data={})
 
         self.assertEqual(302, response.status_code)
-        self.assertEqual(
-            "http://localhost/account/username", response.location
-        )
+        self.assertEqual("/account/username", response.location)

--- a/tests/snapcraft/tests_public.py
+++ b/tests/snapcraft/tests_public.py
@@ -7,8 +7,6 @@ responses.mock.assert_all_requests_are_fired = True
 
 
 class StorePage(TestCase):
-    render_templates = False
-
     def create_app(self):
         app = create_app(testing=True)
         app.secret_key = "secret_key"

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -5,8 +5,6 @@ from webapp.app import create_app
 
 
 class GetDetailsPageTest(TestCase):
-    render_templates = False
-
     def setUp(self):
         self.snap_name = "toto"
         self.api_url = "".join(

--- a/tests/store/tests_distro_page.py
+++ b/tests/store/tests_distro_page.py
@@ -5,8 +5,6 @@ from webapp.app import create_app
 
 
 class GetDistroPageTest(TestCase):
-    render_templates = False
-
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -5,8 +5,6 @@ from webapp.app import create_app
 
 
 class GetEmbeddedCardTest(TestCase):
-    render_templates = False
-
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -5,8 +5,6 @@ from webapp.app import create_app
 
 
 class GetGitHubBadgeTest(TestCase):
-    render_templates = False
-
     snap_payload = {
         "snap-id": "id",
         "name": "snapName",

--- a/tests/store/tests_publisher.py
+++ b/tests/store/tests_publisher.py
@@ -5,8 +5,6 @@ from webapp.app import create_app
 
 
 class GetPublisherPageTest(TestCase):
-    render_templates = False
-
     def setUp(self):
         self.publisher = "jetbrains"
         self.api_url = "".join(

--- a/tests/tests_badge_counter.py
+++ b/tests/tests_badge_counter.py
@@ -4,8 +4,6 @@ from webapp.handlers import badge_counter, badge_logged_in_counter
 
 
 class TestsBadgePrometheusCounter(TestCase):
-    render_templates = False
-
     def setUp(self):
         self.endpoint_url = "/static/images/badges/en/snap-store-black.svg"
         badge_counter._value.set(0.0)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -49,6 +49,12 @@ def create_app(testing=False):
         talisker.requests.configure(webapp.helpers.api_session)
         talisker.requests.configure(webapp.helpers.api_publisher_session)
 
+    if testing:
+
+        @app.context_processor
+        def inject_csrf_token():
+            return dict(csrf_token=lambda: "mocked_csrf_token")
+
     set_handlers(app)
 
     app.register_blueprint(snapcraft_blueprint())

--- a/webapp/docs/views.py
+++ b/webapp/docs/views.py
@@ -38,6 +38,7 @@ def init_docs(app, url_prefix):
         "/docs/search",
         "docs-search",
         build_search_view(
+            app=app,
             session=session,
             site="snapcraft.io/docs",
             template_path="docs/search.html",

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -343,6 +343,7 @@ def post_preview(snap_name):
         "publisher": snap_details["publisher"]["display-name"],
         "username": snap_details["publisher"]["username"],
         "developer_validation": snap_details["publisher"]["validation"],
+        "categories": [],
     }
 
     state = loads(flask.request.form["state"])

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -71,7 +71,7 @@ def get_settings(snap_name, return_json=False):
         "update_metadata_on_release": snap_details[
             "update_metadata_on_release"
         ],
-        "visibility_locked": snap_details["visibility_locked"],
+        "visibility_locked": snap_details["visibility_locked"] | False,
     }
 
     if return_json:


### PR DESCRIPTION
## Done
Bumps `canonicalwebteam.search` module version. This also relied on bumping `flask-base`, which caused over 180 test failures - so the majority of changes are fixing those

## How to QA
- Click around and make sure the site works as usual
- All tests should pass

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no new behaviour

## Issue / Card
Fixes [WD-15006](https://warthogs.atlassian.net/browse/WD-15006)


[WD-15006]: https://warthogs.atlassian.net/browse/WD-15006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ