### PR TITLE
Update link to SPDX specification on listing page

### DIFF
--- a/static/js/publisher/listing/components/LicenseInputs/LicenseInputs.tsx
+++ b/static/js/publisher/listing/components/LicenseInputs/LicenseInputs.tsx
@@ -102,8 +102,8 @@ function LicenseInputs({ listingData, register, setValue, watch }: Props) {
 
               <small className="u-text-muted">
                 Visit{" "}
-                <a href="https://spdx.org/spdx-specification-21-web-version#h.jxpfx0ykyb60">
-                  SPDX Specification 21
+                <a href="https://spdx.github.io/spdx-spec/v2.3/">
+                  SPDX Specification 2.3
                 </a>{" "}
                 for more information.
               </small>


### PR DESCRIPTION
## Done
Updated the SPDX specification link

## How to QA
- Go to https://snapcraft-io-4858.demos.haus/defold/listing (or any other snap listing page)
- Scroll down to the license field
- Click "Custom SPDX expression" radio button
- Check that the SPDX specification link works

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Link change

## Issue / Card
Fixes #4856