### PR TITLE
Wd 15633 add breadcrumb nav metrics page

### DIFF
--- a/static/js/publisher-pages/pages/Metrics/Metrics.tsx
+++ b/static/js/publisher-pages/pages/Metrics/Metrics.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 
 const EmptyData = () => {
   return (
-    <section className="p-strip--light is-shallow">
+    <section className="p-strip--light is-shallow snapcraft-metrics__info">
       <Row>
         <Col size={6}>
           <h2 className="p-heading--4" style={{ marginLeft: "1.5rem" }}>
@@ -40,6 +40,11 @@ function Metrics(): JSX.Element {
 
   return (
     <>
+      <h1 className="p-heading--4">
+        <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /
+        Metrics
+      </h1>
+
       <SectionNav snapName={snapId} activeTab="metrics" />
       {isEmpty && <EmptyData />}
 

--- a/static/sass/_snapcraft_metrics.scss
+++ b/static/sass/_snapcraft_metrics.scss
@@ -61,4 +61,8 @@
       vertical-align: middle;
     }
   }
+
+  .snapcraft-metrics__info {
+    margin-top: 1.5rem;
+  }
 }


### PR DESCRIPTION
## Done
- added breadcrumb nav to the metrics page

## How to QA
- go to https://snapcraft-io-4871.demos.haus/<snap-id>/metrics
- see the bread crumb nav

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #[15633](https://warthogs.atlassian.net/browse/WD-15633)

## Screenshots
![Screenshot from 2024-10-07 09-59-40](https://github.com/user-attachments/assets/011f3f01-6d2b-4e29-befb-1013a5b17e5a)
