### PR TITLE
fix: show error when set default track returns 400

### DIFF
--- a/static/js/publisher/release/actions/defaultTrack.js
+++ b/static/js/publisher/release/actions/defaultTrack.js
@@ -4,6 +4,7 @@ import { CLOSE_MODAL } from "./modal";
 import { showNotification } from "./globalNotification";
 
 export const SET_DEFAULT_TRACK_SUCCESS = "SET_DEFAULT_TRACK_SUCCESS";
+export const SET_DEFAULT_TRACK_FAILURE = "SET_DEFAULT_TRACK_FAILURE";
 
 const fetchDefaultTrack = (snapName, csrfToken, track) => {
   return fetch(`/${snapName}/releases/default-track`, {
@@ -18,7 +19,12 @@ const fetchDefaultTrack = (snapName, csrfToken, track) => {
     redirect: "follow",
     referrer: "no-referrer",
     body: JSON.stringify({ default_track: track }),
-  }).then((response) => response.json());
+  }).then((response) => {
+    if (!response.ok) {
+      return Promise.reject(response);
+    }
+    return response.json();
+  });
 };
 
 export function clearDefaultTrack() {
@@ -51,22 +57,38 @@ export function setDefaultTrack() {
     const { options, currentTrack } = getState();
     const { snapName, csrfToken } = options;
 
-    return fetchDefaultTrack(snapName, csrfToken, currentTrack).then(() => {
-      dispatch({
-        type: SET_DEFAULT_TRACK_SUCCESS,
-        payload: currentTrack,
+    return fetchDefaultTrack(snapName, csrfToken, currentTrack)
+      .then(() => {
+        dispatch({
+          type: SET_DEFAULT_TRACK_SUCCESS,
+          payload: currentTrack,
+        });
+        dispatch(
+          showNotification({
+            status: "success",
+            appearance: "positive",
+            content: `The default track for ${snapName} has been set to ${currentTrack}. All new installations without a specified track (e.g. \`sudo snap install ${snapName}\`) will receive updates from the newly defined default track.`,
+            canDismiss: true,
+          }),
+        );
+      })
+      .catch((errorResponse) => {
+        dispatch({
+          type: SET_DEFAULT_TRACK_FAILURE,
+        });
+        dispatch(
+          showNotification({
+            status: "error",
+            appearance: "negative",
+            content: `Failed to set the default track for ${snapName}. (${errorResponse.status}: ${errorResponse.statusText})`,
+            canDismiss: true,
+          }),
+        );
+      })
+      .finally(() => {
+        dispatch({
+          type: CLOSE_MODAL,
+        });
       });
-      dispatch({
-        type: CLOSE_MODAL,
-      });
-      dispatch(
-        showNotification({
-          status: "success",
-          appearance: "positive",
-          content: `The default track for ${snapName} has been set to ${currentTrack}. All new installations without a specified track (e.g. \`sudo snap install ${snapName}\`) will receive updates from the newly defined default track.`,
-          canDismiss: true,
-        }),
-      );
-    });
   };
 }

--- a/static/js/publisher/release/actions/defaultTrack.test.js
+++ b/static/js/publisher/release/actions/defaultTrack.test.js
@@ -9,10 +9,12 @@ import {
   clearDefaultTrack,
   setDefaultTrack,
 } from "./defaultTrack";
+import { CLOSE_MODAL } from "./modal";
 
 describe("defaultTrack actions", () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: () => ({
         success: true,
       }),
@@ -41,6 +43,20 @@ describe("defaultTrack actions", () => {
             type: SET_DEFAULT_TRACK_SUCCESS,
             payload: "test",
           });
+          expect(actions[1]).toEqual({
+            type: "SHOW_NOTIFICATION",
+            payload: {
+              status: "success",
+              appearance: "positive",
+              content: expect.stringContaining(
+                "The default track for test has been set to test.",
+              ),
+              canDismiss: true,
+            },
+          });
+          expect(actions[2]).toEqual({
+            type: CLOSE_MODAL,
+          });
         });
       });
     });
@@ -59,6 +75,20 @@ describe("defaultTrack actions", () => {
           expect(actions[0]).toEqual({
             type: SET_DEFAULT_TRACK_SUCCESS,
             payload: null,
+          });
+          expect(actions[1]).toEqual({
+            type: "CLOSE_MODAL",
+          });
+          expect(actions[2]).toEqual({
+            type: "SHOW_NOTIFICATION",
+            payload: {
+              status: "success",
+              appearance: "positive",
+              content: expect.stringContaining(
+                "The default track for test has been removed. All new installations without a specified track (e.g. `sudo snap install test`) will receive updates from latest track.",
+              ),
+              canDismiss: true,
+            },
           });
         });
       });


### PR DESCRIPTION
## Done
Adds an error message when `setDefaultTrack` returns a 400.

## How to QA
- Try to set one of your snaps' default tracks to "latest"
    - An error message should show up
- Alternatively, check video below of changing default tracks
- Tests should pass

## Testing
- [X] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-15735](https://warthogs.atlassian.net/browse/WD-15735)

## Screenshots
[Screencast from 08-10-24 17:54:11.webm](https://github.com/user-attachments/assets/28d6b6ad-a702-4dc9-b58a-2a577421844b)


[WD-15735]: https://warthogs.atlassian.net/browse/WD-15735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ