### PR TITLE
Update TiCS workflow to run once per week

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,7 @@
 name: Test coverage
 on:
   schedule:
-    - cron: "0 22 * * *"
+    - cron: "0 22 * * 6"
 
 jobs:
   test:


### PR DESCRIPTION
## Done
From the request of the Tiobe team, reducing the number of submissions to once per week. Specifically on Saturday night at 10pm.

## How to QA
- Check back next week to see the job ran on Saturday

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Workflow update