### PR TITLE
feat: Update badge urls

### DIFF
--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -53,7 +53,7 @@
         <div class="col-7">
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block"><code id="snippet-{{ lang }}-black-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
-  &lt;img alt="{{ data.text }}" src="https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-black.svg" /&gt;
+  &lt;img alt="{{ data.text }}" src="https://snapcraft.io/{{ lang }}/dark/install.svg" /&gt;
 &lt;/a&gt;</code></pre>
           </div>
         </div>
@@ -65,7 +65,7 @@
         </div>
         <div class="col-7">
           <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code id="snippet-{{ lang }}-black-md">[![{{ data.text }}](https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-black.svg)](https://snapcraft.io/{{ snap_name }})</code></pre>
+            <pre class="p-code-snippet__block is-wrapped"><code id="snippet-{{ lang }}-black-md">[![{{ data.text }}](https://snapcraft.io/{{ lang }}/dark/install.svg)](https://snapcraft.io/{{ snap_name }})</code></pre>
           </div>
         </div>
       </div>
@@ -98,7 +98,7 @@
         <div class="col-7">
           <div class="p-code-snippet">
             <pre class="p-code-snippet__block"><code id="snippet-{{ lang }}-white-html">&lt;a href="https://snapcraft.io/{{ snap_name }}"&gt;
-  &lt;img alt="{{ data.text }}" src="https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-white.svg" /&gt;
+  &lt;img alt="{{ data.text }}" src="https://snapcraft.io/{{ lang }}/light/install.svg" /&gt;
 &lt;/a&gt;</code></pre>
           </div>
         </div>
@@ -110,7 +110,7 @@
         </div>
         <div class="col-7">
           <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code id="snippet-{{ lang }}-white-md">[![{{ data.text }}](https://snapcraft.io/static/images/badges/{{ lang }}/snap-store-white.svg)](https://snapcraft.io/{{ snap_name }})</code></pre>
+            <pre class="p-code-snippet__block is-wrapped"><code id="snippet-{{ lang }}-white-md">[![{{ data.text }}](https://snapcraft.io/{{ lang }}/light/install.svg)](https://snapcraft.io/{{ snap_name }})</code></pre>
           </div>
         </div>
       </div>

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -57,7 +57,7 @@
       {% endif %}
       {% if button %}
       <div class="p-embedded-description__badge">
-        <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/en/snap-store-{{ button }}.svg" />
+        <img alt="Get it from the Snap Store" src="https://snapcraft.io/en/{% if button == 'white' %}light{% else %}dark{% endif %}/install.svg" />
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Done
- Updated urls for badges

## How to QA
- Go to 'https://snapcraft-io-4888.demos.haus/lxd/publicise'
- source for both html and markdown should have the correct urls:
     - for the dark badge https://snapcraft.io/en/dark/install.svg
     - for the light badge https://snapcraft.io/en/light/install.svg
 - Go to 'https://snapcraft-io-4888.demos.haus/lxd'
 - Click on the "Create embeddable card" button
 - Verify dark and light badges are shown

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes [#WD-15869](https://warthogs.atlassian.net/browse/WD-15869)

