### PR TITLE
Wd 15869 security header badge issue

### DIFF
--- a/static/js/publisher-pages/pages/Publicise/PubliciseButtons.tsx
+++ b/static/js/publisher-pages/pages/Publicise/PubliciseButtons.tsx
@@ -23,20 +23,23 @@ function PubliciseButtons(): JSX.Element {
   const { snapId } = useParams();
   const [selectedLanguage, setSelectedLanguage] = useState<string>("en");
 
+  const darkBadgeSource = `https://snapcraft.io/${selectedLanguage}/dark/install.svg`;
+  const lightBadgeSource = `https://snapcraft.io/${selectedLanguage}/light/install.svg`;
+
   const htmlSnippetBlack = `<a href="https://snapcraft.io/${snapId}">
-  <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/${selectedLanguage}/snap-store-black.svg" />
+  <img alt="Get it from the Snap Store" src=${darkBadgeSource} />
 </a>
 `;
 
   const htmlSnippetWhite = `<a href="https://snapcraft.io/${snapId}">
-  <img alt="Get it from the Snap Store" src="https://snapcraft.io/static/images/badges/${selectedLanguage}/snap-store-white.svg" />
+  <img alt="Get it from the Snap Store" src=${lightBadgeSource} />
 </a>
 `;
 
-  const markdownSnippetBlack = `[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/${selectedLanguage}/snap-store-black.svg)](https://snapcraft.io/${snapId})
+  const markdownSnippetBlack = `[![Get it from the Snap Store](${darkBadgeSource})](https://snapcraft.io/${snapId})
 `;
 
-  const markdownSnippetWhite = `[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/${selectedLanguage}/snap-store-white.svg)](https://snapcraft.io/${snapId})
+  const markdownSnippetWhite = `[![Get it from the Snap Store](${lightBadgeSource})](https://snapcraft.io/${snapId})
 `;
 
   return (
@@ -73,7 +76,7 @@ function PubliciseButtons(): JSX.Element {
         <Col size={10}>
           <p>
             <img
-              src={`https://snapcraft.io/static/images/badges/${selectedLanguage}/snap-store-black.svg`}
+              src={darkBadgeSource}
               alt="Get it from the Snap Store"
               width="182"
               height="56"
@@ -108,7 +111,7 @@ function PubliciseButtons(): JSX.Element {
         <Col size={10}>
           <p>
             <img
-              src={`https://snapcraft.io/static/images/badges/${selectedLanguage}/snap-store-white.svg`}
+              src={lightBadgeSource}
               alt="Get it from the Snap Store"
               width="182"
               height="56"

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -56,9 +56,8 @@
         <h4 class="p-embedded-description__summary">{{ summary }}</h4>
       {% endif %}
       {% if button %}
-      <div class="p-embedded-description__badge">
-        <img alt="Get it from the Snap Store" src="https://snapcraft.io/en/{% if button == 'white' %}light{% else %}dark{% endif %}/install.svg" />
-      </div>
+      <img alt="Get it from the Snap Store"
+        src="https://snapcraft.io/en/{% if button == 'white' %}light{% else %}dark{% endif %}/install.svg" />
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Done
- Updated urls for badges

## How to QA
- Go to 'https://snapcraft-io-4892.demos.haus/lxd/publicise'
- source for both html and markdown should have the correct urls:
     - for the dark badge https://snapcraft.io/en/dark/install.svg
     - for the light badge https://snapcraft.io/en/light/install.svg
 - Go to 'https://snapcraft-io-4892.demos.haus/lxd/publicise/cards'
 - Verify dark and light badges are shown

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes [#WD-15869](https://warthogs.atlassian.net/browse/WD-15869)

