### PR TITLE
feat: add an extra day to fix the reset issue on the metric page

### DIFF
--- a/webapp/metrics/helper.py
+++ b/webapp/metrics/helper.py
@@ -16,10 +16,18 @@ def get_last_metrics_processed_date():
     # since the metrics are processed during the night
     # https://github.com/canonical-web-and-design/snapcraft.io/pull/616
     three_hours = relativedelta.relativedelta(hours=3)
-    last_metrics_processed = datetime.datetime.utcnow() - three_hours
+    last_metrics_processed = datetime.datetime.now() - three_hours
 
-    one_day = relativedelta.relativedelta(days=1)
-    return last_metrics_processed.date() - one_day
+    # Add an extra day on Mondays and Sundays to prevent the reset issue.
+    if (
+        last_metrics_processed.weekday() == 0
+        or last_metrics_processed.weekday() == 6
+    ):
+        days_to_skip = relativedelta.relativedelta(days=2)
+    else:
+        days_to_skip = relativedelta.relativedelta(days=1)
+
+    return last_metrics_processed.date() - days_to_skip
 
 
 def build_metrics_json(


### PR DESCRIPTION
## Done
- When showing the metrics ,  2 days are subtracted from the current day if its Monday or Sunday.

## How to QA
- Go to https://snapcraft-io-4893.demos.haus/lxd/metrics
- Make sure active devices chart doesnt resets to 0
- Make sure country chart isnt empty

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes [#WD-15452](https://warthogs.atlassian.net/browse/WD-15452)

