### PR TITLE
fix: change 'category' to 'categories' in store filtering url

### DIFF
--- a/static/js/public/featured-snaps.ts
+++ b/static/js/public/featured-snaps.ts
@@ -160,7 +160,7 @@ async function init(featuredCategories: Array<string>): Promise<void> {
 
       await buildCards(category);
 
-      viewCategoryLink?.setAttribute("href", `/search?category=${category}`);
+      viewCategoryLink?.setAttribute("href", `/search?categories=${category}`);
       viewCategoryLink.innerText = `View all ${category} snaps`;
     });
   });

--- a/templates/home/_featured-snaps.html
+++ b/templates/home/_featured-snaps.html
@@ -60,7 +60,7 @@
         <hr class="p-rule">
         <ul class="p-list--divided u-no-margin--bottom">
           <li class="p-list__item">
-            <a href="/search?category={{ featured_categories[0]|lower }}" data-js="view-category-link">
+            <a href="/search?categories={{ featured_categories[0]|lower }}" data-js="view-category-link">
               View all {{ featured_categories[0]|lower }} snaps
             </a>            
           </li>


### PR DESCRIPTION
## Done
- Change `category` to `categories` in store url
## How to QA
- 1. Go to [demo](https://snapcraft-io-4903.demos.haus/)
  2. click on `Games`
  3. click `view all game snaps`
  4. Ensure that the snaps displayed are games snaps and `game` is selected in the sidebar
- Repeat steps ii-iv above for `featured`, `development` and `server`

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card https://forum.snapcraft.io/t/bug-sorting-link-by-games/43904/2
Fixes # https://warthogs.atlassian.net/browse/WD-16692

## Screenshots
