### PR TITLE
chore: update admin snap link in brandstore

### DIFF
--- a/static/js/brand-store/components/Snaps/IncludedSnapsTable.tsx
+++ b/static/js/brand-store/components/Snaps/IncludedSnapsTable.tsx
@@ -30,7 +30,7 @@ function SnapTableRows({
 
   return snaps.map((snap) => {
     const snapName = isGlobal ? (
-      <a href={`https://snapcraft.io/${snap.name}/listing`}>{snap.name}</a>
+      <a href={`https://snapcraft.io/${snap.name}`}>{snap.name}</a>
     ) : (
       snap.name || "-"
     );


### PR DESCRIPTION
## Done
- Updated a Global snap link in the brand store from  `/<snap_name>/listing` to `/<snap_name>`

## How to QA
- Go to the brand store in [demo](https://snapcraft-io-4904.demos.haus/) and check if the Global snap links to the public page instead of a listing page.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Link update for Global snaps in the brand store

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-12915