### PR TITLE
Include H3 in docs side TOC

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -125,6 +125,13 @@
               <li class="p-table-of-contents__item">
                 <a class="p-table-of-contents__link" href="#{{ heading.heading_slug }}">{{ heading.heading_text }}</a>
               </li>
+              {% if heading.children %}
+                <ul class="p-table-of-contents__list">
+                {% for child in heading.children %}
+                  <li class="p-table-of-contents__item"><a class="p-table-of-contents__link" href="#{{ child.heading_slug }}">{{ child.heading_text }}</a></li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
               {% endfor %}
             </ul>
           </nav>


### PR DESCRIPTION
## Done
- Include h3 headings to table of contents (displayed on the right side of the page). H3 contents should nest their parent H2 headings.

## How to QA
- Go to https://snapcraft-io-4918.demos.haus/docs/managing-updates OR https://snapcraft-io-4918.demos.haus/docs/get-started
- Check that the table of contents on the right side of the page load as expected
- It should catch h2 and h3 headings. H3 headings should nest their corresponding H2 parent headings.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no behavioural change

## Issue / Card

Fixes [WD-17314](https://warthogs.atlassian.net/browse/WD-17314)


[WD-17314]: https://warthogs.atlassian.net/browse/WD-17314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ