### PR TITLE
fix: Fix code linting errors in publisher app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     "prettier/prettier": "error",
     "react/react-in-jsx-scope": "off",
     "react/no-unescaped-entities": "off",
+    "react/display-name": "off",
   },
   settings: {
     react: {
@@ -43,6 +44,7 @@ module.exports = {
     },
   ],
   ignorePatterns: [
-    "/static/js/publisher" // skip linting any files in the publisher directory 
+    "/static/js/publisher", // skip linting any files in the publisher directory
+    "/static/js/publisher-pages/pages/Releases", // skip releases for now as structural changes are required to fix TS
   ],
 };

--- a/static/js/publisher-pages/components/SaveAndPreview/SaveAndPreview.test.tsx
+++ b/static/js/publisher-pages/components/SaveAndPreview/SaveAndPreview.test.tsx
@@ -9,7 +9,7 @@ const reset = jest.fn();
 const renderComponent = (
   isDirty: boolean,
   isSaving: boolean,
-  isValid: boolean
+  isValid: boolean,
 ) => {
   return render(
     <SaveAndPreview
@@ -18,13 +18,16 @@ const renderComponent = (
       reset={reset}
       isSaving={isSaving}
       isValid={isValid}
-    />
+    />,
   );
 };
 
 test("the 'Revert' button is disabled by default", () => {
   renderComponent(false, false, true);
-  expect(screen.getByRole("button", { name: "Revert" })).toHaveAttribute("aria-disabled","true");
+  expect(screen.getByRole("button", { name: "Revert" })).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
 });
 
 test("the 'Revert' button is enabled is data is dirty", () => {
@@ -34,7 +37,10 @@ test("the 'Revert' button is enabled is data is dirty", () => {
 
 test("the 'Save' button is disabled by default", () => {
   renderComponent(false, false, true);
-  expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute("aria-disabled","true");
+  expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
 });
 
 test("the 'Save' button is enabled is data is dirty", () => {
@@ -49,12 +55,18 @@ test("the 'Save' button shows loading state if saving", () => {
 
 test("the 'Save' button is disabled when saving", () => {
   renderComponent(true, true, true);
-  expect(screen.getByRole("button", { name: "Saving" })).toHaveAttribute("aria-disabled","true");
+  expect(screen.getByRole("button", { name: "Saving" })).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
 });
 
 test("the 'Save' button is disabled if the form is invalid", () => {
   renderComponent(false, false, false);
-  expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute("aria-disabled","true");
+  expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
 });
 
 test("revert button resets the form", async () => {

--- a/static/js/publisher-pages/components/SaveAndPreview/SaveAndPreview.tsx
+++ b/static/js/publisher-pages/components/SaveAndPreview/SaveAndPreview.tsx
@@ -6,7 +6,7 @@ import debounce from "../../../libs/debounce";
 type Props = {
   snapName: string;
   isDirty: boolean;
-  reset: Function;
+  reset: () => void;
   isSaving: boolean;
   isValid: boolean;
   showPreview?: boolean;
@@ -25,7 +25,7 @@ function SaveAndPreview({
   const handleScroll = () => {
     stickyBar?.current?.classList.toggle(
       "sticky-shadow",
-      stickyBar?.current?.getBoundingClientRect()?.top === 0
+      stickyBar?.current?.getBoundingClientRect()?.top === 0,
     );
   };
 

--- a/static/js/publisher-pages/components/SaveStateNotifications/SaveStateNotifications.tsx
+++ b/static/js/publisher-pages/components/SaveStateNotifications/SaveStateNotifications.tsx
@@ -1,10 +1,13 @@
+import { Dispatch, SetStateAction } from "react";
 import { Notification } from "@canonical/react-components";
 
 type Props = {
   hasSaved: boolean;
-  setHasSaved: Function;
+  setHasSaved: Dispatch<SetStateAction<boolean>>;
   savedError: boolean | Array<{ message: string }>;
-  setSavedError: Function;
+  setSavedError: Dispatch<
+    SetStateAction<boolean | { code: string; message: string }[]>
+  >;
 };
 
 function SaveStateNotifications({

--- a/static/js/publisher-pages/components/SaveStateNotifications/__tests__/SaveStateNotifications.test.tsx
+++ b/static/js/publisher-pages/components/SaveStateNotifications/__tests__/SaveStateNotifications.test.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from "react";
 import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -6,9 +7,9 @@ import SaveStateNotifications from "../SaveStateNotifications";
 
 type Options = {
   hasSaved?: boolean;
-  setHasSaved?: Function;
+  setHasSaved?: Dispatch<SetStateAction<boolean>>;
   savedError?: boolean | Array<{ message: string }>;
-  setSavedError?: Function;
+  setSavedError?: Dispatch<SetStateAction<boolean>>;
 };
 
 const renderComponent = (options: Options) => {
@@ -17,8 +18,9 @@ const renderComponent = (options: Options) => {
       hasSaved={options.hasSaved || false}
       setHasSaved={options.setHasSaved || jest.fn()}
       savedError={options.savedError || false}
+      // @ts-expect-error Mock for testing
       setSavedError={options.setSavedError || jest.fn()}
-    />
+    />,
   );
 };
 
@@ -26,14 +28,14 @@ describe("SaveStateNotifications", () => {
   test("shows success notification if saved", () => {
     renderComponent({ hasSaved: true });
     expect(
-      screen.getByRole("heading", { name: "Changes applied successfully." })
+      screen.getByRole("heading", { name: "Changes applied successfully." }),
     ).toBeInTheDocument();
   });
 
   test("doesn't show success notification if not saved", () => {
     renderComponent({ hasSaved: false });
     expect(
-      screen.queryByRole("heading", { name: "Changes applied successfully." })
+      screen.queryByRole("heading", { name: "Changes applied successfully." }),
     ).not.toBeInTheDocument();
   });
 
@@ -42,7 +44,7 @@ describe("SaveStateNotifications", () => {
     const setHasSaved = jest.fn();
     renderComponent({ hasSaved: true, setHasSaved });
     await user.click(
-      screen.getByRole("button", { name: "Close notification" })
+      screen.getByRole("button", { name: "Close notification" }),
     );
     expect(setHasSaved).toHaveBeenCalled();
   });
@@ -50,14 +52,14 @@ describe("SaveStateNotifications", () => {
   test("shows error notification if saved", () => {
     renderComponent({ savedError: true });
     expect(
-      screen.getByText(/Changes have not been saved./)
+      screen.getByText(/Changes have not been saved./),
     ).toBeInTheDocument();
   });
 
   test("doesn't show error notification if not saved", () => {
     renderComponent({ savedError: false });
     expect(
-      screen.queryByText(/Changes have not been saved./)
+      screen.queryByText(/Changes have not been saved./),
     ).not.toBeInTheDocument();
   });
 
@@ -82,7 +84,7 @@ describe("SaveStateNotifications", () => {
     const setHasSaved = jest.fn();
     renderComponent({ savedError: true, setHasSaved });
     await user.click(
-      screen.getByRole("button", { name: "Close notification" })
+      screen.getByRole("button", { name: "Close notification" }),
     );
     expect(setHasSaved).toHaveBeenCalled();
   });
@@ -92,7 +94,7 @@ describe("SaveStateNotifications", () => {
     const setSavedError = jest.fn();
     renderComponent({ savedError: true, setSavedError });
     await user.click(
-      screen.getByRole("button", { name: "Close notification" })
+      screen.getByRole("button", { name: "Close notification" }),
     );
     expect(setSavedError).toHaveBeenCalled();
   });

--- a/static/js/publisher-pages/components/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/static/js/publisher-pages/components/SearchAutocomplete/SearchAutocomplete.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect } from "react";
 import Downshift from "downshift";
-import { useWatch } from "react-hook-form";
+import {
+  useWatch,
+  UseFormRegister,
+  UseFormSetValue,
+  UseFormGetValues,
+  Control,
+  FieldValues,
+} from "react-hook-form";
 
 type DataItem = {
   key: string;
@@ -11,10 +18,10 @@ type Props = {
   data: Array<DataItem>;
   field: string;
   currentValues: Array<string>;
-  register: Function;
-  setValue: Function;
-  getValues: Function;
-  control: any;
+  register: UseFormRegister<FieldValues>;
+  setValue: UseFormSetValue<FieldValues>;
+  getValues: UseFormGetValues<FieldValues>;
+  control: Control<FieldValues>;
   disabled?: boolean;
 };
 
@@ -83,7 +90,7 @@ function SearchAutocomplete({
                 className="p-icon--close p-multiselect__item-remove"
                 onClick={() => {
                   const newSelections = selections.filter(
-                    (item: DataItem) => item.key !== suggestion.key
+                    (item: DataItem) => item.key !== suggestion.key,
                   );
 
                   const newSelectionsKeys = getNewSelectionKeys(newSelections);
@@ -115,13 +122,13 @@ function SearchAutocomplete({
                   (item) =>
                     !inputValue ||
                     item.key.toLowerCase().includes(inputValue) ||
-                    item.name.toLowerCase().includes(inputValue)
+                    item.name.toLowerCase().includes(inputValue),
                 )
                 .map((item, index) => (
                   <li
+                    key={item.key}
                     className="p-multiselect__option"
                     {...getItemProps({
-                      key: item.key,
                       index,
                       item,
                       style: {

--- a/static/js/publisher-pages/components/SectionNav/SectionNavTest.tsx
+++ b/static/js/publisher-pages/components/SectionNav/SectionNavTest.tsx
@@ -13,48 +13,48 @@ const props = {
 test("the page displays the correct name for the snap", () => {
   render(<SectionNav {...props} />);
   expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-    "test-snap-name"
+    "test-snap-name",
   );
 });
 
 test("the 'Listing' tab has the correct path", () => {
   render(<SectionNav {...props} />);
   expect(
-    screen.getByRole("link", { name: "Listing" }).getAttribute("href")
+    screen.getByRole("link", { name: "Listing" }).getAttribute("href"),
   ).toBe(`/${snapName}/listing`);
 });
 
 test("the 'Builds' tab has the correct path", () => {
   render(<SectionNav {...props} />);
   expect(
-    screen.getByRole("link", { name: "Builds" }).getAttribute("href")
+    screen.getByRole("link", { name: "Builds" }).getAttribute("href"),
   ).toBe(`/${snapName}/builds`);
 });
 
 test("the 'Releases' tab has the correct path", () => {
   render(<SectionNav {...props} />);
   expect(
-    screen.getByRole("link", { name: "Releases" }).getAttribute("href")
+    screen.getByRole("link", { name: "Releases" }).getAttribute("href"),
   ).toBe(`/${snapName}/releases`);
 });
 
 test("the 'Metrics' tab has the correct path", () => {
   render(<SectionNav {...props} />);
   expect(
-    screen.getByRole("link", { name: "Metrics" }).getAttribute("href")
+    screen.getByRole("link", { name: "Metrics" }).getAttribute("href"),
   ).toBe(`/${snapName}/metrics`);
 });
 
 test("the 'Publicise' tab has the correct path", () => {
   render(<SectionNav {...props} />);
   expect(
-    screen.getByRole("link", { name: "Publicise" }).getAttribute("href")
+    screen.getByRole("link", { name: "Publicise" }).getAttribute("href"),
   ).toBe(`/${snapName}/publicise`);
 });
 
 test("the 'Settings' tab has the correct path", () => {
   render(<SectionNav {...props} />);
   expect(
-    screen.getByRole("link", { name: "Settings" }).getAttribute("href")
+    screen.getByRole("link", { name: "Settings" }).getAttribute("href"),
   ).toBe(`/${snapName}/settings`);
 });

--- a/static/js/publisher-pages/components/UpdateMetadataModal/UpdateMetadataModal.tsx
+++ b/static/js/publisher-pages/components/UpdateMetadataModal/UpdateMetadataModal.tsx
@@ -1,9 +1,10 @@
+import { Dispatch, SetStateAction } from "react";
 import { Modal, Button } from "@canonical/react-components";
 
 type Props = {
-  setShowMetadataWarningModal: Function;
-  submitForm: Function;
-  formData: any;
+  setShowMetadataWarningModal: Dispatch<SetStateAction<boolean>>;
+  submitForm: (arg: { [key: string]: unknown }) => void;
+  formData: { [key: string]: unknown };
 };
 
 function UpdateMetadataModal({

--- a/static/js/publisher-pages/components/UpdateMetadataModal/__tests__/UpdateMetadataModal.test.tsx
+++ b/static/js/publisher-pages/components/UpdateMetadataModal/__tests__/UpdateMetadataModal.test.tsx
@@ -14,7 +14,7 @@ const renderComponent = () => {
       setShowMetadataWarningModal={setShowMetadataWarningModal}
       submitForm={submitForm}
       formData={formData}
-    />
+    />,
   );
 };
 

--- a/static/js/publisher-pages/hooks/__tests__/useActiveDeviceMetrics.test.tsx
+++ b/static/js/publisher-pages/hooks/__tests__/useActiveDeviceMetrics.test.tsx
@@ -5,18 +5,19 @@ import useActiveDeviceMetrics from "../useActiveDeviceMetrics";
 
 describe("useActiveDeviceMetrics", () => {
   test("Calls useQuery", () => {
+    // @ts-expect-error Mock for tests
     const spy = jest.spyOn(ReactQuery, "useQuery").mockReturnValue({
       data: [],
       status: "success",
       isFetcing: false,
-    } as any);
+    } as { data: []; status: string; isFetching: boolean });
 
     renderHook(() =>
       useActiveDeviceMetrics({
         period: "30d",
         snapId: "test-id",
         type: "version",
-      })
+      }),
     );
     expect(ReactQuery.useQuery).toHaveBeenCalled();
     spy.mockRestore();
@@ -24,7 +25,7 @@ describe("useActiveDeviceMetrics", () => {
 
   const createWrapper = () => {
     const queryClient = new QueryClient();
-    return ({ children }: any) => (
+    return ({ children }: { children: JSX.Element }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
   };
@@ -54,7 +55,7 @@ describe("useActiveDeviceMetrics", () => {
             total_page_num: 1,
           }),
         ok: true,
-      })
+      }),
     ) as jest.Mock;
 
     const { result } = renderHook(
@@ -66,7 +67,7 @@ describe("useActiveDeviceMetrics", () => {
         }),
       {
         wrapper: createWrapper(),
-      }
+      },
     );
 
     await waitFor(() => expect(result.current.status).toBe("success"));
@@ -112,7 +113,7 @@ describe("useActiveDeviceMetrics", () => {
             total_page_num: 1,
           }),
         ok: true,
-      })
+      }),
     ) as jest.Mock;
 
     const { result } = renderHook(
@@ -124,7 +125,7 @@ describe("useActiveDeviceMetrics", () => {
         }),
       {
         wrapper: createWrapper(),
-      }
+      },
     );
 
     await waitFor(() => expect(result.current.status).toBe("success"));
@@ -139,7 +140,7 @@ describe("useActiveDeviceMetrics", () => {
         json: () => Promise.resolve(undefined),
         ok: false,
         status: 404,
-      })
+      }),
     ) as jest.Mock;
 
     const { result } = renderHook(
@@ -151,7 +152,7 @@ describe("useActiveDeviceMetrics", () => {
         }),
       {
         wrapper: createWrapper(),
-      }
+      },
     );
     await waitFor(() => expect(result.current.status).toBe("success"));
 

--- a/static/js/publisher-pages/hooks/useActiveDeviceMetrics.ts
+++ b/static/js/publisher-pages/hooks/useActiveDeviceMetrics.ts
@@ -19,6 +19,7 @@ function useActiveDeviceMetrics({
   });
 
   const parsePeriod = (period: string) => {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
     const [_, periodLength, periodTime] = period.trim().split(/(\d+)/);
     return { periodLength: +periodLength, periodTime };
   };
@@ -44,8 +45,8 @@ function useActiveDeviceMetrics({
     for (let i = 1; i <= totalPage; i++) {
       responses.push(
         fetch(
-          `/${snapId}/metrics/active-devices?active-devices=${type}&period=${period}&page=${i}&page-length=${pagePeriodLengthInMonths}`
-        )
+          `/${snapId}/metrics/active-devices?active-devices=${type}&period=${period}&page=${i}&page-length=${pagePeriodLengthInMonths}`,
+        ),
       );
     }
 
@@ -88,7 +89,7 @@ function useActiveDeviceMetrics({
       for (const seriesKey of series.keys()) {
         const seriesExistInBatch = data.active_devices.series.find(
           (activeDeviceSeries: { name: string }) =>
-            activeDeviceSeries.name === seriesKey
+            activeDeviceSeries.name === seriesKey,
         );
         if (!seriesExistInBatch) {
           series.set(seriesKey, [

--- a/static/js/publisher-pages/hooks/useMetricsAnnotation.ts
+++ b/static/js/publisher-pages/hooks/useMetricsAnnotation.ts
@@ -5,7 +5,7 @@ function useMetricsAnnotation(snapId?: string) {
     queryKey: ["annotationMetrics", snapId],
     queryFn: async () => {
       const response = await fetch(
-        `/${snapId}/metrics/active-device-annotation`
+        `/${snapId}/metrics/active-device-annotation`,
       );
 
       if (!response.ok) {

--- a/static/js/publisher-pages/pages/Build/Build.tsx
+++ b/static/js/publisher-pages/pages/Build/Build.tsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from "react-router-dom";
 import { useQuery } from "react-query";
 import { Strip, Row, Col, MainTable } from "@canonical/react-components";
-import { formatDistanceToNow, formatDuration } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 
 import SectionNav from "../../components/SectionNav";
 
@@ -25,58 +25,6 @@ function Build(): JSX.Element {
       return responseData.data;
     },
   });
-
-  const formatDurationString = (duration?: string): string => {
-    if (!duration) {
-      return "-";
-    }
-
-    const durationParts = duration.split(":");
-
-    return formatDuration({
-      hours: parseInt(durationParts[0]),
-      minutes: parseInt(durationParts[1]),
-      seconds: Math.floor(parseInt(durationParts[2])),
-    });
-  };
-
-  const formatStatus = (status: string): JSX.Element => {
-    switch (status) {
-      case "never_built":
-        return <>Never built</>;
-      case "building_soon":
-        return <>Building soon</>;
-      case "wont_release":
-        return <>Won't release</>;
-      case "released":
-        return <>Released</>;
-      case "release_failed":
-        return <>Release failed</>;
-      case "releasing_soon":
-        return <>Releasing soon</>;
-      case "in_progress":
-        return (
-          <>
-            <i className="p-icon--spinner u-animation--spin" />
-            In progress
-          </>
-        );
-      case "failed_to_build":
-        return <>Failed to build</>;
-      case "cancelled":
-        return <>Cancelled</>;
-      case "unknown":
-        return <>Unknown</>;
-      case "ERROR":
-        return <>Error</>;
-      case "SUCCESS":
-        return <>Success</>;
-      case "IDLE":
-        return <>Idle</>;
-      default:
-        return <>{status}</>;
-    }
-  };
 
   return (
     <>
@@ -126,6 +74,7 @@ function Build(): JSX.Element {
                 target="_blank"
                 href={data.snap_build.logs}
                 className="p-button"
+                rel="noreferrer"
               >
                 View raw
               </a>

--- a/static/js/publisher-pages/pages/Builds/DisconnectRepoActions.tsx
+++ b/static/js/publisher-pages/pages/Builds/DisconnectRepoActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
 import { Button } from "@canonical/react-components";
@@ -8,7 +8,7 @@ import { buildRepoConnectedState } from "../../state/atoms";
 import type { GithubData } from "../../types";
 
 type Props = {
-  setDisconnectModalOpen: Function;
+  setDisconnectModalOpen: Dispatch<SetStateAction<boolean>>;
   githubData: GithubData | null;
 };
 

--- a/static/js/publisher-pages/pages/Builds/RepoConnected.tsx
+++ b/static/js/publisher-pages/pages/Builds/RepoConnected.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
 import { useQuery } from "react-query";
 import { useRecoilValue } from "recoil";
 import { useParams, Link } from "react-router-dom";
@@ -21,7 +21,7 @@ function RepoConnected({
   setAutoTriggerBuild,
 }: {
   autoTriggerBuild: boolean;
-  setAutoTriggerBuild: Function;
+  setAutoTriggerBuild: Dispatch<SetStateAction<boolean>>;
 }): JSX.Element {
   const { snapId } = useParams();
   const githubData = useRecoilValue(githubDataState);

--- a/static/js/publisher-pages/pages/Builds/RepoNotConnected.tsx
+++ b/static/js/publisher-pages/pages/Builds/RepoNotConnected.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from "react";
 import { useRecoilValue } from "recoil";
 import { Strip } from "@canonical/react-components";
 
@@ -10,7 +11,7 @@ import type { GithubData } from "../../types/";
 function RepoNotConnected({
   setAutoTriggerBuild,
 }: {
-  setAutoTriggerBuild: Function;
+  setAutoTriggerBuild: Dispatch<SetStateAction<boolean>>;
 }): JSX.Element {
   const githubData = useRecoilValue<GithubData | null>(githubDataState);
 

--- a/static/js/publisher-pages/pages/Builds/RepoSelector.tsx
+++ b/static/js/publisher-pages/pages/Builds/RepoSelector.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ChangeEventHandler, useState } from "react";
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
 import { Strip, Row, Col, Select, Button } from "@canonical/react-components";
@@ -11,7 +11,7 @@ type Repo = { name: string; nameWithOwner: string };
 
 type Props = {
   githubData: GithubData;
-  setAutoTriggerBuild: Function;
+  setAutoTriggerBuild: Dispatch<SetStateAction<boolean>>;
 };
 
 function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {

--- a/static/js/publisher-pages/pages/Listing/AdditionalInformation/LicenseInputs.tsx
+++ b/static/js/publisher-pages/pages/Listing/AdditionalInformation/LicenseInputs.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, SetStateAction } from "react";
 import {
   UseFormRegister,
   UseFormSetValue,
@@ -29,9 +29,11 @@ function LicenseInputs({ listingData, register, setValue, watch }: Props) {
   const customLicenseId = nanoid();
 
   useEffect(() => {
-    const subscription = watch((value: { [index: string]: any }) => {
-      setLicense(value?.license);
-    });
+    const subscription = watch(
+      (value: { [index: string]: SetStateAction<string> }) => {
+        setLicense(value?.license);
+      },
+    );
     return () => subscription.unsubscribe();
   }, [watch]);
 

--- a/static/js/publisher-pages/pages/Listing/AdditionalInformation/LicenseSearch.tsx
+++ b/static/js/publisher-pages/pages/Listing/AdditionalInformation/LicenseSearch.tsx
@@ -1,4 +1,10 @@
-import { useState, SyntheticEvent, useEffect } from "react";
+import {
+  useState,
+  SyntheticEvent,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+} from "react";
 import { UseFormRegister, UseFormSetValue, FieldValues } from "react-hook-form";
 import Downshift from "downshift";
 
@@ -14,7 +20,7 @@ type Props = {
   license: string | undefined;
   register: UseFormRegister<FieldValues>;
   setValue: UseFormSetValue<FieldValues>;
-  setLicense: Function;
+  setLicense: Dispatch<SetStateAction<string>>;
   originalLicense: string;
 };
 
@@ -170,9 +176,9 @@ function LicenseSearch({
             >
               {suggestions.map((item: License, index) => (
                 <li
+                  key={item.key}
                   className="p-list__item p-autocomplete__suggestion"
                   {...getItemProps({
-                    key: item.key,
                     index,
                     item,
                     style: {

--- a/static/js/publisher-pages/pages/Listing/ContactInformation/__tests__/PrimaryDomainInput.test.tsx
+++ b/static/js/publisher-pages/pages/Listing/ContactInformation/__tests__/PrimaryDomainInput.test.tsx
@@ -42,7 +42,7 @@ const mockUseFormReturnValue = {
 
 const renderComponent = (
   data: ListingData,
-  defaultValues: { [key: string]: any },
+  defaultValues: { [key: string]: unknown },
 ) => {
   const Component = () => {
     const { register, getFieldState, getValues } = useForm({
@@ -70,10 +70,10 @@ const renderComponent = (
 describe("PrimaryDomainInput", () => {
   it("shows as verified if domain is verified", () => {
     mockUseQueryReturnValue.data.primary_domain = true;
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
     renderComponent(mockListingData, {
@@ -84,7 +84,7 @@ describe("PrimaryDomainInput", () => {
 
   it("shows message if verified domain is changed", async () => {
     mockUseQueryReturnValue.data.primary_domain = true;
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
     mockUseFormReturnValue.getFieldState = jest.fn().mockReturnValue({
@@ -95,7 +95,7 @@ describe("PrimaryDomainInput", () => {
     mockUseFormReturnValue.getValues = jest
       .fn()
       .mockReturnValue("https://example.comabc");
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
     const user = userEvent.setup();
@@ -113,7 +113,7 @@ describe("PrimaryDomainInput", () => {
 
   it("doesn't show message if only verified domain path is changed", async () => {
     mockUseQueryReturnValue.data.primary_domain = true;
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
     mockUseFormReturnValue.getFieldState = jest.fn().mockReturnValue({
@@ -125,7 +125,7 @@ describe("PrimaryDomainInput", () => {
       .fn()
       .mockReturnValue("https://example.com");
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
     const user = userEvent.setup();
@@ -141,14 +141,14 @@ describe("PrimaryDomainInput", () => {
   it("shows message if verified domain is in no path list", async () => {
     mockUseQueryReturnValue.data.primary_domain = true;
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
     mockUseFormReturnValue.getValues = jest
       .fn()
       .mockReturnValue("https://launchpad.net/path");
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
     const user = userEvent.setup();
     renderComponent(
@@ -165,7 +165,7 @@ describe("PrimaryDomainInput", () => {
   it("'Verified ownership' button opens modal with token", async () => {
     mockUseQueryReturnValue.data.primary_domain = true;
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
     mockUseFormReturnValue.getFieldState = jest.fn().mockReturnValue({
@@ -173,7 +173,7 @@ describe("PrimaryDomainInput", () => {
       isDirty: false,
     });
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
     const user = userEvent.setup();
@@ -194,10 +194,10 @@ describe("PrimaryDomainInput", () => {
   it("shows 'Verify ownership' button if not verified", () => {
     mockUseQueryReturnValue.data.primary_domain = false;
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
     renderComponent(mockListingData, {
@@ -212,7 +212,7 @@ describe("PrimaryDomainInput", () => {
   it("'Verify ownership' button opens modal with token", async () => {
     mockUseQueryReturnValue.data.primary_domain = false;
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
     mockUseFormReturnValue.getFieldState = jest.fn().mockReturnValue({
@@ -220,7 +220,7 @@ describe("PrimaryDomainInput", () => {
       isDirty: false,
     });
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
     const user = userEvent.setup();
@@ -239,7 +239,7 @@ describe("PrimaryDomainInput", () => {
   it("'Verify ownership' button is disabled if field is dirty", async () => {
     mockUseQueryReturnValue.data.primary_domain = false;
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => mockUseQueryReturnValue);
 
     mockUseFormReturnValue.getFieldState = jest.fn().mockReturnValue({
@@ -247,10 +247,9 @@ describe("PrimaryDomainInput", () => {
       isDirty: true,
     });
 
-    // @ts-ignore
+    // @ts-expect-error mocks
     useForm.mockImplementation(() => mockUseFormReturnValue);
 
-    const user = userEvent.setup();
     renderComponent(mockListingData, {
       primary_website: "https://example.com",
     });

--- a/static/js/publisher-pages/pages/Listing/ListingDetails/Screenshot.tsx
+++ b/static/js/publisher-pages/pages/Listing/ListingDetails/Screenshot.tsx
@@ -1,4 +1,11 @@
 import { SyntheticEvent } from "react";
+import {
+  UseFormGetValues,
+  UseFieldArrayRemove,
+  UseFormSetValue,
+  UseFormRegister,
+  FieldValues,
+} from "react-hook-form";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
@@ -6,11 +13,11 @@ type Props = {
   field: { id: string };
   index: number;
   screenshotUrls: Array<string>;
-  getValues: Function;
-  removeScreenshotUrl: Function;
-  setValue: Function;
-  register: Function;
-  setImage: Function;
+  getValues: UseFormGetValues<FieldValues>;
+  removeScreenshotUrl: UseFieldArrayRemove;
+  setValue: UseFormSetValue<FieldValues>;
+  register: UseFormRegister<FieldValues>;
+  setImage: (arg: File) => void;
 };
 
 function Screenshot({

--- a/static/js/publisher-pages/pages/Listing/ListingDetails/ScreenshotList.tsx
+++ b/static/js/publisher-pages/pages/Listing/ListingDetails/ScreenshotList.tsx
@@ -1,10 +1,19 @@
 import { useState } from "react";
 import {
+  UseFormGetValues,
+  UseFormSetValue,
+  UseFormRegister,
+  FieldValues,
+  UseFieldArrayRemove,
+  UseFieldArrayMove,
+} from "react-hook-form";
+import {
   DndContext,
   closestCenter,
   PointerSensor,
   useSensor,
   useSensors,
+  DragEndEvent,
 } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -17,12 +26,12 @@ import Screenshot from "./Screenshot";
 type Props = {
   screenshots: Array<{ id: string }>;
   screenshotUrls: Array<string>;
-  getValues: Function;
-  removeScreenshotUrl: Function;
-  setValue: Function;
-  register: Function;
-  setImage: Function;
-  moveScreenshotUrl: Function;
+  getValues: UseFormGetValues<FieldValues>;
+  removeScreenshotUrl: UseFieldArrayRemove;
+  setValue: UseFormSetValue<FieldValues>;
+  register: UseFormRegister<FieldValues>;
+  setImage: (arg: File) => void;
+  moveScreenshotUrl: UseFieldArrayMove;
 };
 
 function ScreenshotList({
@@ -38,7 +47,7 @@ function ScreenshotList({
   const [items, setItems] = useState(screenshots);
   const sensors = useSensors(useSensor(PointerSensor));
 
-  const handleDragEnd = (e: any) => {
+  const handleDragEnd = (e: DragEndEvent) => {
     const { active, over } = e;
 
     if (active && over && active?.id !== over?.id) {

--- a/static/js/publisher-pages/pages/Listing/ListingDetails/Screenshots.tsx
+++ b/static/js/publisher-pages/pages/Listing/ListingDetails/Screenshots.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
-import { useFieldArray } from "react-hook-form";
+import {
+  useFieldArray,
+  UseFormRegister,
+  UseFormGetValues,
+  UseFormSetValue,
+  FieldValues,
+  Control,
+} from "react-hook-form";
 import { nanoid } from "nanoid";
 import { Row, Col, Notification } from "@canonical/react-components";
 
@@ -8,10 +15,10 @@ import { validateImageDimensions } from "../../../utils";
 import ScreenshotList from "./ScreenshotList";
 
 type Props = {
-  register: Function;
-  control: any;
-  getValues: Function;
-  setValue: Function;
+  register: UseFormRegister<FieldValues>;
+  control: Control<FieldValues>;
+  getValues: UseFormGetValues<FieldValues>;
+  setValue: UseFormSetValue<FieldValues>;
 };
 
 function Screenshots({ register, control, getValues, setValue }: Props) {

--- a/static/js/publisher-pages/pages/Listing/ListingForm/ListingForm.tsx
+++ b/static/js/publisher-pages/pages/Listing/ListingForm/ListingForm.tsx
@@ -23,7 +23,7 @@ import type { ListingData } from "../../../types";
 
 type Props = {
   data: ListingData;
-  refetch: Function;
+  refetch: () => void;
 };
 
 function ListingForm({ data, refetch }: Props): JSX.Element {
@@ -54,9 +54,9 @@ function ListingForm({ data, refetch }: Props): JSX.Element {
   const [showMetadataWarningModal, setShowMetadataWarningModal] =
     useState<boolean>(false);
 
-  const [formValues, setFormValues] = useState<{ [key: string]: any } | null>(
-    null,
-  );
+  const [formValues, setFormValues] = useState<{
+    [key: string]: unknown;
+  } | null>(null);
 
   const { mutate, isLoading } = useMutateListingData({
     data,
@@ -74,7 +74,8 @@ function ListingForm({ data, refetch }: Props): JSX.Element {
     <>
       <form
         className="p-form"
-        onSubmit={handleSubmit((values: any) => {
+        // @ts-expect-error Conflict between React Query and Reach Hook Form
+        onSubmit={handleSubmit((values: ListingData) => {
           if (
             data.update_metadata_on_release &&
             shouldShowUpdateMetadataWarning(dirtyFields)
@@ -118,6 +119,7 @@ function ListingForm({ data, refetch }: Props): JSX.Element {
               <UpdateMetadataModal
                 setShowMetadataWarningModal={setShowMetadataWarningModal}
                 submitForm={mutate}
+                // @ts-expect-error Conflict between React Query and React Hook Form
                 formData={formValues}
               />
             ) : null}

--- a/static/js/publisher-pages/pages/Listing/PreviewForm/PreviewForm.tsx
+++ b/static/js/publisher-pages/pages/Listing/PreviewForm/PreviewForm.tsx
@@ -1,8 +1,9 @@
+import { UseFormGetValues, FieldValues } from "react-hook-form";
 import { Form } from "@canonical/react-components";
 
 type Props = {
   snapName: string;
-  getValues: Function;
+  getValues: UseFormGetValues<FieldValues>;
 };
 
 type ListingData = {

--- a/static/js/publisher-pages/pages/Metrics/ActiveDeviceMetrics.tsx
+++ b/static/js/publisher-pages/pages/Metrics/ActiveDeviceMetrics.tsx
@@ -1,7 +1,7 @@
 import { useParams, useSearchParams } from "react-router-dom";
 import { Row, Col, Spinner, CodeSnippet } from "@canonical/react-components";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { renderActiveDevicesMetrics } from "../../../publisher/metrics/metrics";
 import { select } from "d3-selection";
 import ActiveDeviceAnnotation from "./ActiveDeviceAnnotation";

--- a/static/js/publisher-pages/pages/Metrics/Metrics.tsx
+++ b/static/js/publisher-pages/pages/Metrics/Metrics.tsx
@@ -1,4 +1,4 @@
-import { useParams, useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Row, Col } from "@canonical/react-components";
 
 import SectionNav from "../../components/SectionNav";

--- a/static/js/publisher-pages/pages/Metrics/TerritoryMetrics.tsx
+++ b/static/js/publisher-pages/pages/Metrics/TerritoryMetrics.tsx
@@ -1,11 +1,5 @@
-import { useParams, useSearchParams } from "react-router-dom";
-import {
-  Row,
-  Col,
-  Select,
-  Spinner,
-  CodeSnippet,
-} from "@canonical/react-components";
+import { useParams } from "react-router-dom";
+import { Row, Col, Spinner, CodeSnippet } from "@canonical/react-components";
 
 import { useEffect } from "react";
 import { renderTerritoriesMetrics } from "../../../publisher/metrics/metrics";
@@ -27,7 +21,15 @@ export const TerritoryMetrics = ({
     status: string;
     data:
       | {
-          active_devices: any;
+          active_devices: {
+            [key: string]: {
+              code: string;
+              color_rgb: string;
+              name: string;
+              number_of_users: number;
+              percentage_of_users: number;
+            };
+          };
           territories_total: number;
         }
       | undefined;
@@ -41,6 +43,7 @@ export const TerritoryMetrics = ({
           selector: "#territories",
           metrics: countryInfo.active_devices,
         });
+      // @ts-expect-error Type clash
       onDataLoad(countryInfo.active_devices?.length);
     }
   }, [countryInfo]);

--- a/static/js/publisher-pages/pages/Metrics/__tests__/ActiveDeviceAnnotation.test.tsx
+++ b/static/js/publisher-pages/pages/Metrics/__tests__/ActiveDeviceAnnotation.test.tsx
@@ -13,7 +13,7 @@ const renderComponent = () => {
       <BrowserRouter>
         <ActiveDeviceAnnotation snapId="test" />
       </BrowserRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 };
 
@@ -52,7 +52,7 @@ jest.mock("react-query", () => ({
 
 describe("ActiveDeviceAnnotation", () => {
   test("renders the information correctly", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockReturnValue({
       status: "success",
       data: mockMetricsAnnotation,
@@ -62,33 +62,33 @@ describe("ActiveDeviceAnnotation", () => {
 
     await waitFor(() => {
       const serverAndCloudElement = container.querySelector(
-        '[data-id="category-server-and-cloud"]'
+        '[data-id="category-server-and-cloud"]',
       );
       expect(serverAndCloudElement).toBeInTheDocument();
       expect(serverAndCloudElement).toHaveTextContent(
-        "Added to Server and cloud in January 2019"
+        "Added to Server and cloud in January 2019",
       );
 
       const categoryDevelopmentElement = container.querySelector(
-        '[data-id="category-development"]'
+        '[data-id="category-development"]',
       );
       expect(categoryDevelopmentElement).toBeInTheDocument();
       expect(categoryDevelopmentElement).toHaveTextContent(
-        "Added to Development in February 2019"
+        "Added to Development in February 2019",
       );
 
       const categoryFeaturedElement = container.querySelector(
-        '[data-id="category-featured"]'
+        '[data-id="category-featured"]',
       );
       expect(categoryFeaturedElement).toBeInTheDocument();
       expect(categoryFeaturedElement).toHaveTextContent(
-        "Featured snap since July 2024"
+        "Featured snap since July 2024",
       );
     });
   });
 
   test("renders empty annotations if the data is returned empty", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockReturnValue({
       status: "success",
       data: {
@@ -102,7 +102,7 @@ describe("ActiveDeviceAnnotation", () => {
 
     await waitFor(() => {
       const serverAndCloudElement = container.querySelector(
-        '[data-id="category-server-and-cloud"]'
+        '[data-id="category-server-and-cloud"]',
       );
       expect(serverAndCloudElement).not.toBeInTheDocument();
     });

--- a/static/js/publisher-pages/pages/Metrics/__tests__/ActiveDeviceMetrics.test.tsx
+++ b/static/js/publisher-pages/pages/Metrics/__tests__/ActiveDeviceMetrics.test.tsx
@@ -17,7 +17,7 @@ const renderComponent = (isEmpty: boolean) => {
       <BrowserRouter>
         <ActiveDeviceMetrics isEmpty={isEmpty} onDataLoad={jest.fn()} />
       </BrowserRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 };
 
@@ -82,12 +82,12 @@ jest.mock("react-router-dom", () => ({
 
 describe("ActiveDeviceMetrics", () => {
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useSearchParams.mockReturnValue([new URLSearchParams()]);
   });
 
   test("renders the information correctly", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation((params) => {
       if (params) {
         if (params.queryKey[0] === "activeDeviceMetrics") {
@@ -124,7 +124,7 @@ describe("ActiveDeviceMetrics", () => {
   });
 
   test("renders the error state", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation((params) => {
       if (params) {
         if (params.queryKey[0] === "activeDeviceMetrics") {
@@ -158,13 +158,13 @@ describe("ActiveDeviceMetrics", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("An error occurred. Please try again.")
+        screen.getByText("An error occurred. Please try again."),
       ).toBeInTheDocument();
     });
   });
 
   test("renders the loading state", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation((params) => {
       if (params) {
         if (params.queryKey[0] === "activeDeviceMetrics") {
@@ -202,7 +202,7 @@ describe("ActiveDeviceMetrics", () => {
   });
 
   test("renders the empty state", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation((params) => {
       if (params) {
         if (params.queryKey[0] === "activeDeviceMetrics") {

--- a/static/js/publisher-pages/pages/Metrics/__tests__/TerritoryMetrics.test.tsx
+++ b/static/js/publisher-pages/pages/Metrics/__tests__/TerritoryMetrics.test.tsx
@@ -17,7 +17,7 @@ const renderComponent = (isEmpty: boolean) => {
       <BrowserRouter>
         <TerritoryMetrics isEmpty={isEmpty} onDataLoad={jest.fn()} />
       </BrowserRouter>
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 };
 
@@ -53,12 +53,12 @@ jest.mock("react-router-dom", () => ({
 
 describe("ActiveDeviceMetrics", () => {
   beforeEach(() => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useSearchParams.mockReturnValue([new URLSearchParams()]);
   });
 
   test("renders the information correctly", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => ({
       status: "success",
       data: mockTerritoryMetrics,
@@ -73,7 +73,7 @@ describe("ActiveDeviceMetrics", () => {
   });
 
   test("renders the error state", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => ({
       status: "error",
       data: undefined,
@@ -83,13 +83,13 @@ describe("ActiveDeviceMetrics", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("An error occurred. Please try again.")
+        screen.getByText("An error occurred. Please try again."),
       ).toBeInTheDocument();
     });
   });
 
   test("renders the loading state", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => ({
       isFetching: true,
       data: undefined,
@@ -103,7 +103,7 @@ describe("ActiveDeviceMetrics", () => {
   });
 
   test("renders the empty state", async () => {
-    // @ts-ignore
+    // @ts-expect-error mocks
     useQuery.mockImplementation(() => ({
       status: "success",
       data: undefined,

--- a/static/js/publisher-pages/pages/Publicise/PubliciseCards.tsx
+++ b/static/js/publisher-pages/pages/Publicise/PubliciseCards.tsx
@@ -10,7 +10,7 @@ import {
 function PubliciseCards(): JSX.Element {
   const { snapId } = useParams();
   const [buttonType, setButtonType] = useState<"black" | "white" | "hidden">(
-    "black"
+    "black",
   );
   const [showAllChannels, setShowAllChannels] = useState<boolean>(true);
   const [showSummary, setShowSummary] = useState<boolean>(true);
@@ -35,7 +35,7 @@ function PubliciseCards(): JSX.Element {
   }
 
   const iframeQueryString = new URLSearchParams(
-    iframeQueryParameters
+    iframeQueryParameters,
   ).toString();
 
   const htmlSnippet = `<iframe src="https://snapcraft.io/${snapId}/embedded?${iframeQueryString}"width="100%" height="990px" style="border: 1px solid #CCC; border-radius: 2px;"></iframe>`;
@@ -87,7 +87,7 @@ function PubliciseCards(): JSX.Element {
               onChange={(
                 e: SyntheticEvent<HTMLInputElement> & {
                   target: HTMLInputElement;
-                }
+                },
               ) => {
                 setShowAllChannels(e.target.checked);
               }}
@@ -98,7 +98,7 @@ function PubliciseCards(): JSX.Element {
               onChange={(
                 e: SyntheticEvent<HTMLInputElement> & {
                   target: HTMLInputElement;
-                }
+                },
               ) => {
                 setShowSummary(e.target.checked);
               }}
@@ -109,7 +109,7 @@ function PubliciseCards(): JSX.Element {
               onChange={(
                 e: SyntheticEvent<HTMLInputElement> & {
                   target: HTMLInputElement;
-                }
+                },
               ) => {
                 setShowScreenshot(e.target.checked);
               }}

--- a/static/js/publisher-pages/pages/Publicise/__tests__/Publicise.test.tsx
+++ b/static/js/publisher-pages/pages/Publicise/__tests__/Publicise.test.tsx
@@ -18,7 +18,7 @@ const renderComponent = (view?: "badges" | "cards" | undefined) => {
   );
 };
 
-let mockPubliciseData = {
+const mockPubliciseData = {
   is_released: true,
   private: false,
   trending: false,

--- a/static/js/publisher-pages/pages/Settings/SettingsForm.tsx
+++ b/static/js/publisher-pages/pages/Settings/SettingsForm.tsx
@@ -56,7 +56,7 @@ function SettingsForm({ settings }: Props) {
 
   const isDirty = formState.isDirty;
   const isValid = formState.isValid;
-  const dirtyFields: { [key: string]: any } = formState.dirtyFields;
+  const dirtyFields: { [key: string]: unknown } = formState.dirtyFields;
 
   const whitelistCountryKeyValues = useWatch({
     control,
@@ -68,7 +68,7 @@ function SettingsForm({ settings }: Props) {
     name: "blacklist_country_keys",
   });
 
-  const onSubmit = (data: any) => {
+  const onSubmit = (data: SettingsData) => {
     if (getValues("update_metadata_on_release") && dirtyFields.visibility) {
       setShowMetadataWarningModal(true);
       setFormData(data);
@@ -77,7 +77,7 @@ function SettingsForm({ settings }: Props) {
     }
   };
 
-  const submitForm = async (data: any) => {
+  const submitForm = async (data: SettingsData) => {
     setIsSaving(true);
     setHasSaved(false);
     setSavedError(false);
@@ -312,9 +312,13 @@ function SettingsForm({ settings }: Props) {
                     data={countries}
                     field="whitelist_country_keys"
                     currentValues={settingsData?.whitelist_countries}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     register={register}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     setValue={setValue}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     getValues={getValues}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     control={control}
                     disabled={getValues("country_keys_status") === "exclude"}
                   />
@@ -335,9 +339,13 @@ function SettingsForm({ settings }: Props) {
                     data={countries}
                     field="blacklist_country_keys"
                     currentValues={settingsData?.blacklist_countries}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     register={register}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     setValue={setValue}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     getValues={getValues}
+                    // @ts-expect-error Conflict between React Query and React Hook Form
                     control={control}
                     disabled={getValues("country_keys_status") === "include"}
                   />
@@ -504,6 +512,7 @@ function SettingsForm({ settings }: Props) {
       {showMetadataWarningModal ? (
         <UpdateMetadataModal
           setShowMetadataWarningModal={setShowMetadataWarningModal}
+          // @ts-expect-error Conflict between React Query and React Hook Form
           submitForm={submitForm}
           formData={formData}
         />

--- a/static/js/publisher-pages/pages/Settings/UnregisterSnapModal.tsx
+++ b/static/js/publisher-pages/pages/Settings/UnregisterSnapModal.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { Button, Modal } from "@canonical/react-components";
 
 type UnregisterSnapModalProps = {
   snapName: string;
-  setUnregisterModalOpen: Function;
-  setUnregisterError: Function;
-  setUnregisterErrorMessage: Function;
+  setUnregisterModalOpen: Dispatch<SetStateAction<boolean>>;
+  setUnregisterError: Dispatch<SetStateAction<boolean>>;
+  setUnregisterErrorMessage: Dispatch<SetStateAction<string>>;
 };
 
 export function UnregisterSnapModal({

--- a/static/js/publisher-pages/pages/Settings/__tests__/UnregisterSnapModal.test.tsx
+++ b/static/js/publisher-pages/pages/Settings/__tests__/UnregisterSnapModal.test.tsx
@@ -9,7 +9,7 @@ global.fetch = jest.fn(() =>
   Promise.resolve({
     ok: true,
     json: () => Promise.resolve({}),
-  })
+  }),
 ) as jest.Mock;
 
 const mockSetUnregisterModalOpen = jest.fn();
@@ -68,7 +68,7 @@ describe("UnregisterSnapModal", () => {
           headers: {
             "X-CSRFToken": window["CSRF_TOKEN"],
           },
-        })
+        }),
       );
       expect(window.location.href).toBe("/snaps");
     });
@@ -80,7 +80,7 @@ describe("UnregisterSnapModal", () => {
       Promise.resolve({
         ok: false,
         json: () => Promise.resolve({ error: "Some error occurred" }),
-      })
+      }),
     );
     render(<UnregisterSnapModal {...defaultProps} />);
     await user.click(screen.getByText("Unregister"));
@@ -88,7 +88,7 @@ describe("UnregisterSnapModal", () => {
       expect(mockSetUnregisterModalOpen).toHaveBeenCalledWith(false);
       expect(mockSetUnregisterError).toHaveBeenCalledWith(true);
       expect(mockSetUnregisterErrorMessage).toHaveBeenCalledWith(
-        "Some error occurred"
+        "Some error occurred",
       );
     });
   });
@@ -97,7 +97,7 @@ describe("UnregisterSnapModal", () => {
     const user = userEvent.setup();
     console.error = jest.fn();
     (global.fetch as jest.Mock).mockImplementationOnce(() =>
-      Promise.reject("Fetch error")
+      Promise.reject("Fetch error"),
     );
     render(<UnregisterSnapModal {...defaultProps} />);
     await user.click(screen.getByText("Unregister"));

--- a/static/js/publisher-pages/utils/formatImageChanges.ts
+++ b/static/js/publisher-pages/utils/formatImageChanges.ts
@@ -24,7 +24,7 @@ export default function formatImageChanges(
   }
 
   if (screenshotUrls.length) {
-    screenshotUrls.forEach((url, i) => {
+    screenshotUrls.forEach((url) => {
       images.push({
         url,
         type: "screenshot",

--- a/static/js/publisher-pages/utils/getDefaultListingData.ts
+++ b/static/js/publisher-pages/utils/getDefaultListingData.ts
@@ -37,7 +37,7 @@ function getPublicMetricsDistrosValue(
 }
 
 export default function getDefaultListingData(data: ListingData): {
-  [key: string]: any;
+  [key: string]: unknown;
 } {
   return {
     contacts: data.contacts,

--- a/static/js/publisher-pages/utils/getListingChanges.ts
+++ b/static/js/publisher-pages/utils/getListingChanges.ts
@@ -1,13 +1,32 @@
+import { FieldValues } from "react-hook-form";
+
 import formatImageChanges from "./formatImageChanges";
 
 import type { ListingData } from "../types";
 
 export default function getListingChanges(
-  dirtyFields: any,
-  fieldValues: any,
+  dirtyFields: { [key: string]: boolean },
+  fieldValues: FieldValues,
   data: ListingData,
-): { [key: string]: any } {
-  const changes: { [key: string]: any } = {};
+) {
+  const changes: {
+    [key: string]: unknown;
+    images?: {
+      url: string;
+      type: string;
+      status: string;
+      name?: string;
+    }[];
+    links?: {
+      website: string[];
+      donations: string[];
+      contact: string[];
+      issues: string[];
+      source: string[];
+    };
+    categories?: string[] | undefined;
+    public_metrics_blacklist?: string[];
+  } = {};
 
   if (
     dirtyFields.banner_urls ||

--- a/static/js/publisher-pages/utils/getSettingsChanges.ts
+++ b/static/js/publisher-pages/utils/getSettingsChanges.ts
@@ -1,5 +1,10 @@
-function getSettingsChanges(dirtyFields: { [key: string]: any }, data: any) {
-  const changes: { [key: string]: any } = {};
+import type { SettingsData } from "../types";
+
+function getSettingsChanges(
+  dirtyFields: { [key: string]: unknown },
+  data: SettingsData,
+) {
+  const changes: { [key: string]: unknown } = {};
 
   if (dirtyFields?.visibility) {
     if (data?.visibility === "public") {

--- a/static/js/publisher-pages/utils/getSettingsFormData.ts
+++ b/static/js/publisher-pages/utils/getSettingsFormData.ts
@@ -4,8 +4,8 @@ import type { SettingsData } from "../types";
 
 function getSettingsFormData(
   settingsData: SettingsData,
-  dirtyFields: { [key: string]: any },
-  data: any,
+  dirtyFields: { [key: string]: unknown },
+  data: SettingsData,
 ) {
   const changes = getSettingsChanges(dirtyFields, data);
   const formData = new FormData();

--- a/static/js/publisher-pages/utils/shouldShowUpdateMetadataWarning.ts
+++ b/static/js/publisher-pages/utils/shouldShowUpdateMetadataWarning.ts
@@ -1,5 +1,5 @@
 interface DirtyField {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 function shouldShowUpdateMetadataWarning(dirtyFields: DirtyField) {


### PR DESCRIPTION
## Done
Fixed TypeScript and lint errors in the publisher pages.

**Note**:
- The releases section is ignored because it is legacy code and large structural changes will be required to pass these checks which is dangerous to do in the scope of this project
- Some parts around where React Query and React Form interact has been ignored as there seems to be type clashes between the two
- The lint check will still fail as there are a11y issues to be addressed which will happen in a separate PR

## How to QA
The lint errors should be related to TypeScript
