### PR TITLE
fix: Fix publisher a11y errors in publicise buttons section

### DIFF
--- a/static/js/publisher-pages/pages/Publicise/PubliciseButtons.tsx
+++ b/static/js/publisher-pages/pages/Publicise/PubliciseButtons.tsx
@@ -46,7 +46,7 @@ function PubliciseButtons(): JSX.Element {
     <>
       <Row>
         <Col size={2}>
-          <label>Language:</label>
+          <p>Language:</p>
         </Col>
         <Col size={10}>
           <Select
@@ -86,7 +86,7 @@ function PubliciseButtons(): JSX.Element {
       </Row>
       <Row>
         <Col size={2}>
-          <label>HTML:</label>
+          <p>HTML:</p>
         </Col>
         <Col size={10}>
           <div className="p-code-snippet">
@@ -96,7 +96,7 @@ function PubliciseButtons(): JSX.Element {
       </Row>
       <Row>
         <Col size={2}>
-          <label>Markdown:</label>
+          <p>Markdown:</p>
         </Col>
         <Col size={10}>
           <div className="p-code-snippet">
@@ -121,7 +121,7 @@ function PubliciseButtons(): JSX.Element {
       </Row>
       <Row>
         <Col size={2}>
-          <label>HTML:</label>
+          <p>HTML:</p>
         </Col>
         <Col size={10}>
           <div className="p-code-snippet">
@@ -131,7 +131,7 @@ function PubliciseButtons(): JSX.Element {
       </Row>
       <Row>
         <Col size={2}>
-          <label>Markdown:</label>
+          <p>Markdown:</p>
         </Col>
         <Col size={10}>
           <div className="p-code-snippet">
@@ -144,7 +144,7 @@ function PubliciseButtons(): JSX.Element {
       <hr />
       <Row>
         <Col size={2}>
-          <label>Download all:</label>
+          <p>Download all:</p>
         </Col>
         <Col size={10}>
           <a


### PR DESCRIPTION
## Done
Converted pseudo labels to paragraphs

## How to QA
- Go to https://snapcraft-io-4925.demos.haus/<SNAP_NAME>/publicise
- Check that "Language", "HTML" and "Markdown" still have titles
- **Note**: `lint-js` will still fail as there are errors in other files that need to be addressed separately
