### PR TITLE
fix: Fix a11y errors in license search

### DIFF
--- a/static/js/publisher-pages/pages/Listing/AdditionalInformation/LicenseSearch.tsx
+++ b/static/js/publisher-pages/pages/Listing/AdditionalInformation/LicenseSearch.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { UseFormRegister, UseFormSetValue, FieldValues } from "react-hook-form";
 import Downshift from "downshift";
+import { Button } from "@canonical/react-components";
 
 import debounce from "../../../../libs/debounce";
 
@@ -109,8 +110,15 @@ function LicenseSearch({
                 key={selectedLicense?.key}
               >
                 {selectedLicense?.name}
-                <i
-                  className="p-icon--close p-multiselect__item-remove"
+                <Button
+                  type="button"
+                  style={{
+                    backgroundColor: "transparent",
+                    border: 0,
+                    color: "inherit",
+                    margin: 0,
+                    padding: 0,
+                  }}
                   onClick={() => {
                     const newSelectedLicenses: (License | undefined)[] =
                       selectedLicenses.filter(
@@ -127,8 +135,10 @@ function LicenseSearch({
                     });
                   }}
                 >
-                  Remove license
-                </i>
+                  <i className="p-icon--close p-multiselect__item-remove">
+                    Remove license
+                  </i>
+                </Button>
               </span>
             ))}
             <input

--- a/static/js/publisher-pages/pages/Listing/ListingDetails/ListingDetails.tsx
+++ b/static/js/publisher-pages/pages/Listing/ListingDetails/ListingDetails.tsx
@@ -303,9 +303,10 @@ function ListingDetails({
                 </p>
                 <p>
                   <small>
-                    <strong>Code</strong>: Text indented with 3 spaces or inside single backticks
+                    <strong>Code</strong>: Text indented with 3 spaces or inside
+                    single backticks
                   </small>
-                  <code>`code`</code> 
+                  <code>`code`</code>
                 </p>
               </Col>
             </Row>

--- a/static/sass/_patterns_form-multiselect.scss
+++ b/static/sass/_patterns_form-multiselect.scss
@@ -52,7 +52,6 @@
       .p-multiselect__item-remove {
         cursor: pointer;
         height: 0.75em;
-        margin-bottom: 0.125rem;
         margin-left: 0.5rem;
         width: 0.75em;
       }


### PR DESCRIPTION
## Done
Converted the remove licence icon to a button

## How to QA
- Go to https://snapcraft-io-4928.demos.haus/<SNAP_NAME>/listing
- Check that the "x" icon on selected licences looks and works as expected

## Screenshot
![licence_remove](https://github.com/user-attachments/assets/d0873855-3f14-4944-9262-521109b0a6ce)
