### PR TITLE
fix: Fix a11y errors in search autocomplete

### DIFF
--- a/static/js/publisher-pages/components/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/static/js/publisher-pages/components/SearchAutocomplete/SearchAutocomplete.tsx
@@ -8,6 +8,7 @@ import {
   Control,
   FieldValues,
 } from "react-hook-form";
+import { Button } from "@canonical/react-components";
 
 type DataItem = {
   key: string;
@@ -86,8 +87,15 @@ function SearchAutocomplete({
           {selections.map((suggestion: DataItem) => (
             <span key={suggestion.key} className="p-multiselect__item">
               {suggestion.name}
-              <i
-                className="p-icon--close p-multiselect__item-remove"
+              <Button
+                type="button"
+                style={{
+                  backgroundColor: "transparent",
+                  border: 0,
+                  color: "inherit",
+                  margin: 0,
+                  padding: 0,
+                }}
                 onClick={() => {
                   const newSelections = selections.filter(
                     (item: DataItem) => item.key !== suggestion.key,
@@ -101,8 +109,10 @@ function SearchAutocomplete({
                   });
                 }}
               >
-                Remove suggestion
-              </i>
+                <i className="p-icon--close p-multiselect__item-remove">
+                  Remove suggestion
+                </i>
+              </Button>
             </span>
           ))}
 


### PR DESCRIPTION
## Done
Converted the remove licence icon to a button

## How to QA
- https://snapcraft-io-4929.demos.haus/<SNAP_NAME>/settings
- Check that the "x" icon on selected licences looks and works as expected

## Screenshot

![licence_search](https://github.com/user-attachments/assets/e71325b6-4f13-48ee-973c-71ad1d156dab)
