### PR TITLE
fix: stick metrics tooltip to edge of screen

### DIFF
--- a/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.ts
+++ b/static/js/publisher/metrics/graphs/activeDevicesGraph/tooltips.ts
@@ -163,6 +163,19 @@ export function tooltips(this: any) {
       .node()
       .getBoundingClientRect();
 
+    const windowWidth = window.innerWidth;
+    let adjustedLeft = mousePosition[0] + this.margin.left;
+
+    if (tooltipBounding.right > (windowWidth - 15)) {
+      adjustedLeft -= (tooltipBounding.right - windowWidth) + 15;
+    }
+
+    if (tooltipBounding.left < 0) {
+      adjustedLeft -= tooltipBounding.left;
+    }
+
+    this.tooltip.style("left", `${adjustedLeft}px`);
+
     if (tooltipBounding.top < 0) {
       this.tooltip
         .select(".p-tooltip")


### PR DESCRIPTION
## Done
Makes tooltip stick to edge of screen when hovering too far right or left.

## How to QA
- Go to any snap's Metrics page, make the page width smaller and hover to the edge of the graph. 
- The tooltip should not float off the edge, it should stick to the right or left so that no information is hidden.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no behavioural change

## Issue / Card
Fixes [WD-17149](https://warthogs.atlassian.net/browse/WD-17149) and [4909](https://github.com/canonical/snapcraft.io/issues/4909)

[WD-17149]: https://warthogs.atlassian.net/browse/WD-17149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ