### PR TITLE
fix: Fix primary website field clearing on revert

### DIFF
--- a/static/js/publisher-pages/pages/Listing/ContactInformation/PrimaryDomainInput.tsx
+++ b/static/js/publisher-pages/pages/Listing/ContactInformation/PrimaryDomainInput.tsx
@@ -121,6 +121,7 @@ function PrimaryDomainInput({
             <input
               type="url"
               id={id}
+              defaultValue={defaultDomain}
               className="p-form-validation__input"
               {...register("primary_website")}
             />

--- a/static/js/publisher-pages/pages/Listing/ContactInformation/__tests__/PrimaryDomainInput.test.tsx
+++ b/static/js/publisher-pages/pages/Listing/ContactInformation/__tests__/PrimaryDomainInput.test.tsx
@@ -103,7 +103,7 @@ describe("PrimaryDomainInput", () => {
       primary_website: "https://example.com",
     });
     const input = screen.getByRole("textbox", { name: "Primary website:" });
-    await user.type(input, "https://example.comabc");
+    await user.type(input, "abc");
     expect(input).toHaveValue("https://example.comabc");
 
     expect(


### PR DESCRIPTION
## Done
Fixed bug where the primary domain input is cleared when reverting the listing form

## How to QA
- Go to https://snapcraft-io-4938.demos.haus/<SNAP_NAME>/listing (it must have a populated "Primary domain" field)
- Change the value of any field
- Press the "Revert" button
- Check that the "Primary domain" field has it's original value

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-17673