### PR TITLE
fix: Make sure Edit button on preview page closes current tab

### DIFF
--- a/static/js/publisher-pages/pages/Listing/PreviewForm/PreviewForm.tsx
+++ b/static/js/publisher-pages/pages/Listing/PreviewForm/PreviewForm.tsx
@@ -100,6 +100,7 @@ function PreviewForm({ snapName, getValues }: Props) {
       encType="multipart/form-data"
       className="u-hide"
       target="_blank"
+      rel="opener"
     >
       <input type="hidden" name="csrf_token" defaultValue={window.CSRF_TOKEN} />
       <input

--- a/templates/publisher/account-snaps.html
+++ b/templates/publisher/account-snaps.html
@@ -265,10 +265,6 @@ My published snaps — Linux software in the Snap Store
 {% endif %}
 {% endblock %}
 
-{% block scripts_includes %}
-<script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
-{% endblock %}
-
 {% block scripts %}
 {% if snaps %}
 <script>

--- a/templates/publisher/publicise/store_buttons.html
+++ b/templates/publisher/publicise/store_buttons.html
@@ -133,10 +133,6 @@
   </div>
 {% endblock %}
 
-{% block scripts_includes %}
-  <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
-{% endblock %}
-
 {% block scripts %}
   <script>
     window.addEventListener("DOMContentLoaded", function() {

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -309,9 +309,6 @@
 
 {% block scripts_includes %}
   <script src="{{ static_url('js/dist/store-details.js') }}" defer></script>
-  {% if is_preview %}
-    <script src="{{ static_url('js/dist/publisher.js') }}" defer></script>
-  {% endif %}
 {% endblock %}
 
 {% block scripts %}
@@ -374,7 +371,15 @@
         {% endif %}
 
         {% if is_preview %}
-          snapcraft.publisher.preview({{ package_name|tojson }});
+          const editButton = document.querySelector('.js-edit');
+          if (editButton) {
+            editButton.addEventListener("click", (e) => {
+              if (window.opener) {
+                e.preventDefault();
+                window.close();
+              }
+            });
+          }
         {% endif %}
       });
     });


### PR DESCRIPTION
## Done
- Makes sure the Edit button on preview page closes the current tab to take the user back to the `listing` page to make edits
- Removes statements requesting old `publisher.js` and `preview` code

## How to QA
- Go to https://snapcraft-io-4939.demos.haus/<SNAP_NAME>/listing
- Change the value of any field
- Press the "Preview" button
- Click "Edit" at the top of the screen
- Make sure the current tab closes

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes [WD-17675](https://warthogs.atlassian.net/browse/WD-17675)


[WD-17675]: https://warthogs.atlassian.net/browse/WD-17675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ