### PR TITLE
fix: remove extra whitespace in embeddable card

### DIFF
--- a/static/js/publisher-pages/pages/Publicise/PubliciseCards.tsx
+++ b/static/js/publisher-pages/pages/Publicise/PubliciseCards.tsx
@@ -1,4 +1,4 @@
-import { useState, SyntheticEvent } from "react";
+import { useState, useRef, SyntheticEvent } from "react";
 import { useParams } from "react-router-dom";
 import {
   Row,
@@ -16,6 +16,7 @@ function PubliciseCards(): JSX.Element {
   const [showSummary, setShowSummary] = useState<boolean>(true);
   const [showScreenshot, setShowScreenshot] = useState<boolean>(true);
 
+  const iframeRef = useRef<HTMLIFrameElement>(null);
   const iframeQueryParameters: { [key: string]: string } = {};
 
   if (buttonType !== "hidden") {
@@ -38,7 +39,22 @@ function PubliciseCards(): JSX.Element {
     iframeQueryParameters,
   ).toString();
 
-  const htmlSnippet = `<iframe title="Publicise card" src="https://snapcraft.io/${snapId}/embedded?${iframeQueryString}"width="100%" height="990px" style="border: 1px solid #CCC; border-radius: 2px;"></iframe>`;
+  const htmlSnippet = `<iframe title="Publicise card" src="https://snapcraft.io/${snapId}/embedded?${iframeQueryString}" style="width: 100%; height: 100%; border: 1px solid #CCC; border-radius: 2px;"></iframe>`;
+
+  const adjustIframeHeight = () => {
+    const iframe = iframeRef.current;
+    if (iframe) {
+      try {
+        iframe.style.height =
+          iframe.contentWindow?.document.body.scrollHeight + "px";
+      } catch (error) {
+        console.warn(
+          "Unable to access iframe content for height adjustment:",
+          error,
+        );
+      }
+    }
+  };
 
   return (
     <>
@@ -124,14 +140,16 @@ function PubliciseCards(): JSX.Element {
         <Col size={8}>
           <p>
             <iframe
+              ref={iframeRef}
               title="Card preview"
               src={`/${snapId}/embedded?${iframeQueryString}`}
               width="100%"
               style={{
                 border: "1px solid rgb(204, 204, 204)",
                 borderRadius: "2px",
-                height: "990px",
+                height: "auto",
               }}
+              onLoad={adjustIframeHeight}
             ></iframe>
           </p>
         </Col>


### PR DESCRIPTION
## Done
- Removes extra whitespace from embeddable card template

## How to QA
- Go to https://snapcraft-io-4943.demos.haus/<snap_name>/publicise/cards
- Check that there is no unnecessary whitespace in the embeddable card preview
- Change the settings and make sure the card resizes

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes [WD-17680](https://warthogs.atlassian.net/browse/WD-17680)


[WD-17680]: https://warthogs.atlassian.net/browse/WD-17680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ