### PR TITLE
fix: Fix preview card button being squashed

### DIFF
--- a/static/sass/styles-embedded.scss
+++ b/static/sass/styles-embedded.scss
@@ -58,7 +58,9 @@ body {
 // responsive styles for summary + badge
 @media screen and (min-width: $breakpoint-x-small) {
   .p-embedded-description {
+    align-items: center;
     display: flex;
+    justify-content: space-between;
   }
 
   .p-embedded-description__summary {

--- a/templates/store/snap-embedded-card.html
+++ b/templates/store/snap-embedded-card.html
@@ -56,8 +56,10 @@
         <h4 class="p-embedded-description__summary">{{ summary }}</h4>
       {% endif %}
       {% if button %}
-      <img alt="Get it from the Snap Store"
+      <div>
+        <img alt="Get it from the Snap Store"
         src="https://snapcraft.io/en/{% if button == 'white' %}light{% else %}dark{% endif %}/install.svg" />
+      </div>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Done
Fixed issue where preview card button is squashed

## How to QA
- Go to https://snapcraft-io-4945.demos.haus/<SNAP_NAME>/publicise/cards
- Check that the "Get if from the Snapstore" button looks as expected

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-17679