### PR TITLE
fix: Add loading state to single build page

### DIFF
--- a/static/js/publisher-pages/pages/Build/Build.tsx
+++ b/static/js/publisher-pages/pages/Build/Build.tsx
@@ -7,7 +7,7 @@ import SectionNav from "../../components/SectionNav";
 
 function Build(): JSX.Element {
   const { buildId, snapId } = useParams();
-  const { data, isFetched } = useQuery({
+  const { data, isFetched, isLoading } = useQuery({
     queryKey: ["build"],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/builds/${buildId}`);
@@ -33,56 +33,62 @@ function Build(): JSX.Element {
         <Link to={`/${snapId}/builds`}>Builds</Link> / Build #{buildId}
       </h1>
       <SectionNav activeTab="builds" snapName={snapId} />
+      {isLoading && (
+        <Strip shallow>
+          <p>
+            <i className="p-icon--spinner u-animation--spin"></i>&nbsp;Loading{" "}
+            {snapId} build data
+          </p>
+        </Strip>
+      )}
       <Strip shallow>
         {isFetched && data && (
-          <MainTable
-            headers={[
-              { content: "id" },
-              { content: "Architecture" },
-              { content: "Build duration" },
-              { content: "Result" },
-              { content: "Build finished", className: "u-align-text--right" },
-            ]}
-            rows={[
-              {
-                columns: [
-                  { content: buildId },
-                  { content: data.snap_build.arch_tag },
-                  { content: data.snap_build.duration },
-                  { content: data.snap_build.status },
-                  {
-                    content: formatDistanceToNow(data.snap_build.datebuilt, {
-                      addSuffix: true,
-                    }),
-                    className: "u-align--right",
-                  },
-                ],
-              },
-            ]}
-          />
-        )}
-        <Row>
-          <Col size={6}>
-            <h2 className="p-heading--4">Build log</h2>
-          </Col>
-          <Col size={6} className="u-align-text--right">
-            <a className="p-button--base" href="#footer">
-              Scroll to bottom
-            </a>
-            {isFetched && data && (
-              <a
-                target="_blank"
-                href={data.snap_build.logs}
-                className="p-button"
-                rel="noreferrer"
-              >
-                View raw
-              </a>
-            )}
-          </Col>
-        </Row>
-        {isFetched && data && (
           <>
+            <MainTable
+              headers={[
+                { content: "id" },
+                { content: "Architecture" },
+                { content: "Build duration" },
+                { content: "Result" },
+                { content: "Build finished", className: "u-align-text--right" },
+              ]}
+              rows={[
+                {
+                  columns: [
+                    { content: buildId },
+                    { content: data.snap_build.arch_tag },
+                    { content: data.snap_build.duration },
+                    { content: data.snap_build.status },
+                    {
+                      content: formatDistanceToNow(data.snap_build.datebuilt, {
+                        addSuffix: true,
+                      }),
+                      className: "u-align--right",
+                    },
+                  ],
+                },
+              ]}
+            />
+            <Row>
+              <Col size={6}>
+                <h2 className="p-heading--4">Build log</h2>
+              </Col>
+              <Col size={6} className="u-align-text--right">
+                <a className="p-button--base" href="#footer">
+                  Scroll to bottom
+                </a>
+                {isFetched && data && (
+                  <a
+                    target="_blank"
+                    href={data.snap_build.logs}
+                    className="p-button"
+                    rel="noreferrer"
+                  >
+                    View raw
+                  </a>
+                )}
+              </Col>
+            </Row>
             <pre>{data.raw_logs}</pre>
           </>
         )}

--- a/static/js/publisher-pages/pages/Releases/Releases.tsx
+++ b/static/js/publisher-pages/pages/Releases/Releases.tsx
@@ -39,7 +39,7 @@ function Releases(): JSX.Element {
         <Strip shallow>
           <p>
             <i className="p-icon--spinner u-animation--spin"></i>&nbsp;Loading{" "}
-            {snapId} releases data
+            {snapId} builds data
           </p>
         </Strip>
       )}


### PR DESCRIPTION
## Done
Added a loading state to the single build page

## How to QA
- Run the repo locally
- Follow the steps to setup a GitHub application: https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds
- Go to a snap with builds, e.g. /<SNAP_NAME>/builds
- Click to a single build page
- Check that there is a loading state before the data loads

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-17167