### PR TITLE
fix: ensure markdown is rendered correctly

### DIFF
--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -1,4 +1,5 @@
 import re
+import html
 
 from mistune import HTMLRenderer, Markdown
 from mistune.block_parser import (
@@ -59,4 +60,5 @@ parser = Markdown(
 
 
 def parse_markdown_description(content):
-    return parser(content)
+    unescaped_content = html.unescape(content)
+    return parser(unescaped_content)


### PR DESCRIPTION
## Done
- Ensures `<` and `>` symbols are rendered correctly in preview pages of snaps

## How to QA
- Go to https://snapcraft-io-4948.demos.haus/test-flight-tracker/listing and click "Preview" and check that the symbols are rendered correctly in the Description
- Compare against https://snapcraft-io-4934.demos.haus/test-flight-tracker/listing (again, click "Preview")
    - The symbols here are not rendering
- Can also QA with `deno` snap description 

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-17676](https://warthogs.atlassian.net/browse/WD-17676)



[WD-17676]: https://warthogs.atlassian.net/browse/WD-17676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ