### PR TITLE
fix: build page showing stale data while fetching logs

### DIFF
--- a/static/js/publisher-pages/pages/Build/Build.tsx
+++ b/static/js/publisher-pages/pages/Build/Build.tsx
@@ -7,8 +7,8 @@ import SectionNav from "../../components/SectionNav";
 
 function Build(): JSX.Element {
   const { buildId, snapId } = useParams();
-  const { data, isFetched, isLoading } = useQuery({
-    queryKey: ["build"],
+  const { data, isFetched, isLoading, isFetching } = useQuery({
+    queryKey: ["build", snapId, buildId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/builds/${buildId}`);
 
@@ -24,7 +24,14 @@ function Build(): JSX.Element {
 
       return responseData.data;
     },
+    refetchOnWindowFocus: false,
   });
+
+  const isDataLoading =
+    isLoading ||
+    isFetching ||
+    !data ||
+    (data.snap_build && data.snap_build.id.toString() !== buildId);
 
   return (
     <>
@@ -33,7 +40,7 @@ function Build(): JSX.Element {
         <Link to={`/${snapId}/builds`}>Builds</Link> / Build #{buildId}
       </h1>
       <SectionNav activeTab="builds" snapName={snapId} />
-      {isLoading && (
+      {isDataLoading && (
         <Strip shallow>
           <p>
             <i className="p-icon--spinner u-animation--spin"></i>&nbsp;Loading{" "}
@@ -41,58 +48,54 @@ function Build(): JSX.Element {
           </p>
         </Strip>
       )}
-      <Strip shallow>
-        {isFetched && data && (
-          <>
-            <MainTable
-              headers={[
-                { content: "id" },
-                { content: "Architecture" },
-                { content: "Build duration" },
-                { content: "Result" },
-                { content: "Build finished", className: "u-align-text--right" },
-              ]}
-              rows={[
-                {
-                  columns: [
-                    { content: buildId },
-                    { content: data.snap_build.arch_tag },
-                    { content: data.snap_build.duration },
-                    { content: data.snap_build.status },
-                    {
-                      content: formatDistanceToNow(data.snap_build.datebuilt, {
-                        addSuffix: true,
-                      }),
-                      className: "u-align--right",
-                    },
-                  ],
-                },
-              ]}
-            />
-            <Row>
-              <Col size={6}>
-                <h2 className="p-heading--4">Build log</h2>
-              </Col>
-              <Col size={6} className="u-align-text--right">
-                <a className="p-button--base" href="#footer">
-                  Scroll to bottom
-                </a>
-                {isFetched && data && (
-                  <a
-                    target="_blank"
-                    href={data.snap_build.logs}
-                    className="p-button"
-                    rel="noreferrer"
-                  >
-                    View raw
-                  </a>
-                )}
-              </Col>
-            </Row>
-            <pre>{data.raw_logs}</pre>
-          </>
-        )}
-      </Strip>
+      {!isDataLoading && isFetched && data && (
+        <Strip shallow>
+          <MainTable
+            headers={[
+              { content: "id" },
+              { content: "Architecture" },
+              { content: "Build duration" },
+              { content: "Result" },
+              { content: "Build finished", className: "u-align-text--right" },
+            ]}
+            rows={[
+              {
+                columns: [
+                  { content: buildId },
+                  { content: data.snap_build.arch_tag },
+                  { content: data.snap_build.duration },
+                  { content: data.snap_build.status },
+                  {
+                    content: formatDistanceToNow(data.snap_build.datebuilt, {
+                      addSuffix: true,
+                    }),
+                    className: "u-align--right",
+                  },
+                ],
+              },
+            ]}
+          />
+          <Row>
+            <Col size={6}>
+              <h2 className="p-heading--4">Build log</h2>
+            </Col>
+            <Col size={6} className="u-align-text--right">
+              <a className="p-button--base" href="#footer">
+                Scroll to bottom
+              </a>
+              <a
+                target="_blank"
+                href={data.snap_build.logs}
+                className="p-button"
+                rel="noreferrer"
+              >
+                View raw
+              </a>
+            </Col>
+          </Row>
+          <pre>{data.raw_logs}</pre>
+        </Strip>
+      )}
       <div id="footer"></div>
     </>
   );


### PR DESCRIPTION
## Done
- Show a loading state not just on initial load (`isLoading`) but also when the query is refetching old data (`isFetching`)
- Verify that returned data matches the current `buildId` before rendering to ensure correct data is shown

## How to QA
- Go to demo and to a snap with builds

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-17896

