### PR TITLE
fix: Fix missing banner in listing publisher page

### DIFF
--- a/static/js/publisher-pages/pages/Listing/ListingDetails/ImageUpload.tsx
+++ b/static/js/publisher-pages/pages/Listing/ListingDetails/ImageUpload.tsx
@@ -144,6 +144,16 @@ function ImageUpload({
     };
   };
 
+  const showDeleteButton = (): boolean => {
+    const fieldValue = getValues(imageUrlFieldKey);
+
+    if (fieldValue && fieldValue.length > 0) {
+      return true;
+    }
+
+    return false;
+  };
+
   return (
     <Row className="p-form__group p-form__group--top" data-tour={tourLabel}>
       <Col size={2}>
@@ -179,7 +189,8 @@ function ImageUpload({
                 setIsDragging(false);
               }}
             >
-              {getValues(imageUrlFieldKey) ? (
+              {getValues(imageUrlFieldKey) &&
+              getValues(imageUrlFieldKey).length > 0 ? (
                 <div
                   className="snap-image-upload-preview"
                   style={{
@@ -239,7 +250,7 @@ function ImageUpload({
               />
             </div>
 
-            {previewImageUrl && (
+            {showDeleteButton() && (
               <button
                 type="button"
                 className="p-button--base snap-remove-icon"

--- a/static/js/publisher-pages/utils/__tests__/getDefaultListingData.test.ts
+++ b/static/js/publisher-pages/utils/__tests__/getDefaultListingData.test.ts
@@ -28,7 +28,6 @@ describe("getDefaultData", () => {
     expect(defaultData.video_urls).toBeDefined();
     expect(defaultData.websites).toBeDefined();
 
-    expect(defaultData.banner_urls).not.toBeDefined();
     expect(defaultData.categories).not.toBeDefined();
     expect(defaultData.public_metrics_blacklist).not.toBeDefined();
     expect(defaultData.snap_id).not.toBeDefined();

--- a/static/js/publisher-pages/utils/getDefaultListingData.ts
+++ b/static/js/publisher-pages/utils/getDefaultListingData.ts
@@ -40,6 +40,7 @@ export default function getDefaultListingData(data: ListingData): {
   [key: string]: unknown;
 } {
   return {
+    banner_urls: data.banner_urls,
     contacts: data.contacts,
     description: data.description,
     donations: data.donations,


### PR DESCRIPTION
## Done
Fixed bugs where the banner image wasn't being displayed in the listing publisher page and delete icons weren't showing when reverting changes.

## How to QA
- Go to https://snapcraft-io-4950.demos.haus/<SNAP_NAME>/listing
- If a banner is uploaded it should be visible
- Delete the banner and save
- Upload a banner then revert change
- The remove banner icon should be there

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes:
- https://warthogs.atlassian.net/browse/WD-17890
- https://warthogs.atlassian.net/browse/WD-17889
- https://warthogs.atlassian.net/browse/WD-17888
- https://warthogs.atlassian.net/browse/WD-17885