### PR TITLE
fix: Fix form not resetting when making changes to images

### DIFF
--- a/static/js/publisher-pages/hooks/useMutateListingData.ts
+++ b/static/js/publisher-pages/hooks/useMutateListingData.ts
@@ -21,7 +21,6 @@ type Options = {
 function useMutateListingData({
   data,
   dirtyFields,
-  getDefaultData,
   refetch,
   reset,
   setShowSuccessNotification,
@@ -86,13 +85,17 @@ function useMutateListingData({
       }
     },
     onSuccess: () => {
-      const response = refetch();
-      setShowSuccessNotification(true);
-      // @ts-expect-error Conflict between React Query and React Hook Form
-      reset(getDefaultData(response.data));
-
       const mainPanel = document.querySelector(".l-main") as HTMLElement;
       mainPanel.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+      refetch();
+      setShowSuccessNotification(true);
+    },
+    onSettled: (_error, _context, data) => {
+      if (data) {
+        reset(data);
+      } else {
+        reset();
+      }
     },
   });
 }

--- a/static/js/publisher-pages/utils/__tests__/formatImageChanges.test.ts
+++ b/static/js/publisher-pages/utils/__tests__/formatImageChanges.test.ts
@@ -7,7 +7,6 @@ describe("formatImageChanges", () => {
       "https://example.com/icon",
       ["https://example.com/screenshot"],
       [],
-      {},
     );
 
     expect(imageChanges[0].url).toBe("https://example.com/banner");

--- a/static/js/publisher-pages/utils/formatImageChanges.ts
+++ b/static/js/publisher-pages/utils/formatImageChanges.ts
@@ -3,11 +3,10 @@ export default function formatImageChanges(
   iconUrl: string,
   screenshotUrls: string[],
   screenshots: FileList[],
-  dirtyFields: { [key: string]: boolean },
 ) {
   const images = [];
 
-  if (!dirtyFields.banner_urls && bannerUrls.length > 0) {
+  if (bannerUrls.length > 0) {
     images.push({
       url: bannerUrls[0],
       type: "banner",

--- a/static/js/publisher-pages/utils/getListingChanges.ts
+++ b/static/js/publisher-pages/utils/getListingChanges.ts
@@ -41,7 +41,6 @@ export default function getListingChanges(
       fieldValues.icon_url,
       fieldValues.screenshot_urls,
       fieldValues.screenshots,
-      dirtyFields,
     );
   }
 


### PR DESCRIPTION
## Done
Fixed a bug where changes to images on the publisher listing page were not resetting the form properly when saved

## How to QA
- Go to https://snapcraft-io-4952.demos.haus/<SNAP_NAME>/listing
- Add or remove an icon or banner and save the form
- The page should scroll back to the top and the "Revert" and "Save" buttons should be disabled

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes:
- https://warthogs.atlassian.net/browse/WD-17891
- https://warthogs.atlassian.net/browse/WD-17892
- https://warthogs.atlassian.net/browse/WD-17893
- https://warthogs.atlassian.net/browse/WD-17886
- https://warthogs.atlassian.net/browse/WD-17887