### PR TITLE
fix: Fix bug where snaps weren't loading when adding to store

### DIFF
--- a/static/js/brand-store/pages/Snaps/SnapsSearch.tsx
+++ b/static/js/brand-store/pages/Snaps/SnapsSearch.tsx
@@ -58,7 +58,7 @@ function SnapsSearch({
                 setIsSearching(true);
 
                 fetch(
-                  `/admin/${storeId}/snaps/search?q=${e.target.value}&allowed_for_inclusion=${storeId}`,
+                  `/api/${storeId}/snaps/search?q=${e.target.value}&allowed_for_inclusion=${storeId}`,
                 )
                   .then((response) => {
                     if (response.status !== 200) {
@@ -135,6 +135,8 @@ function SnapsSearch({
                         style: {
                           backgroundColor:
                             highlightedIndex === index ? "#f7f7f7" : "#fff",
+                          paddingLeft: "1rem",
+                          paddingRight: "1rem",
                         },
                       })}
                     >


### PR DESCRIPTION
## Done
Fixed a bug where the list of snaps to include in a store were not loading

## How to QA
- Go to https://snapcraft-io-4973.demos.haus/admin
- Press the "Include snap" button
- Type into the "Search available snaps" input, e.g. `core`
- Check that results appear

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):
