### PR TITLE
Fix (or silence) Sass warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-python": "yarn run lint-python && FLASK_DEBUG=0 python3 -m unittest discover tests",
     "test-python-job": "SECRET_KEY=insecure_secret_key coverage run  --source=. -m unittest discover tests",
     "build": "yarn run build-js && yarn run build-css",
-    "build-css": "sass static/sass/styles.scss:static/css/styles.css static/sass/styles-embedded.scss:static/css/styles-embedded.css --load-path=node_modules --style=compressed && postcss --use autoprefixer --no-map --replace 'static/css/**/*.css'",
+    "build-css": "sass --quiet-deps static/sass/styles.scss:static/css/styles.css static/sass/styles-embedded.scss:static/css/styles-embedded.css --load-path=node_modules --style=compressed && postcss --use autoprefixer --no-map --replace 'static/css/**/*.css'",
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-bundle",
     "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/d3/dist/d3.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-bundle": "webpack && yarn build-latest-news",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test-python": "yarn run lint-python && FLASK_DEBUG=0 python3 -m unittest discover tests",
     "test-python-job": "SECRET_KEY=insecure_secret_key coverage run  --source=. -m unittest discover tests",
     "build": "yarn run build-js && yarn run build-css",
-    "build-css": "sass --quiet-deps static/sass/styles.scss:static/css/styles.css static/sass/styles-embedded.scss:static/css/styles-embedded.css --load-path=node_modules --style=compressed && postcss --use autoprefixer --no-map --replace 'static/css/**/*.css'",
+    "build-css": "sass --quiet-deps --silence-deprecation=import static/sass/styles.scss:static/css/styles.css static/sass/styles-embedded.scss:static/css/styles-embedded.css --load-path=node_modules --style=compressed && postcss --use autoprefixer --no-map --replace 'static/css/**/*.css'",
     "build-js": "yarn run copy-3rd-party-js && yarn run build-js-bundle",
     "copy-3rd-party-js": "mkdir -p static/js/modules && cp node_modules/d3/dist/d3.min.js static/js/modules && cp node_modules/clipboard/dist/clipboard.min.js static/js/modules && cp node_modules/raven-js/dist/raven.min.js static/js/modules",
     "build-js-bundle": "webpack && yarn build-latest-news",

--- a/static/sass/_patterns_first-snap-flow.scss
+++ b/static/sass/_patterns_first-snap-flow.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin snapcraft-p-first-snap-flow {
   .p-flow-details {
     width: 100%;
@@ -16,11 +18,11 @@
   // before this vanilla bug is fixed:
   // https://github.com/canonical-web-and-design/vanilla-framework/issues/2301
   .p-accordion p {
-    margin-bottom: map-get($sp-after, p) - map-get($nudges, nudge--p);
+    margin-bottom: map.get($sp-after, p) - map.get($nudges, nudge--p);
   }
 
   .p-accordion__panel {
-    $icon-size: map-get($icon-sizes, accordion);
+    $icon-size: map.get($icon-sizes, accordion);
 
     overflow: visible;
     padding-left: $sph--large + $icon-size + $sph--large; // same as accordion button

--- a/static/sass/_snapcraft_p-build.scss
+++ b/static/sass/_snapcraft_p-build.scss
@@ -1,5 +1,7 @@
+@use "sass:map";
+
 @mixin snapcraft-p-build {
-  $icon-size: map-get($icon-sizes, default);
+  $icon-size: map.get($icon-sizes, default);
 
   .p-icon--github-white {
     @extend %icon;

--- a/static/sass/_snapcraft_p-progressive-bar.scss
+++ b/static/sass/_snapcraft_p-progressive-bar.scss
@@ -1,7 +1,9 @@
+@use "sass:color";
+
 @mixin snapcraft-p-progressive-bar {
-  $inactive: scale-color($color-link, $lightness: 90%);
+  $inactive: color.scale($color-link, $lightness: 90%);
   $active: $color-link;
-  $target: scale-color($color-link, $lightness: -20%);
+  $target: color.scale($color-link, $lightness: -20%);
 
   %bar {
     border-radius: 9px 0 0 9px;
@@ -45,11 +47,11 @@
     pointer-events: none;
 
     .progressive-bar__current {
-      background: lighten(grayscale($active), 20);
+      background: color.adjust(color.grayscale($active), $lightness: 20%, $space: hsl);
     }
 
     .progressive-bar__target {
-      background: lighten(grayscale($target), 20);
+      background: color.adjust(color.grayscale($target), $lightness: 20%, $space: hsl);
     }
   }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -20,7 +20,7 @@ $font-display-option: swap;
 $breakpoint-medium: 619px;
 
 // vanilla patterns
-@import "vanilla-framework/scss/vanilla";
+@import "vanilla-framework";
 @include vanilla;
 
 // import cookie policy

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 // colour definitions
 $ubuntu-orange: #e95420;
 $color-brand: #00302f;
@@ -416,7 +418,7 @@ dl {
     background-color: $colors--light-theme--border-default;
     display: block;
     height: 100%;
-    left: map-get($grid-gutter-widths, default) * -0.5;
+    left: map.get($grid-gutter-widths, default) * -0.5;
     position: absolute;
     width: 1px;
   }

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -13,7 +13,19 @@ module.exports = [
   },
   {
     test: /\.s[ac]ss$/i,
-    use: ["style-loader", "css-loader", "sass-loader"],
+    use: [
+      "style-loader",
+      "css-loader",
+      {
+        loader: "sass-loader",
+        options: {
+          sassOptions: {
+               quietDeps: true,
+               silenceDeprecations: ["import", "global-builtin"],
+          },
+        },
+      },
+    ],
   },
   // TODO:
   // we should get rid of using globals making expose-loader unnecessary


### PR DESCRIPTION
## Done

- silences all sass warnings from dependencies (Vanilla)
- silences all sass warnings related to `import` (they are not urgent and require quite significant changes, automatic migrator doesn't seem to work out of the box https://sass-lang.com/documentation/breaking-changes/import/)
- silences warnings in webpack build as well (also from react-components and store-components)
- updates relevant code around color and other built-in functions to use their latest versions

A follow-up was created to fix warnings upstream in store-components: WD-18313
A follow-up was created to potentially fix import warnings if time allows: WD-18312

## How to QA

- Check the [build logs on CI](https://github.com/canonical/snapcraft.io/actions/runs/12868109724/job/35874131217?pr=4988)
- or pull the branch, run `dotrun build`
- there should be no warnings thrown by SCSS build

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): this is a build config change

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-18305

