### PR TITLE
fix: Fix issue with metrics endpoints returning 404

### DIFF
--- a/tests/publisher/snaps/tests_get_metrics.py
+++ b/tests/publisher/snaps/tests_get_metrics.py
@@ -50,7 +50,7 @@ class GetActiveDeviceMetrics(TestCase):
     @patch("webapp.publisher.snaps.views.authentication.is_authenticated")
     @patch(
         "canonicalwebteam.store_api.stores."
-        "snapstore.SnapStore.get_item_details"
+        "snapstore.SnapPublisher.get_snap_info"
     )
     @patch(
         "canonicalwebteam.store_api.stores."
@@ -64,7 +64,7 @@ class GetActiveDeviceMetrics(TestCase):
     ):
         mock_is_authenticated.return_value = True
 
-        mock_get_item_details.return_value = {"snap-id": "id"}
+        mock_get_item_details.return_value = {"snap_id": "id"}
         random_values = random.sample(range(1, 30), 29)
         dates = [
             datetime(2018, 3, day).strftime("%Y-%m-%d") for day in range(1, 30)
@@ -103,7 +103,7 @@ class GetActiveDeviceMetrics(TestCase):
     @patch("webapp.publisher.snaps.views.authentication.is_authenticated")
     @patch(
         "canonicalwebteam.store_api.stores."
-        "snapstore.SnapStore.get_item_details"
+        "snapstore.SnapPublisher.get_snap_info"
     )
     @patch(
         "canonicalwebteam.store_api.stores."
@@ -116,7 +116,7 @@ class GetActiveDeviceMetrics(TestCase):
         mock_is_authenticated,
     ):
         mock_is_authenticated.return_value = True
-        mock_get_item_details.return_value = {"snap-id": "id"}
+        mock_get_item_details.return_value = {"snap_id": "id"}
         random_values = random.sample(range(1, 30), 29)
         dates = [
             datetime(2018, 3, day).strftime("%Y-%m-%d") for day in range(1, 30)
@@ -155,7 +155,7 @@ class GetActiveDeviceMetrics(TestCase):
     @patch("webapp.publisher.snaps.views.authentication.is_authenticated")
     @patch(
         "canonicalwebteam.store_api.stores."
-        "snapstore.SnapStore.get_item_details"
+        "snapstore.SnapPublisher.get_snap_info"
     )
     @patch(
         "canonicalwebteam.store_api.stores."
@@ -168,7 +168,7 @@ class GetActiveDeviceMetrics(TestCase):
         mock_is_authenticated,
     ):
         mock_is_authenticated.return_value = True
-        mock_get_item_details.return_value = {"snap-id": "id"}
+        mock_get_item_details.return_value = {"snap_id": "id"}
         random_values = random.sample(range(1, 30), 29)
         dates = [
             datetime(2018, 3, day).strftime("%Y-%m-%d") for day in range(1, 30)
@@ -204,7 +204,7 @@ class GetActiveDeviceMetrics(TestCase):
     @patch("webapp.publisher.snaps.views.authentication.is_authenticated")
     @patch(
         "canonicalwebteam.store_api.stores."
-        "snapstore.SnapStore.get_item_details"
+        "snapstore.SnapPublisher.get_snap_info"
     )
     @patch(
         "canonicalwebteam.store_api.stores."
@@ -217,7 +217,7 @@ class GetActiveDeviceMetrics(TestCase):
         mock_is_authenticated,
     ):
         mock_is_authenticated.return_value = True
-        mock_get_item_details.return_value = {"snap-id": "id"}
+        mock_get_item_details.return_value = {"snap_id": "id"}
         random_values = random.sample(range(1, 30), 29)
         dates = [
             datetime(2018, 3, day).strftime("%Y-%m-%d") for day in range(1, 30)
@@ -257,7 +257,7 @@ class GetMetricAnnotation(TestCase):
     snap_name = "test-snap"
     snap_payload = {
         "snap_name": snap_name,
-        "snap_id": "snap-id",
+        "snap_id": "snap_id",
         "categories": {
             "locked": False,
             "items": [
@@ -353,7 +353,7 @@ class GetCountryMetric(TestCase):
     @patch("webapp.publisher.snaps.views.authentication.is_authenticated")
     @patch(
         "canonicalwebteam.store_api.stores."
-        "snapstore.SnapStore.get_item_details"
+        "snapstore.SnapPublisher.get_snap_info"
     )
     @patch(
         "canonicalwebteam.store_api.stores."
@@ -372,7 +372,7 @@ class GetCountryMetric(TestCase):
             {"values": [2], "name": "FR"},
             {"values": [3], "name": "GB"},
         ]
-        mock_get_item_details.return_value = {"snap-id": "id"}
+        mock_get_item_details.return_value = {"snap_id": "id"}
         mock_get_publisher_metrics.return_value = {
             "metrics": [
                 {

--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -75,11 +75,9 @@ def publisher_snap_metrics(snap_name):
 @login_required
 def get_active_devices(snap_name):
 
-    snap_details = store_api.get_item_details(
-        snap_name, api_version=2, fields=["snap-id"]
-    )
+    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
 
-    snap_id = snap_details["snap-id"]
+    snap_id = snap_details["snap_id"]
 
     installed_base_metric = logic.verify_base_metrics(
         flask.request.args.get("active-devices", default="version", type=str)
@@ -187,11 +185,9 @@ def get_active_devices(snap_name):
 
 @login_required
 def get_latest_active_devices(snap_name):
-    snap_details = store_api.get_item_details(
-        snap_name, api_version=2, fields=["snap-id"]
-    )
+    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
 
-    snap_id = snap_details["snap-id"]
+    snap_id = snap_details["snap_id"]
     # get latest active devices
     latest_day_period = logic.extract_metrics_period("1d")
     latest_installed_base = logic.get_installed_based_metric("version")
@@ -263,10 +259,8 @@ def get_metric_annotaion(snap_name):
 
 @login_required
 def get_country_metric(snap_name):
-    snap_details = store_api.get_item_details(
-        snap_name, api_version=2, fields=["snap-id"]
-    )
-    snap_id = snap_details["snap-id"]
+    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
+    snap_id = snap_details["snap_id"]
     metrics_query_json = metrics_helper.build_metric_query_country(
         snap_id=snap_id,
     )


### PR DESCRIPTION
## Done
Fixes metrics not showing on private snaps metrics pages

## How to QA
- Go to a private snaps metrics page: https://snapcraft-io-4997.demos.haus/<PRIVATE_SNAP_NAME>/metrics
- Check that metrics are available

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-18363
