### PR TITLE
fix: Make publisher pages 404 with no permissions

### DIFF
--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -120,11 +120,15 @@ def get_snap_repo(snap_name):
 
 @login_required
 def get_snap_builds_page(snap_name):
+    # If this fails, the page will 404
+    publisher_api.get_snap_info(snap_name, flask.session)
     return flask.render_template("store/publisher.html", snap_name=snap_name)
 
 
 @login_required
 def get_snap_build_page(snap_name, build_id):
+    # If this fails, the page will 404
+    publisher_api.get_snap_info(snap_name, flask.session)
     return flask.render_template(
         "store/publisher.html", snap_name=snap_name, build_id=build_id
     )

--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -62,6 +62,9 @@ def publisher_snap_metrics(snap_name):
     """
     A view to display the snap metrics page for specific snaps.
     """
+    # If this fails, the page will 404
+    publisher_api.get_snap_info(snap_name, flask.session)
+
     context = {
         # Data direct from details API
         "snap_name": snap_name,

--- a/webapp/publisher/snaps/publicise_views.py
+++ b/webapp/publisher/snaps/publicise_views.py
@@ -40,4 +40,6 @@ def get_publicise_data(snap_name):
 
 @login_required
 def get_publicise(snap_name):
+    # If this fails, the page will 404
+    publisher_api.get_snap_info(snap_name, flask.session)
     return flask.render_template("store/publisher.html", snap_name=snap_name)

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -47,6 +47,8 @@ def get_release_history_data(snap_name):
 
 @login_required
 def get_releases(snap_name):
+    # If this fails, the page will 404
+    publisher_api.get_snap_info(snap_name, flask.session)
     return flask.render_template("store/publisher.html")
 
 


### PR DESCRIPTION
## Done
Make publisher pages 404 if the user doesn't have access to that snap

## How to QA
- Make sure you are signed in: https://snapcraft-io-4998.demos.haus/snaps
- Go to https://snapcraft-io-4998.demos.haus/domotzpro-agent/listing
- Check that the page 404s
- Go to https://snapcraft-io-4998.demos.haus/domotzpro-agent/builds
- Check that the page 404s
- Go to https://snapcraft-io-4998.demos.haus/domotzpro-agent/releases
- Check that the page 404s
- Go to https://snapcraft-io-4998.demos.haus/domotzpro-agent/metrics
- Check that the page 404s
- Go to https://snapcraft-io-4998.demos.haus/domotzpro-agent/publicise
- Check that the page 404s
- Go to https://snapcraft-io-4998.demos.haus/domotzpro-agent/settings
- Check that the page 404s

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Already has existing tests

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-18600