### PR TITLE
chore: Add relevant page titles to snap publisher pages

### DIFF
--- a/static/js/publisher/pages/Build/Build.tsx
+++ b/static/js/publisher/pages/Build/Build.tsx
@@ -5,6 +5,8 @@ import { formatDistanceToNow } from "date-fns";
 
 import SectionNav from "../../components/SectionNav";
 
+import { setPageTitle } from "../../utils";
+
 function Build(): JSX.Element {
   const { buildId, snapId } = useParams();
   const { data, isFetched, isLoading, isFetching } = useQuery({
@@ -33,9 +35,11 @@ function Build(): JSX.Element {
     !data ||
     (data.snap_build && data.snap_build.id.toString() !== buildId);
 
+  setPageTitle(`Build ${buildId} for ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /{" "}
         <Link to={`/${snapId}/builds`}>Builds</Link> / Build #{buildId}
       </h1>

--- a/static/js/publisher/pages/Builds/Builds.tsx
+++ b/static/js/publisher/pages/Builds/Builds.tsx
@@ -15,6 +15,8 @@ import {
   githubDataState,
 } from "../../state/atoms";
 
+import { setPageTitle } from "../../utils";
+
 function Builds(): JSX.Element {
   const { snapId } = useParams();
   const [githubData, setGithubData] = useRecoilState(githubDataState);
@@ -45,9 +47,11 @@ function Builds(): JSX.Element {
     retry: 0,
   });
 
+  setPageTitle(`Builds for ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /
         Builds
       </h1>

--- a/static/js/publisher/pages/Listing/Listing.tsx
+++ b/static/js/publisher/pages/Listing/Listing.tsx
@@ -5,6 +5,8 @@ import { Strip } from "@canonical/react-components";
 import SectionNav from "../../components/SectionNav";
 import ListingForm from "./ListingForm";
 
+import { setPageTitle } from "../../utils";
+
 function Listing(): JSX.Element {
   const { snapId } = useParams();
   const { data, isLoading, refetch } = useQuery({
@@ -26,9 +28,11 @@ function Listing(): JSX.Element {
     },
   });
 
+  setPageTitle(`Listing data for ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /
         Listing
       </h1>

--- a/static/js/publisher/pages/Metrics/Metrics.tsx
+++ b/static/js/publisher/pages/Metrics/Metrics.tsx
@@ -6,6 +6,8 @@ import ActiveDeviceMetrics from "./ActiveDeviceMetrics";
 import { TerritoryMetrics } from "./TerritoryMetrics";
 import { useState } from "react";
 
+import { setPageTitle } from "../../utils";
+
 const EmptyData = () => {
   return (
     <section className="p-strip--light is-shallow snapcraft-metrics__info">
@@ -38,9 +40,11 @@ function Metrics(): JSX.Element {
   const isEmpty =
     Boolean(isActiveDeviceMetricEmpty) && Boolean(isCountryMetricEmpty);
 
+  setPageTitle(`Metrics for ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /
         Metrics
       </h1>

--- a/static/js/publisher/pages/Publicise/Publicise.tsx
+++ b/static/js/publisher/pages/Publicise/Publicise.tsx
@@ -14,6 +14,8 @@ import PubliciseButtons from "./PubliciseButtons";
 import PubliciseBadges from "./PubliciseBadges";
 import PubliciseCards from "./PubliciseCards";
 
+import { setPageTitle } from "../../utils";
+
 type Props = {
   view?: undefined | "badges" | "cards";
 };
@@ -48,9 +50,11 @@ function Publicise({ view }: Props): JSX.Element {
     return false;
   };
 
+  setPageTitle(`Publicise ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /
         Publicise
       </h1>

--- a/static/js/publisher/pages/PublisherSettings/PublisherSettings.tsx
+++ b/static/js/publisher/pages/PublisherSettings/PublisherSettings.tsx
@@ -5,6 +5,8 @@ import { Strip, Icon } from "@canonical/react-components";
 import SectionNav from "../../components/SectionNav";
 import PublisherSettingsForm from "./PublisherSettingsForm";
 
+import { setPageTitle } from "../../utils";
+
 function PublisherSettings() {
   const { snapId } = useParams();
   const { data, isLoading, isFetched } = useQuery({
@@ -22,9 +24,11 @@ function PublisherSettings() {
     },
   });
 
+  setPageTitle(`Settings for ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <a href="/snaps">My snaps</a> / <a href={`/${snapId}`}>{snapId}</a> /
         Settings
       </h1>

--- a/static/js/publisher/pages/Releases/Releases.tsx
+++ b/static/js/publisher/pages/Releases/Releases.tsx
@@ -5,6 +5,8 @@ import { Strip, Link } from "@canonical/react-components";
 import SectionNav from "../../components/SectionNav";
 import Release from "./Release";
 
+import { setPageTitle } from "../../utils";
+
 function Releases(): JSX.Element {
   const { snapId } = useParams();
   const { isLoading, isFetched, data } = useQuery({
@@ -26,9 +28,11 @@ function Releases(): JSX.Element {
     },
   });
 
+  setPageTitle(`Releases for ${snapId}`);
+
   return (
     <>
-      <h1 className="p-heading--4">
+      <h1 className="p-heading--4" aria-live="polite">
         <Link href="/snaps">My snaps</Link> /{" "}
         <Link href={`/${snapId}`}>{snapId}</Link> / Releases
       </h1>


### PR DESCRIPTION
## Done
Added appropriate page titles for publisher pages and added an `aria-live` attribute to page headings to inform screen readers that the page has changed.

## How to QA
- Go to https://snapcraft-io-4999.demos.haus/<SNAP_NAME>/listing
- Click between the tabs and make sure the page title in the browser tab makes sense

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-18633