### PR TITLE
Fix top navigation alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ts-loader": "9.5.1",
     "typescript": "5.3.3",
     "uuid": "11.0.4",
-    "vanilla-framework": "4.20.0",
+    "vanilla-framework": "canonical/vanilla-framework#main",
     "watch-cli": "0.2.3",
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ts-loader": "9.5.1",
     "typescript": "5.3.3",
     "uuid": "11.0.4",
-    "vanilla-framework": "canonical/vanilla-framework#main",
+    "vanilla-framework": "4.20.3",
     "watch-cli": "0.2.3",
     "webpack": "5.97.1",
     "webpack-cli": "6.0.1",

--- a/static/js/base/global-nav.ts
+++ b/static/js/base/global-nav.ts
@@ -1,4 +1,4 @@
 import { createNav } from "@canonical/global-nav";
 createNav({
-  breakpoint: 1036,
+  breakpoint: 1175, // keep it in sync with $breakpoint-navigation-threshold in styles.scss
 });

--- a/static/js/base/global-nav.ts
+++ b/static/js/base/global-nav.ts
@@ -1,4 +1,2 @@
 import { createNav } from "@canonical/global-nav";
-createNav({
-  breakpoint: 1175, // keep it in sync with $breakpoint-navigation-threshold in styles.scss
-});
+createNav();

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -15,7 +15,6 @@ $color-paper: #f3f3f3;
 }
 
 // navigation variables
-$breakpoint-navigation-threshold: 1175px; // keep it in sync with global-nav.ts
 $font-display-option: swap;
 
 // responsive
@@ -458,17 +457,6 @@ dl {
 
 .p-navigation__row.is-full-width {
   max-width: 100%;
-}
-
-// Vanilla override - documentaion layout
-.l-docs__subgrid {
-  @media (width >= 1036px) {
-    grid-template-columns: 15rem minmax(0, 1fr) 15rem;
-  }
-
-  @media (width >= calc(1036px + 15rem)) {
-    grid-template-columns: 15rem minmax(0, 1fr) 15rem;
-  }
 }
 
 // Vanilla override

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -15,7 +15,7 @@ $color-paper: #f3f3f3;
 }
 
 // navigation variables
-$breakpoint-navigation-threshold: 1175px;
+$breakpoint-navigation-threshold: 1175px; // keep it in sync with global-nav.ts
 $font-display-option: swap;
 
 // responsive

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -8,7 +8,7 @@
         <div class="l-docs__sidebar">
       {% endif %}
         {% if not docs %}
-        <div class="p-navigation__row {% if full_width_nav %}is-full-width{% endif %}">
+        <div class="p-navigation__row--25-75">
         {% endif %}
           <div class="p-navigation__banner">
             <div class="p-navigation__tagged-logo">

--- a/yarn.lock
+++ b/yarn.lock
@@ -8182,15 +8182,14 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.20.0:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.20.0.tgz#017362c0814a69f4759842c8f35d4ee9e9f5ad83"
-  integrity sha512-XCaLzqlo8Qd/awGD5sNG/1c4LfcaGLCgCZfVPRWyxQIVZRVQrY+Tk335Juz7u/DqUMuULt800oy0sOIVyqABWA==
-
 vanilla-framework@4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"
   integrity sha512-iTmvqWlsX0ic69VZ1sR9NPQtYRR9+iM679HZCl7SDQhMQSsEeJEQ6Ejjen3JN5a7YxiYmeIhxaLlmC4rExRT1w==
+
+vanilla-framework@canonical/vanilla-framework#main:
+  version "4.20.3"
+  resolved "https://codeload.github.com/canonical/vanilla-framework/tar.gz/a2b776370a1d9ea1d9076876bc50e823268c8640"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Fixes the alignment of top navigation:

- uses navigation 25/75 split from Vanilla
- updates Vanilla (to fix the navigation wrapping issue)
- removes unnecessary navigation customisations that were causing conflicts between Vanilla, global-nav and local responsive breakpoints

## How to QA

- visit home page on demo (https://snapcraft-io-5000.demos.haus/)
- make sure top navigation is well aligned (first item should align with hero content)
- make sure navigation works as expected on all screen sizes
- repeat steps above for documentation (test locally as it's not available on demos) 

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): visual changes only

## Issue / Card
Fixes WD-18308

## Screenshots

Before
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/ce837228-2172-4df1-b25f-d06f516a13cf" />


After
<img width="1428" alt="image" src="https://github.com/user-attachments/assets/7bc08b01-ddeb-44e0-8e95-b036e68d176b" />
