### PR TITLE
fix: Update mattermost icon on snapcrafters publisher page

### DIFF
--- a/webapp/store/content/publishers/snapcrafters-snaps.yaml
+++ b/webapp/store/content/publishers/snapcrafters-snaps.yaml
@@ -47,7 +47,7 @@ snaps:
     },
     {
       "developer_validation": "verified",
-      "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2017/04/mattermost-desktop.png",
+      "icon_url": "https://dashboard.snapcraft.io/site_media/appmedia/2025/02/mattermost-desktop.png",
       "origin": "snapcrafters",
       "package_name": "mattermost-desktop",
       "publisher": "Snapcrafters",


### PR DESCRIPTION
## Done
- Updated mattermost logo: reference https://github.com/snapcrafters/mattermost-desktop/issues/118#issuecomment-2647411348

## How to QA
- https://snapcraft-io-5019.demos.haus/publisher/snapcrafters

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): content change

## Issue / Card
Fixes #5018 

## Screenshots
