### PR TITLE
Wd 17847 update snapcraft to use new version of store api

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,8 +6,8 @@
 To use staging APIs locally you can add the following lines to an `.env.local` file:
 
 ```bash
-SNAPSTORE_API_URL=https://api.staging.snapcraft.io/
-SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
+DEVICE_GATEWAY_API_URL=https://api.staging.snapcraft.io/
+DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
 LOGIN_URL=https://login.staging.ubuntu.com
 CANDID_API_URL=https://api.staging.jujucharms.com/identity/
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.7.3
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.image-template==1.4.2
-canonicalwebteam.store-api==5.0.0
+canonicalwebteam.store-api==6.0.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0

--- a/tests/admin/test_brand_store.py
+++ b/tests/admin/test_brand_store.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from canonicalwebteam.store_api.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 from tests.admin.tests_models import TestModelServiceEndpoints
 

--- a/tests/admin/tests_models.py
+++ b/tests/admin/tests_models.py
@@ -13,7 +13,6 @@ candid = CandidClient(api_publisher_session)
 
 
 class TestModelServiceEndpoints(TestAdminEndpoints):
-
     def setUp(self):
         self.api_key = "qwertyuioplkjhgfdsazxcvbnmkiopuytrewqasdfghjklmnbv"
         super().setUp()

--- a/tests/admin/tests_models.py
+++ b/tests/admin/tests_models.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from canonicalwebteam.candid import CandidClient
-from canonicalwebteam.store_api.exceptions import (
+from canonicalwebteam.exceptions import (
     StoreApiResponseErrorList,
     StoreApiResourceNotFound,
 )

--- a/tests/admin/tests_policies.py
+++ b/tests/admin/tests_policies.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock, patch
-from canonicalwebteam.store_api.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 from tests.admin.tests_models import TestModelServiceEndpoints
 

--- a/tests/admin/tests_signing_keys.py
+++ b/tests/admin/tests_signing_keys.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 from tests.admin.tests_models import TestModelServiceEndpoints
-from canonicalwebteam.store_api.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 
 class TestGetSigningKeys(TestModelServiceEndpoints):

--- a/tests/publisher/snaps/tests_get_metrics.py
+++ b/tests/publisher/snaps/tests_get_metrics.py
@@ -365,7 +365,6 @@ class GetCountryMetric(TestCase):
         mock_get_item_details,
         mock_is_authenticated,
     ):
-
         mock_is_authenticated.return_value = True
 
         countries = [

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -332,7 +332,9 @@ def create_models(store_id: str):
             res["success"] = False
             return make_response(res, 500)
 
-        publisher_gateway.create_store_model(flask.session, store_id, name, api_key)
+        publisher_gateway.create_store_model(
+            flask.session, store_id, name, api_key
+        )
         res["success"] = True
 
         return make_response(res, 201)
@@ -566,7 +568,9 @@ def create_signing_key(store_id: str):
 
     try:
         if name and len(name) <= 128:
-            publisher_gateway.create_store_signing_key(flask.session, store_id, name)
+            publisher_gateway.create_store_signing_key(
+                flask.session, store_id, name
+            )
             res["success"] = True
             return make_response(res, 200)
         else:

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -4,12 +4,12 @@ import functools
 # Third party packages
 import flask
 
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
+from canonicalwebteam.store_api.publishergw import PublisherGW
 
 from webapp import authentication
 from webapp.helpers import api_publisher_session
 
-publisher_api = SnapPublisher(api_publisher_session)
+publisher_gateway = PublisherGW(api_publisher_session)
 
 
 def login_required(func):
@@ -33,7 +33,7 @@ def exchange_required(func):
     @functools.wraps(func)
     def is_exchanged(*args, **kwargs):
         if "exchanged_developer_token" not in flask.session:
-            result = publisher_api.exchange_dashboard_macaroons(flask.session)
+            result = publisher_gateway.exchange_dashboard_macaroons(flask.session)
             flask.session["developer_token"] = result
             flask.session["exchanged_developer_token"] = True
         return func(*args, **kwargs)

--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -33,7 +33,9 @@ def exchange_required(func):
     @functools.wraps(func)
     def is_exchanged(*args, **kwargs):
         if "exchanged_developer_token" not in flask.session:
-            result = publisher_gateway.exchange_dashboard_macaroons(flask.session)
+            result = publisher_gateway.exchange_dashboard_macaroons(
+                flask.session
+            )
             flask.session["developer_token"] = result
             flask.session["exchanged_developer_token"] = True
         return func(*args, **kwargs)

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -418,9 +418,9 @@ def set_handlers(app):
         )
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"
-        response.headers["Cross-Origin-Opener-Policy"] = (
-            "same-origin-allow-popups"
-        )
+        response.headers[
+            "Cross-Origin-Opener-Policy"
+        ] = "same-origin-allow-popups"
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
         return response

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -23,7 +23,7 @@ from webapp.config import (
     DNS_VERIFICATION_SALT,
 )
 
-from canonicalwebteam.store_api.exceptions import (
+from canonicalwebteam.exceptions import (
     StoreApiError,
     StoreApiConnectionError,
     StoreApiResourceNotFound,

--- a/webapp/helpers.py
+++ b/webapp/helpers.py
@@ -6,7 +6,7 @@ import flask
 from canonicalwebteam.launchpad import Launchpad
 from ruamel.yaml import YAML
 from webapp.api.requests import PublisherSession, Session
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
+from canonicalwebteam.store_api.dashboard import Dashboard
 import webapp.api.marketo as marketo_api
 
 _yaml = YAML(typ="rt")
@@ -14,7 +14,7 @@ _yaml_safe = YAML(typ="safe")
 api_session = Session()
 api_publisher_session = PublisherSession()
 marketo = marketo_api.Marketo()
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_session)
 
 launchpad = Launchpad(
     username=os.getenv("LP_API_USERNAME"),
@@ -109,7 +109,7 @@ def get_publisher_data():
     # We don't use the data from this endpoint.
     # It is mostly used to make sure the user has signed
     # the terms and conditions.
-    publisher_api.get_account(flask.session)
+    dashboard.get_account(flask.session)
 
     flask_user = flask.session["publisher"]
 

--- a/webapp/packages/logic.py
+++ b/webapp/packages/logic.py
@@ -1,6 +1,5 @@
 import datetime
 
-import talisker
 from flask import make_response
 from typing import List, Dict, TypedDict, Any, Union
 
@@ -112,9 +111,7 @@ def fetch_package(package_name: str, fields: List[str]) -> Package:
     return response.json
 
 
-def parse_package_for_card(
-    package: Dict[str, Any]
-) -> Package:
+def parse_package_for_card(package: Dict[str, Any]) -> Package:
     """
     Parses a snap and returns the formatted package
     based on the given card schema.
@@ -226,9 +223,7 @@ def get_packages(
     packages_per_page = paginate(packages, page, size, total_pages)
     parsed_packages = []
     for package in packages_per_page:
-        parsed_packages.append(
-            parse_package_for_card(package)
-        )
+        parsed_packages.append(parse_package_for_card(package))
     res = parsed_packages
 
     categories = get_store_categories()
@@ -359,7 +354,5 @@ def get_package(
     :return: A dictionary containing the package.
     """
     package = fetch_package(package_name, fields).get("package", {})
-    resp = parse_package_for_card(
-        package
-    )
+    resp = parse_package_for_card(package)
     return {"package": resp}

--- a/webapp/packages/store_packages.py
+++ b/webapp/packages/store_packages.py
@@ -1,4 +1,7 @@
-import talisker
+from talisker import requests
+
+from canonicalwebteam.store_api.dashboard import Dashboard
+
 from webapp.decorators import login_required
 import flask
 from flask import (
@@ -12,12 +15,8 @@ from webapp.packages.logic import (
     get_package,
     get_snaps_account_info,
 )
-from webapp.config import APP_NAME
+from webapp.helpers import api_session
 
-from canonicalwebteam.store_api.stores.snapstore import (
-    SnapStore,
-    SnapPublisher,
-)
 
 FIELDS = [
     "title",
@@ -31,27 +30,8 @@ store_packages = Blueprint(
     "package",
     __name__,
 )
-#    "store": SnapStore,
-#         "publisher": SnapPublisher,
-#         "fields": [
-#             "title",
-#             "summary",
-#             "media",
-#             "publisher",
-#             "categories",
-#         ],
-#         "permissions": [
-#             "edit_account",
-#             "package_access",
-#             "package_metrics",
-#             "package_register",
-#             "package_release",
-#             "package_update",
-#             "package_upload_request",
-#             "store_admin",
-#         ],
-#         "size": 15,
 
+dashboard = Dashboard(api_session)
 
 @store_packages.route("/store.json")
 def get_store_packages():
@@ -60,7 +40,7 @@ def get_store_packages():
 
     res = make_response(
         get_packages(
-            SnapStore, SnapPublisher, APP_NAME, libraries, FIELDS, 15, args
+            FIELDS, 15, args
         )
     )
     return res
@@ -77,9 +57,7 @@ def package(package_type):
     packages.
     """
 
-    publisher_api = SnapPublisher(talisker.requests.get_session())
-
-    account_info = publisher_api.get_account(flask.session)
+    account_info = dashboard.get_account(flask.session)
 
     user_snaps, registered_snaps = get_snaps_account_info(account_info)
     flask_user = flask.session["publisher"]
@@ -101,9 +79,6 @@ def get_store_package(package_name):
     has_libraries = bool(request.args.get("fields", ""))
     res = make_response(
         get_package(
-            SnapStore,
-            SnapPublisher,
-            APP_NAME,
             package_name,
             FIELDS,
             has_libraries,

--- a/webapp/packages/store_packages.py
+++ b/webapp/packages/store_packages.py
@@ -1,5 +1,3 @@
-from talisker import requests
-
 from canonicalwebteam.store_api.dashboard import Dashboard
 
 from webapp.decorators import login_required
@@ -33,16 +31,12 @@ store_packages = Blueprint(
 
 dashboard = Dashboard(api_session)
 
+
 @store_packages.route("/store.json")
 def get_store_packages():
     args = dict(request.args)
-    libraries = bool(args.pop("fields", ""))
 
-    res = make_response(
-        get_packages(
-            FIELDS, 15, args
-        )
-    )
+    res = make_response(get_packages(FIELDS, 15, args))
     return res
 
 
@@ -75,7 +69,6 @@ def package(package_type):
 
 @store_packages.route("/<package_name>/card.json")
 def get_store_package(package_name):
-
     has_libraries = bool(request.args.get("fields", ""))
     res = make_response(
         get_package(

--- a/webapp/publisher/snaps/collaboration_views.py
+++ b/webapp/publisher/snaps/collaboration_views.py
@@ -1,22 +1,18 @@
 # Packages
 import flask
 from flask import json
-from canonicalwebteam.store_api.stores.snapstore import (
-    SnapPublisher,
-    SnapStore,
-)
+from canonicalwebteam.store_api.dashboard import Dashboard
 
 # Local
 from webapp.helpers import api_publisher_session
 from webapp.decorators import login_required
 
-store_api = SnapStore(api_publisher_session)
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_publisher_session)
 
 
 @login_required
 def get_collaboration_snap(snap_name):
-    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
+    snap_details = dashboard.get_snap_info(flask.session, snap_name)
 
     context = {
         "snap_id": snap_details["snap_id"],

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -10,6 +10,7 @@ from canonicalwebteam.exceptions import (
 )
 from canonicalwebteam.store_api.dashboard import Dashboard
 from canonicalwebteam.store_api.devicegw import DeviceGW
+
 # Local
 from webapp import helpers
 from webapp.helpers import api_session
@@ -24,8 +25,6 @@ from webapp.store.logic import (
 
 dashboard = Dashboard(api_session)
 device_gateway = DeviceGW("snap", api_session)
-
-
 
 
 def get_market_snap(snap_name):

--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -75,7 +75,6 @@ def publisher_snap_metrics(snap_name):
 
 @login_required
 def get_active_devices(snap_name):
-
     snap_details = device_gateway.get_item_details(
         snap_name, api_version=2, fields=["snap-id"]
     )
@@ -147,10 +146,11 @@ def get_active_devices(snap_name):
     metric_name = metrics_data["metric_name"]
     # Add constants to a variable
     if len(series) > downsample_data_limit:
-        downsampled_buckets, downsampled_series = (
-            metrics_helper.downsample_series(
-                buckets, series, downsample_target_size
-            )
+        (
+            downsampled_buckets,
+            downsampled_series,
+        ) = metrics_helper.downsample_series(
+            buckets, series, downsample_target_size
         )
     else:
         downsampled_buckets = buckets

--- a/webapp/publisher/snaps/publicise_views.py
+++ b/webapp/publisher/snaps/publicise_views.py
@@ -5,7 +5,7 @@ from canonicalwebteam.store_api.devicegw import DeviceGW
 from canonicalwebteam.exceptions import StoreApiError
 
 # Local
-from webapp.helpers import api_publisher_session, api_session
+from webapp.helpers import api_session
 from webapp.decorators import login_required
 
 dashboard = Dashboard(api_session)
@@ -14,7 +14,6 @@ device_gateway = DeviceGW("snap", api_session)
 
 @login_required
 def get_publicise_data(snap_name):
-
     snap_details = dashboard.get_snap_info(flask.session, snap_name)
 
     try:

--- a/webapp/publisher/snaps/publicise_views.py
+++ b/webapp/publisher/snaps/publicise_views.py
@@ -1,26 +1,24 @@
 # Packages
 import flask
-from canonicalwebteam.store_api.stores.snapstore import (
-    SnapStore,
-    SnapPublisher,
-)
-from canonicalwebteam.store_api.exceptions import StoreApiError
+from canonicalwebteam.store_api.dashboard import Dashboard
+from canonicalwebteam.store_api.devicegw import DeviceGW
+from canonicalwebteam.exceptions import StoreApiError
 
 # Local
-from webapp.helpers import api_publisher_session
+from webapp.helpers import api_publisher_session, api_session
 from webapp.decorators import login_required
 
-store_api = SnapStore(api_publisher_session)
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_session)
+device_gateway = DeviceGW("snap", api_session)
 
 
 @login_required
 def get_publicise_data(snap_name):
 
-    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
+    snap_details = dashboard.get_snap_info(flask.session, snap_name)
 
     try:
-        snap_public_details = store_api.get_item_details(
+        snap_public_details = device_gateway.get_item_details(
             snap_name, api_version=2
         )
         trending = snap_public_details["snap"]["trending"]
@@ -41,5 +39,5 @@ def get_publicise_data(snap_name):
 @login_required
 def get_publicise(snap_name):
     # If this fails, the page will 404
-    publisher_api.get_snap_info(snap_name, flask.session)
+    dashboard.get_snap_info(snap_name, flask.session)
     return flask.render_template("store/publisher.html", snap_name=snap_name)

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -1,13 +1,13 @@
 # Packages
 import flask
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
-from canonicalwebteam.store_api.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.store_api.dashboard import Dashboard
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 # Local
 from webapp.helpers import api_publisher_session
 from webapp.decorators import login_required
 
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_publisher_session)
 
 
 @login_required
@@ -19,11 +19,11 @@ def redirect_get_release_history(snap_name):
 
 @login_required
 def get_release_history_data(snap_name):
-    release_history = publisher_api.snap_release_history(
+    release_history = dashboard.snap_release_history(
         flask.session, snap_name
     )
 
-    channel_map = publisher_api.snap_channel_map(flask.session, snap_name)
+    channel_map = dashboard.snap_channel_map(flask.session, snap_name)
 
     snap = channel_map.get("snap", {})
 
@@ -48,7 +48,7 @@ def get_release_history_data(snap_name):
 @login_required
 def get_releases(snap_name):
     # If this fails, the page will 404
-    publisher_api.get_snap_info(snap_name, flask.session)
+    dashboard.get_snap_info(flask.session, snap_name)
     return flask.render_template("store/publisher.html")
 
 
@@ -64,7 +64,7 @@ def get_release_history_json(snap_name):
     page = flask.request.args.get("page", default=1, type=int)
 
     try:
-        release_history = publisher_api.snap_release_history(
+        release_history = dashboard.snap_release_history(
             flask.session, snap_name, page
         )
     except StoreApiResponseErrorList as api_response_error_list:
@@ -85,8 +85,8 @@ def post_release(snap_name):
         return flask.jsonify(response), 400
 
     try:
-        response = publisher_api.post_snap_release(
-            flask.session, snap_name, data
+        response = dashboard.post_snap_release(
+            flask.session, data
         )
     except StoreApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
@@ -115,7 +115,7 @@ def post_close_channel(snap_name):
         return flask.jsonify({}), 400
 
     try:
-        snap_id = publisher_api.get_snap_id(snap_name, flask.session)
+        snap_id = dashboard.get_snap_id(flask.session, snap_name)
     except StoreApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
@@ -123,7 +123,7 @@ def post_close_channel(snap_name):
             return flask.jsonify(api_response_error_list.errors), 400
 
     try:
-        response = publisher_api.post_close_channel(
+        response = dashboard.post_close_channel(
             flask.session, snap_id, data
         )
     except StoreApiResponseErrorList as api_response_error_list:
@@ -148,7 +148,7 @@ def post_default_track(snap_name):
         return flask.jsonify({}), 400
 
     try:
-        snap_id = publisher_api.get_snap_id(snap_name, flask.session)
+        snap_id = dashboard.get_snap_id(flask.session, snap_name)
     except StoreApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
@@ -156,7 +156,7 @@ def post_default_track(snap_name):
             return flask.jsonify(api_response_error_list.errors), 400
 
     try:
-        publisher_api.snap_metadata(snap_id, flask.session, data)
+        dashboard.snap_metadata(flask.session, snap_id, data)
     except StoreApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
@@ -175,7 +175,7 @@ def get_snap_revision_json(snap_name, revision):
     """
     Return JSON object from the publisher API
     """
-    revision = publisher_api.get_snap_revision(
+    revision = dashboard.get_snap_revision(
         flask.session, snap_name, revision
     )
 

--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -19,9 +19,7 @@ def redirect_get_release_history(snap_name):
 
 @login_required
 def get_release_history_data(snap_name):
-    release_history = dashboard.snap_release_history(
-        flask.session, snap_name
-    )
+    release_history = dashboard.snap_release_history(flask.session, snap_name)
 
     channel_map = dashboard.snap_channel_map(flask.session, snap_name)
 
@@ -85,9 +83,7 @@ def post_release(snap_name):
         return flask.jsonify(response), 400
 
     try:
-        response = dashboard.post_snap_release(
-            flask.session, data
-        )
+        response = dashboard.post_snap_release(flask.session, data)
     except StoreApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
@@ -123,9 +119,7 @@ def post_close_channel(snap_name):
             return flask.jsonify(api_response_error_list.errors), 400
 
     try:
-        response = dashboard.post_close_channel(
-            flask.session, snap_id, data
-        )
+        response = dashboard.post_close_channel(flask.session, snap_id, data)
     except StoreApiResponseErrorList as api_response_error_list:
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
@@ -175,8 +169,6 @@ def get_snap_revision_json(snap_name, revision):
     """
     Return JSON object from the publisher API
     """
-    revision = dashboard.get_snap_revision(
-        flask.session, snap_name, revision
-    )
+    revision = dashboard.get_snap_revision(flask.session, snap_name, revision)
 
     return flask.jsonify(revision)

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -4,8 +4,8 @@ from json import loads
 # Packages
 import flask
 import pycountry
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
-from canonicalwebteam.store_api.exceptions import (
+from canonicalwebteam.store_api.dashboard import Dashboard
+from canonicalwebteam.exceptions import (
     StoreApiResponseErrorList,
 )
 
@@ -14,7 +14,7 @@ from webapp.helpers import api_publisher_session, launchpad
 from webapp.decorators import login_required
 from webapp.publisher.snaps import logic
 
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_publisher_session)
 
 
 @login_required
@@ -24,7 +24,7 @@ def get_settings_json(snap_name):
 
 @login_required
 def get_settings_data(snap_name):
-    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
+    snap_details = dashboard.get_snap_info(flask.session, snap_name)
 
     if "whitelist_country_codes" in snap_details:
         whitelist_country_codes = (
@@ -79,7 +79,7 @@ def get_settings_data(snap_name):
 
 @login_required
 def get_settings(snap_name, return_json=False):
-    snap_details = publisher_api.get_snap_info(snap_name, flask.session)
+    snap_details = dashboard.get_snap_info(flask.session, snap_name)
 
     if "whitelist_country_codes" in snap_details:
         whitelist_country_codes = (
@@ -151,8 +151,8 @@ def post_settings_data(snap_name):
 
         if body_json:
             try:
-                response = publisher_api.snap_metadata(
-                    snap_id, flask.session, body_json
+                response = dashboard.snap_metadata(
+                    flask.session, snap_id,  body_json
                 )
                 return flask.jsonify(response)
             except StoreApiResponseErrorList as api_response_error_list:
@@ -165,8 +165,8 @@ def post_settings_data(snap_name):
 
         if error_list:
             try:
-                snap_details = publisher_api.get_snap_info(
-                    snap_name, flask.session
+                snap_details = dashboard.get_snap_info(
+                    flask.session, snap_name
                 )
             except StoreApiResponseErrorList as api_response_error_list:
                 if api_response_error_list.status_code == 404:

--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -152,7 +152,7 @@ def post_settings_data(snap_name):
         if body_json:
             try:
                 response = dashboard.snap_metadata(
-                    flask.session, snap_id,  body_json
+                    flask.session, snap_id, body_json
                 )
                 return flask.jsonify(response)
             except StoreApiResponseErrorList as api_response_error_list:

--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -2,8 +2,8 @@
 import flask
 from flask.json import jsonify
 
-from canonicalwebteam.store_api.stores.snapstore import SnapPublisher
-from canonicalwebteam.store_api.exceptions import StoreApiResponseErrorList
+from canonicalwebteam.store_api.dashboard import Dashboard
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 # Local
 import webapp.api.marketo as marketo_api
@@ -16,7 +16,7 @@ account = flask.Blueprint(
 )
 
 marketo = marketo_api.Marketo()
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_publisher_session)
 
 
 @account.route("/")
@@ -66,7 +66,7 @@ def get_agreement():
 def post_agreement():
     agreed = flask.request.form.get("i_agree")
     if agreed == "on":
-        publisher_api.post_agreement(flask.session, True)
+        dashboard.post_agreement(flask.session, True)
         return flask.redirect(flask.url_for(".get_account"))
     else:
         return flask.redirect(flask.url_for(".get_agreement"))
@@ -86,7 +86,7 @@ def post_account_name():
     if username:
         errors = []
         try:
-            publisher_api.post_username(flask.session, username)
+            dashboard.post_username(flask.session, username)
         except StoreApiResponseErrorList as api_response_error_list:
             errors = errors + api_response_error_list.errors
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -39,7 +39,8 @@ FIELDS = [
     "trending",
     "unlisted",
     "links",
- ]
+]
+
 
 def snap_details_views(store):
     snap_regex = "[a-z0-9-]*[a-z][a-z0-9-]*"
@@ -53,7 +54,9 @@ def snap_details_views(store):
         return context
 
     def _get_context_snap_details(snap_name):
-        details = device_gateway.get_item_details(snap_name, fields=FIELDS, api_version=2)
+        details = device_gateway.get_item_details(
+            snap_name, fields=FIELDS, api_version=2
+        )
         # 404 for any snap under quarantine
         if details["snap"]["publisher"]["username"] == "snap-quarantine":
             flask.abort(404, "No snap named {}".format(snap_name))
@@ -98,7 +101,9 @@ def snap_details_views(store):
         binary_filesize = latest_channel["download"]["size"]
 
         # filter out banner and banner-icon images from screenshots
-        screenshots = logic.filter_screenshots(details.get("snap", {}).get("media", []))
+        screenshots = logic.filter_screenshots(
+            details.get("snap", {}).get("media", [])
+        )
 
         icon_url = helpers.get_icon(details.get("snap", {}).get("media", []))
 
@@ -141,8 +146,9 @@ def snap_details_views(store):
                 is_users_snap = True
 
         # build list of categories of a snap
-        categories = logic.get_snap_categories(details.get(
-            "snap", {}).get("categories", []))
+        categories = logic.get_snap_categories(
+            details.get("snap", {}).get("categories", [])
+        )
 
         developer = logic.get_snap_developer(details["name"])
 
@@ -263,7 +269,9 @@ def snap_details_views(store):
             ),
         ]
 
-        metrics_response = device_gateway.get_public_metrics(metrics_query_json)
+        metrics_response = device_gateway.get_public_metrics(
+            metrics_query_json
+        )
 
         os_metrics = None
         country_devices = None

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -28,7 +28,6 @@ device_gateway = DeviceGW("snap", api_session)
 
 
 def store_blueprint(store_query=None):
-
     store = flask.Blueprint(
         "store",
         __name__,
@@ -153,7 +152,9 @@ def store_blueprint(store_query=None):
         error_info = {}
         searched_results = []
 
-        searched_results = device_gateway.search(snap_searched, size=size, page=page)
+        searched_results = device_gateway.search(
+            snap_searched, size=size, page=page
+        )
 
         snaps_results = searched_results["results"]
 

--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -6,14 +6,15 @@ from webapp.decorators import exchange_required, login_required
 import webapp.helpers as helpers
 import webapp.store.logic as logic
 from webapp.api import requests
-from canonicalwebteam.store_api.stores.snapstore import (
-    SnapStore,
-    SnapPublisher,
-)
-from canonicalwebteam.store_api.exceptions import StoreApiError
+
+from canonicalwebteam.exceptions import StoreApiError
+from canonicalwebteam.store_api.dashboard import Dashboard
+from canonicalwebteam.store_api.publishergw import PublisherGW
+from canonicalwebteam.store_api.devicegw import DeviceGW
+
 from webapp.api.exceptions import ApiError
 from webapp.store.snap_details_views import snap_details_views
-from webapp.helpers import api_publisher_session
+from webapp.helpers import api_publisher_session, api_session
 from flask.json import jsonify
 import os
 from webapp.extensions import csrf
@@ -21,11 +22,12 @@ from webapp.extensions import csrf
 session = talisker.requests.get_session(requests.Session)
 
 YOUTUBE_API_KEY = os.getenv("YOUTUBE_API_KEY")
-publisher_api = SnapPublisher(api_publisher_session)
+dashboard = Dashboard(api_session)
+publisher_gateway = PublisherGW("snap", api_publisher_session)
+device_gateway = DeviceGW("snap", api_session)
 
 
 def store_blueprint(store_query=None):
-    api = SnapStore(session, store_query)
 
     store = flask.Blueprint(
         "store",
@@ -33,7 +35,7 @@ def store_blueprint(store_query=None):
         template_folder="/templates",
         static_folder="/static",
     )
-    snap_details_views(store, api)
+    snap_details_views(store)
 
     def format_validation_set(validation_set):
         return validation_set["headers"]
@@ -44,7 +46,7 @@ def store_blueprint(store_query=None):
         res = {}
 
         try:
-            validation_sets = publisher_api.get_validation_sets(flask.session)
+            validation_sets = dashboard.get_validation_sets(flask.session)
             res["success"] = True
 
             if len(validation_sets["assertions"]) > 0:
@@ -75,7 +77,7 @@ def store_blueprint(store_query=None):
         res = {}
 
         try:
-            validation_set = publisher_api.get_validation_set(
+            validation_set = dashboard.get_validation_set(
                 flask.session, validation_set_id
             )
             res["success"] = True
@@ -117,7 +119,7 @@ def store_blueprint(store_query=None):
         status_code = 200
 
         try:
-            snaps = api.get_all_items(size=16)["results"]
+            snaps = device_gateway.get_all_items(size=16)["results"]
         except (StoreApiError, ApiError):
             snaps = []
 
@@ -151,7 +153,7 @@ def store_blueprint(store_query=None):
         error_info = {}
         searched_results = []
 
-        searched_results = api.search(snap_searched, size=size, page=page)
+        searched_results = device_gateway.search(snap_searched, size=size, page=page)
 
         snaps_results = searched_results["results"]
 
@@ -235,7 +237,7 @@ def store_blueprint(store_query=None):
                 for publisher in context["publishers"]:
                     snaps_results = []
                     try:
-                        snaps_results = api.get_publisher_items(
+                        snaps_results = device_gateway.get_publisher_items(
                             publisher, size=500, page=1
                         )["results"]
                     except StoreApiError:
@@ -273,7 +275,7 @@ def store_blueprint(store_query=None):
         snaps_count = 0
         publisher_details = {"display-name": publisher, "username": publisher}
 
-        snaps_results = api.find(
+        snaps_results = device_gateway.find(
             publisher=publisher,
             fields=[
                 "title",
@@ -314,7 +316,7 @@ def store_blueprint(store_query=None):
         error_info = {}
         snaps_results = []
 
-        snaps_results = api.get_category_items(
+        snaps_results = device_gateway.get_category_items(
             category=category, size=10, page=1
         )["results"]
         for snap in snaps_results:
@@ -346,9 +348,9 @@ def store_blueprint(store_query=None):
     def featured_snaps_in_category(category):
         snaps_results = []
 
-        snaps_results = api.get_category_items(
+        snaps_results = device_gateway.get_category_items(
             category=category, size=3, page=1
-        )["results"]
+        )["_embedded"]["clickindex:package"]
 
         for snap in snaps_results:
             snap["icon_url"] = helpers.get_icon(snap["media"])
@@ -422,7 +424,7 @@ def store_blueprint(store_query=None):
         if auto_phasing_percentage is not None:
             auto_phasing_percentage = float(auto_phasing_percentage)
 
-        response = publisher_api.create_track(
+        response = publisher_gateway.create_track(
             flask.session,
             snap_name,
             track_name,


### PR DESCRIPTION
## Done
- Update snapcraft to use the refactored store api
## How to QA
- This QA will be done locally
    - Pull this branch and [this branch of store-api](https://github.com/canonical/canonicalwebteam.store-api/pull/146)
    - Edit the `canonicalwebteam.store-api==6.0.0` in `requirement.txt` file to `-e ./canonicalwebteam.store-api` and run `dotrun serve -m <path-to-your-local-store-api>:canonicalwebteam.store-api`
    - Check that everything works as expected, click around as much as possible and comment any broken link or bugs.
    
    **Note**: The tests are not passing for now, they will be updated
## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
