### PR TITLE
chore: Change icon in brand stores navigation

### DIFF
--- a/static/js/publisher/components/Navigation/Navigation.tsx
+++ b/static/js/publisher/components/Navigation/Navigation.tsx
@@ -139,7 +139,7 @@ function Navigation({
                     <ul className="p-side-navigation__list u-no-margin--bottom">
                       <li className="p-side-navigation__item--title p-muted-heading">
                         <span className="p-side-navigation__link">
-                          <i className="p-icon--pods is-light p-side-navigation__icon"></i>
+                          <i className="p-icon--units is-light p-side-navigation__icon"></i>
                           <span className="p-side-navigation__label">
                             My stores
                           </span>

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -186,6 +186,7 @@ $color-social-icon-foreground: $color-light;
 @include vf-p-icon-security;
 @include vf-p-icon-models;
 @include vf-p-icon-edit;
+@include vf-p-icon-units;
 
 dl {
   margin-bottom: $spv--x-large;


### PR DESCRIPTION
## Done
Changes the icon for "My stores" in the brand store navigation

## How to QA
- Go to https://snapcraft-io-5023.demos.haus/admin
- Check that the "My stores" heading in the side navigation uses [the units icon from Vanilla](https://vanillaframework.io/docs/patterns/icons)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Small visual change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-14703

## Screenshots
![Screenshot 2025-02-12 at 09 16 13](https://github.com/user-attachments/assets/065cf70f-fbf0-4e24-8453-36300ef64a6a)
