### PR TITLE
chore: Add validation sets link to brand store nav

### DIFF
--- a/static/js/base/navigation.ts
+++ b/static/js/base/navigation.ts
@@ -13,33 +13,48 @@ if (navAccountContainer) {
 
   fetch("/account.json")
     .then((response) => response.json())
-    .then((data: { publisher: { fullname: string; has_stores: boolean } }) => {
-      if (data.publisher) {
-        const displayName = navAccountContainer.querySelector(
-          ".js-account--name",
-        ) as HTMLElement;
-
-        notAuthenticatedMenu.classList.add("u-hide");
-        authenticatedMenu.classList.remove("u-hide");
-        displayName.innerHTML = data.publisher["fullname"];
-        if (window.sessionStorage) {
-          window.sessionStorage.setItem(
-            "displayName",
-            data.publisher["fullname"],
-          );
-        }
-
-        if (data.publisher.has_stores) {
-          const storesMenu = authenticatedMenu.querySelector(
-            ".js-nav-account--stores",
+    .then(
+      (data: {
+        publisher: {
+          fullname: string;
+          has_stores: boolean;
+          has_validation_sets: boolean;
+        };
+      }) => {
+        if (data.publisher) {
+          const displayName = navAccountContainer.querySelector(
+            ".js-account--name",
           ) as HTMLElement;
-          storesMenu.classList.remove("u-hide");
+
+          notAuthenticatedMenu.classList.add("u-hide");
+          authenticatedMenu.classList.remove("u-hide");
+          displayName.innerHTML = data.publisher["fullname"];
+          if (window.sessionStorage) {
+            window.sessionStorage.setItem(
+              "displayName",
+              data.publisher["fullname"],
+            );
+          }
+
+          if (data.publisher.has_stores) {
+            const storesMenu = authenticatedMenu.querySelector(
+              ".js-nav-account--stores",
+            ) as HTMLElement;
+            storesMenu.classList.remove("u-hide");
+          }
+
+          if (data.publisher.has_validation_sets) {
+            const validationSetsMenu = authenticatedMenu.querySelector(
+              ".js-nav-account--validation-sets",
+            ) as HTMLElement;
+            validationSetsMenu.classList.remove("u-hide");
+          }
+        } else {
+          notAuthenticatedMenu.classList.remove("u-hide");
+          authenticatedMenu.classList.add("u-hide");
         }
-      } else {
-        notAuthenticatedMenu.classList.remove("u-hide");
-        authenticatedMenu.classList.add("u-hide");
-      }
-    })
+      },
+    )
     .catch(() => {
       notAuthenticatedMenu.classList.remove("u-hide");
       authenticatedMenu.classList.add("u-hide");

--- a/static/js/publisher/components/Navigation/Navigation.tsx
+++ b/static/js/publisher/components/Navigation/Navigation.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, ReactNode } from "react";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { useParams, NavLink } from "react-router-dom";
+import { Icon } from "@canonical/react-components";
 
 import Logo from "./Logo";
 
 import { publisherState } from "../../state/publisherState";
 import { brandIdState } from "../../state/brandStoreState";
-import { useBrand, usePublisher } from "../../hooks";
+import { useBrand, usePublisher, useValidationSets } from "../../hooks";
 
 import { brandStoresState } from "../../state/brandStoreState";
 
@@ -21,6 +22,7 @@ function Navigation({
   const { id } = useParams();
   const { data: brand } = useBrand(id);
   const { data: publisherData } = usePublisher();
+  const { data: validationSetsData } = useValidationSets();
   const [pinSideNavigation, setPinSideNavigation] = useState<boolean>(false);
   const [collapseNavigation, setCollapseNavigation] = useState<boolean>(false);
   const [showStoreSelector, setShowStoreSelector] = useState<boolean>(false);
@@ -129,6 +131,25 @@ function Navigation({
                     </a>
                   </li>
                 </ul>
+                {validationSetsData && validationSetsData.length > 0 && (
+                  <ul className="p-side-navigation__list">
+                    <li className="p-side-navigation__item">
+                      <NavLink
+                        to="/validation-sets"
+                        className="p-side-navigation__link"
+                      >
+                        <Icon
+                          name="topic"
+                          light
+                          className="p-side-navigation__icon"
+                        />
+                        <span className="p-side-navigation__label">
+                          My validation sets
+                        </span>
+                      </NavLink>
+                    </li>
+                  </ul>
+                )}
               </div>
               {publisher?.has_stores && (
                 <>

--- a/static/js/publisher/components/PrimaryNav/PrimaryNav.tsx
+++ b/static/js/publisher/components/PrimaryNav/PrimaryNav.tsx
@@ -4,7 +4,7 @@ import {
   SideNavigationText,
 } from "@canonical/react-components";
 
-import { usePublisher } from "../../hooks";
+import { usePublisher, useValidationSets } from "../../hooks";
 
 function PrimaryNav({
   collapseNavigation,
@@ -15,6 +15,7 @@ function PrimaryNav({
 }): JSX.Element {
   const location = useLocation();
   const { data: publisherData } = usePublisher();
+  const { data: validationSetsData } = useValidationSets();
 
   return (
     <>
@@ -43,14 +44,18 @@ function PrimaryNav({
             ],
           },
           {
-            items: [
-              {
-                label: "My validation sets",
-                href: "/validation-sets",
-                icon: "topic",
-                "aria-current": location.pathname.includes("/validation-sets"),
-              },
-            ],
+            items:
+              validationSetsData && validationSetsData.length > 0
+                ? [
+                    {
+                      label: "My validation sets",
+                      href: "/validation-sets",
+                      icon: "topic",
+                      "aria-current":
+                        location.pathname.includes("/validation-sets"),
+                    },
+                  ]
+                : [],
           },
         ]}
       />

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -96,7 +96,7 @@
                     <li>
                       <a href="/account/snaps" class="p-navigation__dropdown-item">My published snaps</a>
                     </li>
-                    <li>
+                    <li class="js-nav-account--validation-sets u-hide">
                       <a href="/validation-sets" class="p-navigation__dropdown-item">My validation sets</a>
                     </li>
                     <li class="js-nav-account--stores u-hide">

--- a/webapp/login/views.py
+++ b/webapp/login/views.py
@@ -72,6 +72,7 @@ def after_login(resp):
         return flask.redirect(LOGIN_URL)
 
     account = dashboard.get_account(flask.session)
+    validation_sets = dashboard.get_validation_sets(flask.session)
 
     if account:
         flask.session["publisher"] = {
@@ -90,6 +91,11 @@ def after_login(resp):
             flask.session["publisher"]["has_stores"] = (
                 len(dashboard.get_stores(flask.session)) > 0
             )
+
+        flask.session["publisher"]["has_validation_sets"] = (
+            validation_sets is not None
+            and len(validation_sets["assertions"]) > 0
+        )
     else:
         flask.session["publisher"] = {
             "identity_url": resp.identity_url,


### PR DESCRIPTION
## Done
- Adds "Validation sets" link to the brand store navigation if the user has validation sets
- Only shows "Validation sets" link in the account dropdown if the user has validation sets

## How to QA
- Go to https://snapcraft-io-5033.demos.haus/
- Make sure you are logged in
- Click the account dropdown in the right hand side of the navigation
- If you have validation sets you should see a link to them, otherwise you shouldn't
- Go to https://snapcraft-io-5033.demos.haus/admin
- If you have validation sets you should see a link to them in the side navigation, otherwise you shouldn't
- Go to https://snapcraft-io-5033.demos.haus/<SNAP_NAME>/listing
- If you have validation sets you should see a link to them in the side navigation, otherwise you shouldn't

### Note
To create a validation set, here are the steps on a Linux machine:
- `snapcraft login`
- `snapcraft create-key <key_name>`
- `snapcraft edit-validation-sets <snapcraft_account_id> <validation_set_name> <validation_set_sequence: number> --key=<key_name>`

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-19512
