### PR TITLE
chore: Add store selector to publisher pages

### DIFF
--- a/static/js/publisher/components/Navigation/Navigation.tsx
+++ b/static/js/publisher/components/Navigation/Navigation.tsx
@@ -4,14 +4,13 @@ import { useParams, NavLink } from "react-router-dom";
 import { Icon } from "@canonical/react-components";
 
 import Logo from "./Logo";
+import StoreSelector from "../StoreSelector";
 
 import { publisherState } from "../../state/publisherState";
 import { brandIdState } from "../../state/brandStoreState";
 import { useBrand, usePublisher, useValidationSets } from "../../hooks";
 
 import { brandStoresState } from "../../state/brandStoreState";
-
-import type { Store } from "../../types/shared";
 
 function Navigation({
   sectionName,
@@ -25,25 +24,8 @@ function Navigation({
   const { data: validationSetsData } = useValidationSets();
   const [pinSideNavigation, setPinSideNavigation] = useState<boolean>(false);
   const [collapseNavigation, setCollapseNavigation] = useState<boolean>(false);
-  const [showStoreSelector, setShowStoreSelector] = useState<boolean>(false);
-  const [filteredBrandStores, setFilteredBrandstores] =
-    useState<Array<Store>>(brandStoresList);
   const [publisher, setPublisher] = useRecoilState(publisherState);
   const [brandId, setBrandId] = useRecoilState(brandIdState);
-
-  const getStoreName = (id: string | undefined) => {
-    if (!id) {
-      return;
-    }
-
-    const targetStore = brandStoresList.find((store) => store.id === id);
-
-    if (targetStore) {
-      return targetStore.name;
-    }
-
-    return;
-  };
 
   const currentStore = brandStoresList.find((store) => store.id === id);
 
@@ -52,10 +34,6 @@ function Navigation({
       setBrandId(brand?.["account-id"]);
     }
   }, [brand]);
-
-  useEffect(() => {
-    setFilteredBrandstores(brandStoresList);
-  }, [brandStoresList]);
 
   useEffect(() => {
     if (publisherData) {
@@ -173,85 +151,7 @@ function Navigation({
                       <li className="p-side-navigation__item">
                         <span className="p-side-navigation__link">
                           <span className="p-side-navigation__label">
-                            <div className="store-selector">
-                              <button
-                                className="store-selector__button u-no-margin--bottom"
-                                onClick={() => {
-                                  setShowStoreSelector(!showStoreSelector);
-                                }}
-                              >
-                                {getStoreName(id)}
-                              </button>
-                              {showStoreSelector && (
-                                <div className="store-selector__panel">
-                                  <div className="p-search-box u-no-margin--bottom">
-                                    <label
-                                      htmlFor="search-stores"
-                                      className="u-off-screen"
-                                    >
-                                      Search stores
-                                    </label>
-                                    <input
-                                      type="search"
-                                      className="p-search-box__input"
-                                      id="search-stores"
-                                      name="search-stores"
-                                      placeholder="Search"
-                                      onInput={(e) => {
-                                        const value = (
-                                          e.target as HTMLInputElement
-                                        ).value;
-
-                                        if (value.length > 0) {
-                                          setFilteredBrandstores(
-                                            brandStoresList.filter((store) => {
-                                              const storeName =
-                                                store.name.toLowerCase();
-                                              return storeName.includes(
-                                                value.toLowerCase(),
-                                              );
-                                            }),
-                                          );
-                                        } else {
-                                          setFilteredBrandstores(
-                                            brandStoresList,
-                                          );
-                                        }
-                                      }}
-                                    />
-                                    <button
-                                      type="reset"
-                                      className="p-search-box__reset"
-                                    >
-                                      <i className="p-icon--close">Close</i>
-                                    </button>
-                                    <button
-                                      type="submit"
-                                      className="p-search-box__button"
-                                    >
-                                      <i className="p-icon--search">Search</i>
-                                    </button>
-                                  </div>
-                                  <ul className="store-selector__list">
-                                    {filteredBrandStores.map((store: Store) => (
-                                      <li
-                                        key={store.id}
-                                        className="store-selector__item"
-                                      >
-                                        <NavLink
-                                          to={`/admin/${store.id}/snaps`}
-                                          onClick={() => {
-                                            setShowStoreSelector(false);
-                                          }}
-                                        >
-                                          {store.name}
-                                        </NavLink>
-                                      </li>
-                                    ))}
-                                  </ul>
-                                </div>
-                              )}
-                            </div>
+                            <StoreSelector />
                           </span>
                         </span>
                       </li>
@@ -259,7 +159,7 @@ function Navigation({
                   </div>
                   <div className="p-side-navigation--icons hide-collapsed is-dark">
                     <ul className="p-side-navigation__list">
-                      {sectionName && (
+                      {sectionName && id && (
                         <>
                           <li className="p-side-navigation__item">
                             <NavLink

--- a/static/js/publisher/components/PrimaryNav/PrimaryNav.tsx
+++ b/static/js/publisher/components/PrimaryNav/PrimaryNav.tsx
@@ -1,10 +1,16 @@
+import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { useSetRecoilState } from "recoil";
 import {
   SideNavigation,
   SideNavigationText,
 } from "@canonical/react-components";
 
-import { usePublisher, useValidationSets } from "../../hooks";
+import StoreSelector from "../StoreSelector";
+
+import { usePublisher, useValidationSets, useBrandStores } from "../../hooks";
+
+import { brandStoresState } from "../../state/brandStoreState";
 
 function PrimaryNav({
   collapseNavigation,
@@ -16,6 +22,15 @@ function PrimaryNav({
   const location = useLocation();
   const { data: publisherData } = usePublisher();
   const { data: validationSetsData } = useValidationSets();
+  const { data: brandStoresList } = useBrandStores();
+
+  const setRecoilBrandStores = useSetRecoilState(brandStoresState);
+
+  useEffect(() => {
+    if (brandStoresList) {
+      setRecoilBrandStores(brandStoresList);
+    }
+  }, [brandStoresList]);
 
   return (
     <>
@@ -59,6 +74,37 @@ function PrimaryNav({
           },
         ]}
       />
+
+      {publisherData &&
+        publisherData.publisher &&
+        publisherData.publisher.has_stores && (
+          <>
+            <div className="nav-list-separator">
+              <hr />
+            </div>
+            <div className="p-side-navigation--icons hide-collapsed is-dark">
+              <ul className="p-side-navigation__list u-no-margin--bottom">
+                <li className="p-side-navigation__item--title p-muted-heading">
+                  <span className="p-side-navigation__link">
+                    <i className="p-icon--units is-light p-side-navigation__icon"></i>
+                    <span className="p-side-navigation__label">My stores</span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div className="p-side-navigation is-dark">
+              <ul className="p-side-navigation__list">
+                <li className="p-side-navigation__item">
+                  <span className="p-side-navigation__link">
+                    <span className="p-side-navigation__label">
+                      <StoreSelector nativeNavLink={true} />
+                    </span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </>
+        )}
 
       {publisherData && publisherData.publisher && (
         <div className="p-side-navigation--icons is-dark">

--- a/static/js/publisher/components/StoreSelector/StoreSelector.tsx
+++ b/static/js/publisher/components/StoreSelector/StoreSelector.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect, ReactNode } from "react";
+import { useRecoilValue } from "recoil";
+import { useParams, NavLink } from "react-router-dom";
+
+import { brandStoresState } from "../../state/brandStoreState";
+
+import type { Store } from "../../types/shared";
+
+type Props = {
+  nativeNavLink?: boolean;
+};
+
+function StoreSelector({ nativeNavLink }: Props): ReactNode {
+  const { id } = useParams();
+  const brandStoresList = useRecoilValue(brandStoresState);
+  const [showStoreSelector, setShowStoreSelector] = useState<boolean>(false);
+  const [filteredBrandStores, setFilteredBrandstores] =
+    useState<Array<Store>>(brandStoresList);
+
+  const getStoreName = (id: string | undefined) => {
+    if (!id) {
+      return;
+    }
+
+    const targetStore = brandStoresList.find((store) => store.id === id);
+
+    if (targetStore) {
+      return targetStore.name;
+    }
+
+    return;
+  };
+
+  useEffect(() => {
+    setFilteredBrandstores(brandStoresList);
+  }, [brandStoresList]);
+
+  return (
+    <div className="store-selector">
+      <button
+        className="store-selector__button u-no-margin--bottom"
+        onClick={() => {
+          setShowStoreSelector(!showStoreSelector);
+        }}
+      >
+        {id !== undefined ? getStoreName(id) : "Select a store"}
+      </button>
+      {showStoreSelector && (
+        <div className="store-selector__panel">
+          <div className="p-search-box u-no-margin--bottom">
+            <label htmlFor="search-stores" className="u-off-screen">
+              Search stores
+            </label>
+            <input
+              type="search"
+              className="p-search-box__input"
+              id="search-stores"
+              name="search-stores"
+              placeholder="Search"
+              onInput={(e) => {
+                const value = (e.target as HTMLInputElement).value;
+
+                if (value.length > 0) {
+                  setFilteredBrandstores(
+                    brandStoresList.filter((store) => {
+                      const storeName = store.name.toLowerCase();
+                      return storeName.includes(value.toLowerCase());
+                    }),
+                  );
+                } else {
+                  setFilteredBrandstores(brandStoresList);
+                }
+              }}
+            />
+            <button type="reset" className="p-search-box__reset">
+              <i className="p-icon--close">Close</i>
+            </button>
+            <button type="submit" className="p-search-box__button">
+              <i className="p-icon--search">Search</i>
+            </button>
+          </div>
+          <ul className="store-selector__list" style={{ listStyle: "none" }}>
+            {filteredBrandStores.map((store: Store) => (
+              <li key={store.id} className="store-selector__item">
+                {nativeNavLink ? (
+                  <a href={`/admin/${store.id}/snaps`}>{store.name}</a>
+                ) : (
+                  <NavLink
+                    to={`/admin/${store.id}/snaps`}
+                    onClick={() => {
+                      setShowStoreSelector(false);
+                    }}
+                  >
+                    {store.name}
+                  </NavLink>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default StoreSelector;

--- a/static/js/publisher/components/StoreSelector/index.ts
+++ b/static/js/publisher/components/StoreSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./StoreSelector";


### PR DESCRIPTION
## Done
Adds the brand store selector to the publisher pages navigation

## How to QA
- Go to https://snapcraft-io-5035.demos.haus/<SNAP_NAME>/listing
- Check that there is a store selector in the side navigation (if you have stores)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-19513
