### PR TITLE
fix: Use correct template for metrics views

### DIFF
--- a/webapp/publisher/snaps/metrics_views.py
+++ b/webapp/publisher/snaps/metrics_views.py
@@ -70,7 +70,7 @@ def publisher_snap_metrics(snap_name):
         "is_linux": "Linux" in flask.request.headers["User-Agent"],
     }
 
-    return flask.render_template("publisher/metrics.html", **context)
+    return flask.render_template("store/publisher.html", **context)
 
 
 @login_required


### PR DESCRIPTION
## Done
Use correct template for publisher metrics page

## How to QA
- Go to https://snapcraft-io-5038.demos.haus/<SNAP_NAME>/metrics
- The page should load with metrics data

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
