### PR TITLE
fix: Fix register snap link

### DIFF
--- a/static/js/publisher/components/PublishedSnapList/PublishedSnapList.tsx
+++ b/static/js/publisher/components/PublishedSnapList/PublishedSnapList.tsx
@@ -81,12 +81,12 @@ function PublishedSnapList({
     <Strip element="section" shallow>
       <div className="u-fixed-width u-clearfix">
         <h2 className="p-heading--4 u-float-left">My published snaps</h2>
-        <Link
-          to="/account/register-snap"
+        <a
+          href="/account/register-snap"
           className="p-button u-float-right p-snap-list__register u-no-margin--top"
         >
           Register a snap name
-        </Link>
+        </a>
       </div>
       {isEmpty && <EmptySnapList />}
 


### PR DESCRIPTION
## Done
Fixes issue where "Register a snap name" button doesn't work as it's not part of the publisher SPA

## How to QA
- Go to https://snapcraft-io-5041.demos.haus/snaps
- Click the "Register a snap name" button
- Check that it goes to https://snapcraft-io-5041.demos.haus/register-snap
