### PR TITLE
fix: Remove login which causes redirect loop for new accounts

### DIFF
--- a/webapp/publisher/views.py
+++ b/webapp/publisher/views.py
@@ -56,7 +56,6 @@ def post_publisher_details():
 
 
 @account.route("/agreement")
-@login_required
 def get_agreement():
     return flask.render_template("store/publisher.html")
 


### PR DESCRIPTION
## Done
Fixes bug where new accounts get caught in a redirect loop when trying to accept the developer agreement programme

## How to QA
- https://snapcraft-io-5048.demos.haus/ and login
- Go to https://snapcraft-io-5048.demos.haus/account/agreement
- Accept the agreement
- You should be taken to https://snapcraft-io-5048.demos.haus/snaps

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):
