### PR TITLE
fix: remove unnecessary z-index

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -445,7 +445,6 @@ dl {
   .p-accordion__panel {
     padding-left: 0;
     position: relative;
-    z-index: 1;
   }
 
   .p-accordion__list {


### PR DESCRIPTION
## Done
- incorrect z-index causing child components to have incorrect layout 
## How to QA
- go to /snaps
- metrics toolbar should be over all other components
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): layout fix

## Issue / Card
Fixes WD-19998 reported here https://chat.canonical.com/canonical/pl/sizwtkcrupydpfe7t7em47iaje

## Screenshots


![image](https://github.com/user-attachments/assets/6ab6d529-2fe0-44bb-99f1-ba63942cd283)
