### PR TITLE
Builds: default string for Organizations dropdown if user does not have "name"

### DIFF
--- a/static/js/publisher/pages/Builds/RepoSelector.tsx
+++ b/static/js/publisher/pages/Builds/RepoSelector.tsx
@@ -192,7 +192,8 @@ function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {
             options={[
               { label: "Select organization", value: "" },
               {
-                label: githubData?.github_user.name,
+                label:
+                  githubData?.github_user.name || githubData?.github_user.login,
                 value: githubData?.github_user.login,
               },
               ...getOrgs(),


### PR DESCRIPTION
The problem I encountered is that the Organizations dropdown had the list of organizations that my GitHub account is a part of, and then a blank entry that represents the repos owned by my user. I checked out the source code of that page and it uses the `name` attribute of the GH user, which is optional.
My user didn't have it set so the entry was empty. The issue is cosmetic/UX only, as clicking on the black entry still shows the user's own repos and everything is connected successfully.

## Done

Added the `login` attribute of the GH user as default value for the label of the dropdown entry representing the user's repos.

Unfortunately, I wasn't able to get a working test environment due to yarn and/or node version issues,  even in a fresh VM, so this change is completely untested either by a human on the website, or by automated tests.
Running `dotrun` results in 
```
error nanoid@5.0.7: The engine "node" is incompatible with this module. Expected version "^18 || >=20". Got "16.15.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
which I wasn't able to resolve. If you have any guidance on how to get a working test environment I'd be more than happy to manually test the change and add unit tests for this.
I think the change is so small an inconsequential that it might not be necessary, but the decision is for the maintainers to take.

## How to QA

## Testing
- [ ] This PR has tests
- [x] No testing required: I believe the change to be very simple and inconsequential to the application

## Issue / Card
Fixes #5034

## Screenshots

I don't have a snap that is not connected to a GH repo and I don't see the use in creating a new one just for this, so I cannot provide screenshots. The issue can be replicated starting from any snap that is not connected to a GH repo (or a brand new snap), going to the Builds page, logging in to GH with a user that does not have the `name` property set, and clicking on the Organizations dropdown. What is currently happening is that the first entry is blank. After the change, the blank entry would be replaced with the GH username.