### PR TITLE
Add bot user token for accessing CVEs to secrets

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -41,6 +41,11 @@ env: &env
       key: github-snapcraft-user-token
       name: snapcraft-io
 
+  - name: GITHUB_SNAPCRAFT_BOT_USER_TOKEN
+    secretKeyRef:
+      key: github-snapcraft-bot-user-token
+      name: snapcraft-io
+
   - name: GITHUB_WEBHOOK_SECRET
     secretKeyRef:
       key: github-webhook-secret
@@ -80,7 +85,7 @@ env: &env
     secretKeyRef:
       key: discourse-api-username
       name: snapcraft-io
-  
+
   - name: DNS_VERIFICATION_SALT
     secretKeyRef:
       key: dns-verification-salt


### PR DESCRIPTION
## Done

Adds `GITHUB_SNAPCRAFT_BOT_USER_TOKEN` env variable with `snapcraft-bot` user GH token for accessing CVEs.

## How to QA

- Just code review for now
- search snapcraft.io code for `GITHUB_SNAPCRAFT_BOT_USER_TOKEN`, make sure it's the env variable needed for CVE API
- optionally, if you have access to k8s (demos or production) you can verify if `snapcraft-io/github-snapcraft-bot-user-token` exists there

## Issue / Card

Fixes WD-18863
