### PR TITLE
fix: Update store-api to fix remove icon bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==5.7.3
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.image-template==1.4.2
-canonicalwebteam.store-api==6.0.0
+canonicalwebteam.store-api==6.1.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0


### PR DESCRIPTION
## Done
Updated store-api to fix issue with icons not being removed

## How to QA
- Go to https://snapcraft-io-5062.demos.haus/<SNAP_NAME>/listing
- Remove the icon and save
- Reload the page
- The icon should be removed