### PR TITLE
chore: Remove links from registered snap names list

### DIFF
--- a/static/js/publisher/components/RegisteredSnaps/RegisteredSnaps.tsx
+++ b/static/js/publisher/components/RegisteredSnaps/RegisteredSnaps.tsx
@@ -40,7 +40,7 @@ function RegisteredSnaps({
             width: "25%",
             content: (
               <>
-                <Link to={`/${snap.snapName}/listing`}>{snap.snapName}</Link>
+                {snap.snapName}
                 {isDisputePending && (
                   <>
                     &nbsp;
@@ -62,7 +62,7 @@ function RegisteredSnaps({
           {
             content: isUsersSnap ? (
               <button
-                className="p-button--base u-no-margin--bottom"
+                className="p-button--base u-no-margin--bottom is-dense"
                 onClick={() => {
                   setUnregisterSnapModal(snap.snapName);
                 }}
@@ -75,7 +75,7 @@ function RegisteredSnaps({
                   message={"Snaps can only be unregistered by their owner."}
                 >
                   <button
-                    className="u-no-margin--bottom u-no-margin--right"
+                    className="u-no-margin--bottom u-no-margin--right is-dense"
                     disabled
                   >
                     Unregister


### PR DESCRIPTION
## Done
Removes the links from the registered snap names list

## How to QA
- Go to https://snapcraft-io-5072.demos.haus/snaps
- Check that the snaps names in the "Registered snap names" table are not links

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-20981
