### PR TITLE
fix: don't index unlisted snaps

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -12,6 +12,12 @@
   {% endblock %}
 {% endif %}
 
+{% block extra_meta %}
+  {% if unlisted %}
+    <meta name="robots" content="noindex" />
+  {% endif %}
+{% endblock %}
+
 {% block meta_schema %}
   <script type="application/ld+json">
     {


### PR DESCRIPTION
## Done
- Don't index installation instruction pages
## How to QA
- go to an unlisted snap (i.e stress-ng-dev)
- no-index meta tag should be present in the main snap details page
- no-index meta tag should be present in all the installation instruction pages
- listed snaps (code,lxd) should not have those tags

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): search indexing change

## Issue / Card
Fixes WD-21065

