### PR TITLE
chore: Delete unused type and move constants file

### DIFF
--- a/static/js/publisher/components/PublishedSnapList/PublishedSnapList.tsx
+++ b/static/js/publisher/components/PublishedSnapList/PublishedSnapList.tsx
@@ -4,7 +4,7 @@ import { ISnap } from "../../types";
 import SnapNameEntry from "./SnapNameEntry";
 import NewSnapNotification from "../NewSnapNotification";
 import EmptySnapList from "../EmptySnapList";
-import { PAGE_NUMBER } from "../../types/constants";
+import { ITEMS_PER_PAGE } from "../../constants";
 
 function PublishedSnapList({
   snaps,
@@ -115,7 +115,7 @@ function PublishedSnapList({
           />
           <Pagination
             currentPage={currentPage}
-            itemsPerPage={PAGE_NUMBER}
+            itemsPerPage={ITEMS_PER_PAGE}
             paginate={(page) => setCurrentPage(page)}
             totalItems={totalItems}
           />

--- a/static/js/publisher/components/PublishedSnapSection/PublishedSnapSection.tsx
+++ b/static/js/publisher/components/PublishedSnapSection/PublishedSnapSection.tsx
@@ -3,7 +3,7 @@ import { Accordion } from "@canonical/react-components";
 import { ISnap } from "../../types";
 import PublishedSnapList from "../PublishedSnapList";
 import PublisherMetrics from "../PublisherMetrics";
-import { PAGE_NUMBER } from "../../types/constants";
+import { ITEMS_PER_PAGE } from "../../constants";
 
 function PublishedSnapSection({
   snaps,
@@ -14,10 +14,10 @@ function PublishedSnapSection({
 }) {
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  const firstItemOfPage = (currentPage - 1) * PAGE_NUMBER;
+  const firstItemOfPage = (currentPage - 1) * ITEMS_PER_PAGE;
   const snapsInPage = snaps.slice(
     firstItemOfPage,
-    firstItemOfPage + PAGE_NUMBER,
+    firstItemOfPage + ITEMS_PER_PAGE,
   );
 
   return (

--- a/static/js/publisher/components/RegisteredSnaps/RegisteredSnaps.tsx
+++ b/static/js/publisher/components/RegisteredSnaps/RegisteredSnaps.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 
 import { ISnap } from "../../types";
-import { PAGE_NUMBER } from "../../types/constants";
+import { ITEMS_PER_PAGE } from "../../constants";
 
 function RegisteredSnaps({
   snaps,
@@ -168,7 +168,7 @@ function RegisteredSnaps({
             {
               key: "registered-snap-names",
               title: `Registered snap names (${snaps.length})`,
-              content: <MainTable rows={getData()} paginate={PAGE_NUMBER} />,
+              content: <MainTable rows={getData()} paginate={ITEMS_PER_PAGE} />,
             },
           ]}
           expanded="registered-snap-names"

--- a/static/js/publisher/constants/index.ts
+++ b/static/js/publisher/constants/index.ts
@@ -1,0 +1,1 @@
+export const ITEMS_PER_PAGE = 10;

--- a/static/js/publisher/types/constants.ts
+++ b/static/js/publisher/types/constants.ts
@@ -1,1 +1,0 @@
-export const PAGE_NUMBER = 10;

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -4,18 +4,6 @@ export type RouteParams = {
 
 export type Status = "Pending" | "Expired" | "Revoked";
 
-// Slices
-export type CurrentStoreSlice = {
-  currentStore: {
-    currentStore: {
-      id: string;
-      "manual-review-policy": string;
-      private: boolean;
-      name: string;
-    };
-  };
-};
-
 // Item lists
 export type InvitesList = Array<Invite>;
 export type MembersList = Array<Member>;


### PR DESCRIPTION
## Done
- Removes unused type (`CurrentStoreSlice`) which was left over from Redux Toolkit
- Renames `PAGE_NUMBER` constant to `ITEMS_PER_PAGE` to be clearer as to its intent
- Moves constants file from types to a constants directory as it is not a type (there are potentially more constants that could be added to this file in the codebase)

## How to QA
All the checks should pass

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes
