### PR TITLE
fix: Fix welcome heading when publisher has no snaps

### DIFF
--- a/static/js/publisher/components/PublishedSnapList/PublishedSnapList.tsx
+++ b/static/js/publisher/components/PublishedSnapList/PublishedSnapList.tsx
@@ -79,10 +79,13 @@ function PublishedSnapList({
 
   return (
     <Strip element="section" shallow>
-      <div className="u-fixed-width">
-        <h2 className="p-heading--4 u-float-left">My published snaps</h2>
-      </div>
       {isEmpty && <EmptySnapList />}
+
+      {!isEmpty && (
+        <div className="u-fixed-width">
+          <h2 className="p-heading--4">My published snaps</h2>
+        </div>
+      )}
 
       {shouldShowNewSnapNotification && <NewSnapNotification snap={snaps[0]} />}
 


### PR DESCRIPTION

## Done

Currently if published has no snaps we show both "My published snaps" and "Get started" headings (floated next to one another).

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/a43592c1-ddba-4e57-80e0-edaeeb8be8cc" />

This PR fixes this by hiding "My published snaps" heading if there are no snaps.

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/cc00934d-2e39-46d1-92ba-777383d65748" />


## How to QA

- log in to demo with user that doesn't have snaps https://snapcraft-io-5079.demos.haus/snaps
- check if heading displays correctly

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): visual changes only


