### PR TITLE
fix: Address Signing Keys compiler warnings from TiCS dashboard

### DIFF
--- a/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
+++ b/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
@@ -87,11 +87,11 @@ function SigningKeys(): React.JSX.Element {
         signal,
         setEnableTableActions,
       });
-
-      return () => {
-        controller.abort();
-      };
     }
+
+    return () => {
+      controller.abort();
+    };
   }, [models]);
 
   return (


### PR DESCRIPTION
## Done
Address compiler warnings from [the TiCS dashboard](https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=ProjectGroup(PublicRepos),Project(snapcraft.io),Sub(static),Sub(js),Sub(publisher),Sub(pages),Sub(SigningKeys),Sub()&metric=tqiCompWarn)

## How to QA
- Go to https://snapcraft-io-5088.demos.haus/admin/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/signing-keys
- Check that the page loads as expected

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes
