### PR TITLE
fix: Address register snap compiler warnings from TiCS dashboard

### DIFF
--- a/static/js/publisher/pages/RegisterSnap/RegistrationError.tsx
+++ b/static/js/publisher/pages/RegisterSnap/RegistrationError.tsx
@@ -59,6 +59,8 @@ function RegistrationError({ snapName, errorCode, isPrivate, store }: Props) {
       </Notification>
     );
   }
+
+  return null;
 }
 
 export default RegistrationError;


### PR DESCRIPTION
## Done
Addresses register snap compiler warnings from [the TiCS dashboard](https://canonical.tiobe.com/tiobeweb/TICS/TqiDashboard.html#axes=ProjectGroup(PublicRepos),Project(snapcraft.io),Sub(static),Sub(js),Sub(publisher),Sub(pages),Sub(RegisterSnap),Sub()&metric=tqiCompWarn)

## How to QA
- Go to https://snapcraft-io-5089.demos.haus/register-snap
- Register a snap name that you already own or that already exists
- Check that a notification appears telling you about the error

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes