### PR TITLE
fix: Fix incorrect notification when registering snap name in the global store

### DIFF
--- a/static/js/publisher/pages/RegisterSnap/RegistrationError.tsx
+++ b/static/js/publisher/pages/RegisterSnap/RegistrationError.tsx
@@ -11,8 +11,15 @@ type Props = {
 function RegistrationError({ snapName, errorCode, isPrivate, store }: Props) {
   if (errorCode === "name-review-required") {
     return (
-      <Notification severity="information">
-        <strong>{snapName}</strong> has been submitted for review
+      <Notification severity="caution">
+        All snap names are currently subject to a review. Please see{" "}
+        <a href="https://forum.snapcraft.io/t/manual-review-of-all-new-snap-name-registrations/39440">
+          https://forum.snapcraft.io/t/manual-review-of-all-new-snap-name-registrations/39440
+        </a>{" "}
+        for details. Follow this link to submit a name request for your snap:
+        <a href="https://dashboard.snapcraft.io/register-snap">
+          https://dashboard.snapcraft.io/register-snap
+        </a>
       </Notification>
     );
   }

--- a/static/js/publisher/pages/RegisterSnap/__tests__/RegisterSnapError.test.tsx
+++ b/static/js/publisher/pages/RegisterSnap/__tests__/RegisterSnapError.test.tsx
@@ -1,0 +1,60 @@
+import { BrowserRouter } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import RegistrationError from "../RegistrationError";
+
+function renderComponent(errorCode: string) {
+  return render(
+    <BrowserRouter>
+      <RegistrationError
+        snapName="test-snap-name"
+        isPrivate="private"
+        store="ubuntu"
+        errorCode={errorCode}
+      />
+    </BrowserRouter>,
+  );
+}
+
+describe("RegistrationError", () => {
+  test("points user to dashboard when registering snap in global store", () => {
+    renderComponent("name-review-required");
+    expect(
+      screen.getByRole("link", {
+        name: "https://dashboard.snapcraft.io/register-snap",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test("informs user if they already own snap", () => {
+    renderComponent("already_owned");
+    const el = screen.getByText("You already own", { exact: false });
+    expect(el.textContent).toEqual("You already own 'test-snap-name'.");
+  });
+
+  test("directs user to request a reserved name", () => {
+    renderComponent("reserved_name");
+    expect(
+      screen.getByRole("link", { name: "request a reserved name" }),
+    ).toBeInTheDocument();
+  });
+
+  test("informs user if no permission to register snap", () => {
+    renderComponent("no-permission");
+    expect(
+      screen.getByText(
+        "You do not have permission to register snaps to this store. Contact the store administrator.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test("informs user if snap needs to be registered", () => {
+    renderComponent("other_error_code");
+    expect(
+      screen.getByText(
+        "Before you can push your snap to the store, its name must be registered",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Done
Fixes issue where the correct notification isn't displayed when registering snap names in the global store

## How to QA
- Go to https://snapcraft-io-5095.demos.haus/register-snap
- Register a new snap name that isn't reserved or already existing
- Check that the notification links to the dashboard

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):