### PR TITLE
fix: Address code coverage warnings from TiCS dashboard for publisher utils

### DIFF
--- a/static/js/publisher/utils/__tests__/getSettingsChanges.test.ts
+++ b/static/js/publisher/utils/__tests__/getSettingsChanges.test.ts
@@ -1,0 +1,107 @@
+import getSettingsChanges from "../getSettingsChanges";
+
+describe("getSettingsChanges", () => {
+  test("handles setting visibility to public", () => {
+    const changes = getSettingsChanges(
+      { visibility: true },
+      { visibility: "public" },
+    );
+
+    expect(changes.private).toEqual(false);
+    expect(changes.unlisted).toEqual(false);
+  });
+
+  test("handles setting visibility to unlisted", () => {
+    const changes = getSettingsChanges(
+      { visibility: true },
+      { visibility: "unlisted" },
+    );
+
+    expect(changes.unlisted).toEqual(true);
+    expect(changes.private).toEqual(false);
+  });
+
+  test("handles setting visibility to private", () => {
+    const changes = getSettingsChanges(
+      { visibility: true },
+      { visibility: "private" },
+    );
+
+    expect(changes.private).toEqual(true);
+    expect(changes.unlisted).toEqual(false);
+  });
+
+  test("handles setting territories to all", () => {
+    const changes = getSettingsChanges(
+      { territory_distribution_status: true },
+      { territory_distribution_status: "all" },
+    );
+
+    expect(changes.whitelist_countries).toHaveLength(0);
+    expect(changes.blacklist_countries).toHaveLength(0);
+  });
+
+  test("handles removing custom whitelist countries", () => {
+    const changes = getSettingsChanges(
+      { whitelist_country_keys: true },
+      { territory_distribution_status: "custom" },
+    );
+
+    expect(changes.whitelist_countries).toHaveLength(0);
+    expect(changes.blacklist_countries).toHaveLength(0);
+  });
+
+  test("handles setting custom whitelist countries", () => {
+    const changes = getSettingsChanges(
+      { whitelist_country_keys: true },
+      {
+        territory_distribution_status: "custom",
+        whitelist_country_keys: "EN US FR",
+      },
+    );
+
+    expect(changes.whitelist_countries).toEqual(["EN", "US", "FR"]);
+    expect(changes.blacklist_countries).toHaveLength(0);
+  });
+
+  test("handles removing custom blacklist countries", () => {
+    const changes = getSettingsChanges(
+      { blacklist_country_keys: true },
+      { territory_distribution_status: "custom" },
+    );
+
+    expect(changes.blacklist_countries).toHaveLength(0);
+    expect(changes.whitelist_countries).toHaveLength(0);
+  });
+
+  test("handles setting custom blacklist countries", () => {
+    const changes = getSettingsChanges(
+      { blacklist_country_keys: true },
+      {
+        territory_distribution_status: "custom",
+        blacklist_country_keys: "EN US FR",
+      },
+    );
+
+    expect(changes.blacklist_countries).toEqual(["EN", "US", "FR"]);
+    expect(changes.whitelist_countries).toHaveLength(0);
+  });
+
+  test("handles enabling update metadata on release", () => {
+    const changes = getSettingsChanges(
+      { update_metadata_on_release: true },
+      { update_metadata_on_release: true },
+    );
+
+    expect(changes.update_metadata_on_release).toEqual("on");
+  });
+
+  test("handles disabling update metadata on release", () => {
+    const changes = getSettingsChanges(
+      { update_metadata_on_release: true },
+      { update_metadata_on_release: false },
+    );
+
+    expect(changes.update_metadata_on_release).toEqual(false);
+  });
+});

--- a/static/js/publisher/utils/__tests__/getSettingsData.test.ts
+++ b/static/js/publisher/utils/__tests__/getSettingsData.test.ts
@@ -1,0 +1,83 @@
+import getSettingsData from "../getSettingsData";
+
+const testSettingsData = {
+  whitelist_countries: [],
+  blacklist_countries: [],
+};
+
+describe("getSettingsData", () => {
+  test("gets unlisted visibility status", () => {
+    const settings = getSettingsData({ ...testSettingsData, unlisted: true });
+    expect(settings.visibility).toEqual("unlisted");
+  });
+
+  test("gets private visibility status", () => {
+    const settings = getSettingsData({ ...testSettingsData, private: true });
+    expect(settings.visibility).toEqual("private");
+  });
+
+  test("gets public visibility status", () => {
+    const settings = getSettingsData({
+      ...testSettingsData,
+      unlisted: false,
+      private: false,
+    });
+
+    expect(settings.visibility).toEqual("public");
+  });
+
+  test("gets custom territory distribution status if whitelist", () => {
+    const settings = getSettingsData({
+      ...testSettingsData,
+      whitelist_countries: ["EN"],
+    });
+
+    expect(settings.territory_distribution_status).toEqual("custom");
+  });
+
+  test("gets custom territory distribution status if blacklist", () => {
+    const settings = getSettingsData({
+      ...testSettingsData,
+      blacklist_countries: ["EN"],
+    });
+
+    expect(settings.territory_distribution_status).toEqual("custom");
+  });
+
+  test("gets all territory distrubtion status", () => {
+    const settings = getSettingsData(testSettingsData);
+    expect(settings.territory_distribution_status).toEqual("all");
+  });
+
+  test("gets whitelist country keys", () => {
+    const settings = getSettingsData({
+      ...testSettingsData,
+      whitelist_countries: ["US", "EN"],
+    });
+
+    expect(settings.whitelist_country_keys).toEqual("EN US");
+  });
+
+  test("gets blacklist country keys", () => {
+    const settings = getSettingsData({
+      ...testSettingsData,
+      blacklist_countries: ["US", "EN"],
+    });
+
+    expect(settings.blacklist_country_keys).toEqual("EN US");
+  });
+
+  test("gets country keys status if blacklist country keys", () => {
+    const settings = getSettingsData({
+      ...testSettingsData,
+      blacklist_countries: ["EN", "US"],
+    });
+
+    expect(settings.country_keys_status).toEqual("exclude");
+  });
+
+  test("gets country keys status", () => {
+    const settings = getSettingsData(testSettingsData);
+    expect(settings.country_keys_status).toEqual("include");
+  });
+});

--- a/static/js/publisher/utils/getSettingsChanges.ts
+++ b/static/js/publisher/utils/getSettingsChanges.ts
@@ -32,7 +32,10 @@ function getSettingsChanges(
 
   if (data?.territory_distribution_status === "custom") {
     if (dirtyFields?.whitelist_country_keys) {
-      if (!data?.whitelist_country_keys.length) {
+      if (
+        !data?.whitelist_country_keys ||
+        !data?.whitelist_country_keys.length
+      ) {
         changes.whitelist_countries = [];
       } else {
         changes.whitelist_countries = data?.whitelist_country_keys.split(" ");
@@ -42,7 +45,10 @@ function getSettingsChanges(
     }
 
     if (dirtyFields?.blacklist_country_keys) {
-      if (!data?.blacklist_country_keys.length) {
+      if (
+        !data?.blacklist_country_keys ||
+        !data?.blacklist_country_keys.length
+      ) {
         changes.blacklist_countries = [];
       } else {
         changes.blacklist_countries = data?.blacklist_country_keys.split(" ");


### PR DESCRIPTION
## Done
Adds tests for publisher utils

## How to QA
All tests should pass (except the inclusive naming check)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):
