### PR TITLE
feat(CVEs): Adds the API endpoint to check CVEs availability for given snap

### DIFF
--- a/tests/publisher/cve/test_has_cve.py
+++ b/tests/publisher/cve/test_has_cve.py
@@ -2,7 +2,6 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from webapp.publisher.cve.cve_helper import CveHelper
-from werkzeug.exceptions import NotFound
 
 
 class HasCvesTest(unittest.TestCase):
@@ -17,8 +16,7 @@ class HasCvesTest(unittest.TestCase):
         ]
 
         result = CveHelper.has_cve_data("my-snap")
-
-        self.assertEqual(result, True)
+        self.assertTrue(result)
 
     @patch("requests.get")
     def test_has_cve_data_not_found(self, mock_get):
@@ -26,5 +24,5 @@ class HasCvesTest(unittest.TestCase):
             MagicMock(status_code=404, json=lambda: {}),
         ]
 
-        with self.assertRaises(NotFound):
-            CveHelper.has_cve_data("my-snap")
+        result = CveHelper.has_cve_data("my-snap")
+        self.assertFalse(result)

--- a/tests/publisher/cve/test_has_cve.py
+++ b/tests/publisher/cve/test_has_cve.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from webapp.publisher.cve.cve_helper import CveHelper
+from werkzeug.exceptions import NotFound
+
+
+class HasCvesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.file_metadata = {"download_url": "https://example.com/file.json"}
+
+    @patch("requests.get")
+    def test_has_cve_data(self, mock_get):
+        mock_get.side_effect = [
+            MagicMock(status_code=200, json=lambda: self.file_metadata),
+        ]
+
+        result = CveHelper.has_cve_data("my-snap")
+
+        self.assertEqual(result, True)
+
+    @patch("requests.get")
+    def test_has_cve_data_not_found(self, mock_get):
+        mock_get.side_effect = [
+            MagicMock(status_code=404, json=lambda: {}),
+        ]
+
+        with self.assertRaises(NotFound):
+            CveHelper.has_cve_data("my-snap")

--- a/tests/publisher/cve/test_has_cve_api.py
+++ b/tests/publisher/cve/test_has_cve_api.py
@@ -1,0 +1,74 @@
+from unittest import TestCase
+from webapp.app import create_app
+from unittest.mock import patch
+
+
+class TestEndpoints(TestCase):
+    def setUp(self):
+        self.app = create_app(testing=True)
+        self.client = self.app.test_client()
+        self._log_in(is_canonical=False)
+
+    def _log_in(self, is_canonical=False):
+        test_macaroon = "test_macaroon"
+        with self.client.session_transaction() as s:
+            s["publisher"] = {
+                "account_id": "test_account_id",
+                "image": None,
+                "nickname": "XYZ",
+                "fullname": "ABC XYZ",
+                "email": "testing@testing.com",
+                "stores": [],
+                "is_canonical": is_canonical,
+            }
+            s["macaroons"] = test_macaroon
+            s["developer_token"] = test_macaroon
+            s["exchanged_developer_token"] = True
+
+    def _set_user_is_canonical(self, value):
+        self._log_in(is_canonical=value)
+
+
+class TestModelServiceEndpoints(TestEndpoints):
+    @patch(
+        "webapp.publisher.cve.cve_helper.CveHelper.has_cve_data",
+        return_value=True,
+    )
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_snap_info",
+        return_value={"snap_id": "id"},
+    )
+    def test_get_policies_for_canonical_user(
+        self, mock_get_snap_info, mock_get
+    ):
+        self._set_user_is_canonical(True)
+
+        response = self.client.get("api/snaps/cve/test")
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["success"], True)
+
+    @patch(
+        "webapp.publisher.cve.cve_helper.CveHelper.has_cve_data",
+        return_value=False,
+    )
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_snap_info",
+        return_value={"snap_id": "id"},
+    )
+    def test_get_policies_no_data(self, mock_get_snap_info, mock_get):
+        self._set_user_is_canonical(True)
+
+        response = self.client.get("api/snaps/cve/test")
+        data = response.json
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(data["success"], False)
+
+    def test_get_policies_for_non_canonical_user(self):
+        response = self.client.get("api/snaps/cve/test")
+        data = response.json
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(data["success"], False)

--- a/tests/publisher/cve/test_has_cve_api.py
+++ b/tests/publisher/cve/test_has_cve_api.py
@@ -38,9 +38,7 @@ class TestModelServiceEndpoints(TestEndpoints):
         "canonicalwebteam.store_api.dashboard.Dashboard.get_snap_info",
         return_value={"snap_id": "id"},
     )
-    def test_get_policies_for_canonical_user(
-        self, mock_get_snap_info, mock_get
-    ):
+    def test_has_cves_for_canonical_user(self, mock_get_snap_info, mock_get):
         self._set_user_is_canonical(True)
 
         response = self.client.get("api/snaps/cve/test")
@@ -57,7 +55,7 @@ class TestModelServiceEndpoints(TestEndpoints):
         "canonicalwebteam.store_api.dashboard.Dashboard.get_snap_info",
         return_value={"snap_id": "id"},
     )
-    def test_get_policies_no_data(self, mock_get_snap_info, mock_get):
+    def test_has_cves_no_data(self, mock_get_snap_info, mock_get):
         self._set_user_is_canonical(True)
 
         response = self.client.get("api/snaps/cve/test")
@@ -66,7 +64,7 @@ class TestModelServiceEndpoints(TestEndpoints):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(data["success"], False)
 
-    def test_get_policies_for_non_canonical_user(self):
+    def test_has_cves_for_non_canonical_user(self):
         response = self.client.get("api/snaps/cve/test")
         data = response.json
 

--- a/webapp/publisher/cve/cve_helper.py
+++ b/webapp/publisher/cve/cve_helper.py
@@ -111,11 +111,13 @@ class CveHelper:
 
     @staticmethod
     def has_cve_data(snap_name):
-        file_metadata = CveHelper._get_cve_file_metadata(
-            "snap-cves/{}.json".format(snap_name)
-        )
-
-        return bool(file_metadata)
+        try:
+            CveHelper._get_cve_file_metadata(
+                "snap-cves/{}.json".format(snap_name)
+            )
+            return True
+        except NotFound:
+            return False
 
     @staticmethod
     def get_cve_with_revision(snap_name, revision):

--- a/webapp/publisher/cve/cve_helper.py
+++ b/webapp/publisher/cve/cve_helper.py
@@ -110,6 +110,14 @@ class CveHelper:
             raise NotFound
 
     @staticmethod
+    def has_cve_data(snap_name):
+        file_metadata = CveHelper._get_cve_file_metadata(
+            "snap-cves/{}.json".format(snap_name)
+        )
+
+        return bool(file_metadata)
+
+    @staticmethod
     def get_cve_with_revision(snap_name, revision):
         file_metadata = CveHelper._get_cve_file_metadata(
             "snap-cves/{}.json".format(snap_name)

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -54,13 +54,12 @@ def has_cves(snap_name):
 
     snap_has_cves = CveHelper.has_cve_data(snap_name)
     if snap_has_cves:
-        return flask.jsonify({"success": True, "has_cves": True})
+        return flask.jsonify({"success": True})
     else:
         return (
             flask.jsonify(
                 {
-                    "success": True,
-                    "has_cves": False,
+                    "success": False,
                     "error": f"No CVEs data available for '{snap_name}' snap.",
                 }
             ),

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -4,7 +4,6 @@ from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiError
 from webapp.helpers import api_publisher_session
 from webapp.decorators import login_required
 from webapp.publisher.cve.cve_helper import CveHelper
-from werkzeug.exceptions import NotFound
 
 dashboard = Dashboard(api_publisher_session)
 
@@ -53,10 +52,7 @@ def has_cves(snap_name):
             status_code,
         )
 
-    try:
-        snap_has_cves = CveHelper.has_cve_data(snap_name)
-    except NotFound:
-        snap_has_cves = False
+    snap_has_cves = CveHelper.has_cve_data(snap_name)
     if snap_has_cves:
         return flask.jsonify({"success": True})
     else:

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -4,6 +4,7 @@ from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiError
 from webapp.helpers import api_publisher_session
 from webapp.decorators import login_required
 from webapp.publisher.cve.cve_helper import CveHelper
+from werkzeug.exceptions import NotFound
 
 dashboard = Dashboard(api_publisher_session)
 
@@ -52,7 +53,10 @@ def has_cves(snap_name):
             status_code,
         )
 
-    snap_has_cves = CveHelper.has_cve_data(snap_name)
+    try:
+        snap_has_cves = CveHelper.has_cve_data(snap_name)
+    except NotFound:
+        snap_has_cves = False
     if snap_has_cves:
         return flask.jsonify({"success": True})
     else:

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -64,7 +64,7 @@ def has_cves(snap_name):
             flask.jsonify(
                 {
                     "success": False,
-                    "error": f"No CVEs data available for '{snap_name}' snap.",
+                    "error": f"CVEs data for '{snap_name}' snap not found.",
                 }
             ),
             404,

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -1,6 +1,6 @@
 import flask
 from canonicalwebteam.store_api.dashboard import Dashboard
-
+from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiError
 from webapp.helpers import api_publisher_session
 from webapp.decorators import login_required
 from webapp.publisher.cve.cve_helper import CveHelper
@@ -8,8 +8,77 @@ from webapp.publisher.cve.cve_helper import CveHelper
 dashboard = Dashboard(api_publisher_session)
 
 
+def can_user_access_cve_data(snap_name):
+    """
+    Check if the user has access to CVE data for the given snap.
+
+    :return: A tuple containing:
+        has_access (bool): True if the user has access, False otherwise.
+        error_message (str): Error message if access is denied.
+        status_code (int): HTTP status code for the response.
+    """
+    is_user_canonical = flask.session["publisher"].get("is_canonical", False)
+
+    # TODO: in future with brand store support we will need more specific
+    # checks, such as those implemented in CveHelper.can_user_access_cve_data
+    # For now, we only check if user is Canonical member and has
+    # publisher access to the snap.
+    if not is_user_canonical:
+        return (False, "User is not allowed to see snap's CVE data.", 403)
+
+    try:
+        snap_details = dashboard.get_snap_info(flask.session, snap_name)
+    except StoreApiResourceNotFound:
+        return (False, f"CVEs data for '{snap_name}' snap not found.", 404)
+    except StoreApiError:
+        return (False, f"Error fetching '{snap_name}' snap details.", 500)
+
+    if not snap_details:
+        return (False, f"CVEs data for '{snap_name}' snap not found.", 404)
+
+    return (True, None, 200)
+
+
+@login_required
+def has_cves(snap_name):
+
+    # Check if the user has access to CVE data for the given snap
+    has_access, error_message, status_code = can_user_access_cve_data(
+        snap_name
+    )
+    if not has_access:
+        return (
+            flask.jsonify({"success": False, "error": error_message}),
+            status_code,
+        )
+
+    snap_has_cves = CveHelper.has_cve_data(snap_name)
+    if snap_has_cves:
+        return flask.jsonify({"success": True, "has_cves": True})
+    else:
+        return (
+            flask.jsonify(
+                {
+                    "success": True,
+                    "has_cves": False,
+                    "error": f"No CVEs data available for '{snap_name}' snap.",
+                }
+            ),
+            404,
+        )
+
+
 @login_required
 def get_cves(snap_name, revision):
+    # Check if the user has access to CVE data for the given snap
+    has_access, error_message, status_code = can_user_access_cve_data(
+        snap_name
+    )
+    if not has_access:
+        return (
+            flask.jsonify({"success": False, "error": error_message}),
+            status_code,
+        )
 
     # Filtering params
     usn_ids = flask.request.args.getlist("usn_id")
@@ -59,34 +128,6 @@ def get_cves(snap_name, revision):
     # Pagination params
     page = flask.request.args.get("page", default=1, type=int)
     page_size = flask.request.args.get("page_size", default=10, type=int)
-    is_user_canonical = flask.session["publisher"].get("is_canonical", False)
-
-    # TODO: in future with brand store support we will need more specific
-    # checks, such as those implemented in CveHelper.can_user_access_cve_data
-    # For now, we only check if user is Canonical member and has
-    # publisher access to the snap.
-    if not is_user_canonical:
-        return (
-            flask.jsonify(
-                {
-                    "success": False,
-                    "error": "User is not allowed to see snap's CVE data.",
-                }
-            ),
-            403,
-        )
-
-    snap_details = dashboard.get_snap_info(flask.session, snap_name)
-    if not snap_details:
-        return (
-            flask.jsonify(
-                {
-                    "success": False,
-                    "error": f"Snap '{snap_name}' not found.",
-                }
-            ),
-            404,
-        )
 
     cves = CveHelper.get_cve_with_revision(snap_name, revision)
     cves = CveHelper.filter_cve_data(

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -285,6 +285,11 @@ publisher_snaps.add_url_rule(
     view_func=cve_views.get_cves,
 )
 
+publisher_snaps.add_url_rule(
+    "/api/snaps/cve/<snap_name>",
+    view_func=cve_views.has_cves,
+)
+
 
 @publisher_snaps.route("/account/snaps")
 @login_required


### PR DESCRIPTION
## Done

Adds an API endpoint to check if given snap has CVE data available.
If the user is allowed to see the CVE data (is Canonical publisher and has access to said snap), and there is CVE data available in the snap-cves repo, it should return true, otherwise it should error.

## How to QA

- sign in
- assuming you have access to docker snap (https://snapcraft-io-5100.demos.haus/docker/listing)
- go to API endpoint for snap that has CVES: https://snapcraft-io-5100.demos.haus/api/snaps/cve/docker - it should return succecss true
- go to any other snap you have access to that doesn't have CVEs: https://snapcraft-io-5100.demos.haus/api/snaps/cve/firefox - should return error that CVEs data is not available, with 404 status code
- go to API endpoint for non-existent snap: https://snapcraft-io-5100.demos.haus/api/snaps/cve/blabla - should also return error with 404 status code


## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-20926

