### PR TITLE
Add API endpoint to get revisions with CVEs data

### DIFF
--- a/tests/publisher/cve/test_has_cve.py
+++ b/tests/publisher/cve/test_has_cve.py
@@ -1,28 +1,49 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from webapp.publisher.cve.cve_helper import CveHelper
+from werkzeug.exceptions import NotFound
 
 
-class HasCvesTest(unittest.TestCase):
+class HasRevisionsWithCvesTest(unittest.TestCase):
 
-    def setUp(self):
-        self.file_metadata = {"download_url": "https://example.com/file.json"}
-
-    @patch("requests.get")
-    def test_has_cve_data(self, mock_get):
-        mock_get.side_effect = [
-            MagicMock(status_code=200, json=lambda: self.file_metadata),
+    @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
+    def test_returns_revision_numbers(self, mock_get_metadata):
+        mock_get_metadata.return_value = [
+            {"name": "123.yaml"},
+            {"name": "456.yaml"},
+            {"name": "789.yaml"},
         ]
 
-        result = CveHelper.has_cve_data("my-snap")
-        self.assertTrue(result)
+        result = CveHelper.has_revisions_with_cves("my-snap")
+        self.assertEqual(result, [123, 456, 789])
 
-    @patch("requests.get")
-    def test_has_cve_data_not_found(self, mock_get):
-        mock_get.side_effect = [
-            MagicMock(status_code=404, json=lambda: {}),
+    @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
+    def test_ignores_non_yaml_files(self, mock_get_metadata):
+        mock_get_metadata.return_value = [
+            {"name": "README.md"},
+            {"name": "123.yaml"},
+            {"name": "abc.yaml"},
+            {"name": "456.yaml"},
+            {"name": "data.txt"},
         ]
 
-        result = CveHelper.has_cve_data("my-snap")
-        self.assertFalse(result)
+        result = CveHelper.has_revisions_with_cves("my-snap")
+        self.assertEqual(result, [123, 456])
+
+    @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
+    def test_returns_empty_list_if_no_revision_files(self, mock_get_metadata):
+        mock_get_metadata.return_value = [
+            {"name": "README.md"},
+            {"name": "notes.txt"},
+        ]
+
+        result = CveHelper.has_revisions_with_cves("my-snap")
+        self.assertEqual(result, [])
+
+    @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
+    def test_returns_empty_list_on_not_found(self, mock_get_metadata):
+        mock_get_metadata.side_effect = NotFound()
+
+        result = CveHelper.has_revisions_with_cves("my-snap")
+        self.assertEqual(result, [])

--- a/tests/publisher/cve/test_has_cve.py
+++ b/tests/publisher/cve/test_has_cve.py
@@ -15,7 +15,7 @@ class HasRevisionsWithCvesTest(unittest.TestCase):
             {"name": "789.yaml"},
         ]
 
-        result = CveHelper.has_revisions_with_cves("my-snap")
+        result = CveHelper.get_revisions_with_cves("my-snap")
         self.assertEqual(result, [123, 456, 789])
 
     @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
@@ -28,7 +28,7 @@ class HasRevisionsWithCvesTest(unittest.TestCase):
             {"name": "data.txt"},
         ]
 
-        result = CveHelper.has_revisions_with_cves("my-snap")
+        result = CveHelper.get_revisions_with_cves("my-snap")
         self.assertEqual(result, [123, 456])
 
     @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
@@ -38,12 +38,12 @@ class HasRevisionsWithCvesTest(unittest.TestCase):
             {"name": "notes.txt"},
         ]
 
-        result = CveHelper.has_revisions_with_cves("my-snap")
+        result = CveHelper.get_revisions_with_cves("my-snap")
         self.assertEqual(result, [])
 
     @patch("webapp.publisher.cve.cve_helper.CveHelper._get_cve_file_metadata")
     def test_returns_empty_list_on_not_found(self, mock_get_metadata):
         mock_get_metadata.side_effect = NotFound()
 
-        result = CveHelper.has_revisions_with_cves("my-snap")
+        result = CveHelper.get_revisions_with_cves("my-snap")
         self.assertEqual(result, [])

--- a/tests/publisher/cve/test_has_cve_api.py
+++ b/tests/publisher/cve/test_has_cve_api.py
@@ -31,7 +31,7 @@ class TestEndpoints(TestCase):
 
 class TestModelServiceEndpoints(TestEndpoints):
     @patch(
-        "webapp.publisher.cve.cve_helper.CveHelper.has_revisions_with_cves",
+        "webapp.publisher.cve.cve_helper.CveHelper.get_revisions_with_cves",
         return_value=[123, 321],
     )
     @patch(
@@ -48,7 +48,7 @@ class TestModelServiceEndpoints(TestEndpoints):
         self.assertEqual(data["success"], True)
 
     @patch(
-        "webapp.publisher.cve.cve_helper.CveHelper.has_revisions_with_cves",
+        "webapp.publisher.cve.cve_helper.CveHelper.get_revisions_with_cves",
         return_value=[],
     )
     @patch(

--- a/tests/publisher/cve/test_has_cve_api.py
+++ b/tests/publisher/cve/test_has_cve_api.py
@@ -46,6 +46,7 @@ class TestModelServiceEndpoints(TestEndpoints):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data["success"], True)
+        self.assertEqual(data["data"]["revisions"], [123, 321])
 
     @patch(
         "webapp.publisher.cve.cve_helper.CveHelper.get_revisions_with_cves",

--- a/tests/publisher/cve/test_has_cve_api.py
+++ b/tests/publisher/cve/test_has_cve_api.py
@@ -41,7 +41,7 @@ class TestModelServiceEndpoints(TestEndpoints):
     def test_has_cves_for_canonical_user(self, mock_get_snap_info, mock_get):
         self._set_user_is_canonical(True)
 
-        response = self.client.get("api/snaps/cve/test")
+        response = self.client.get("api/test/cves/available")
         data = response.json
 
         self.assertEqual(response.status_code, 200)
@@ -58,14 +58,14 @@ class TestModelServiceEndpoints(TestEndpoints):
     def test_has_cves_no_data(self, mock_get_snap_info, mock_get):
         self._set_user_is_canonical(True)
 
-        response = self.client.get("api/snaps/cve/test")
+        response = self.client.get("api/test/cves/available")
         data = response.json
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(data["success"], False)
 
     def test_has_cves_for_non_canonical_user(self):
-        response = self.client.get("api/snaps/cve/test")
+        response = self.client.get("api/test/cves/available")
         data = response.json
 
         self.assertEqual(response.status_code, 403)

--- a/tests/publisher/cve/test_has_cve_api.py
+++ b/tests/publisher/cve/test_has_cve_api.py
@@ -31,8 +31,8 @@ class TestEndpoints(TestCase):
 
 class TestModelServiceEndpoints(TestEndpoints):
     @patch(
-        "webapp.publisher.cve.cve_helper.CveHelper.has_cve_data",
-        return_value=True,
+        "webapp.publisher.cve.cve_helper.CveHelper.has_revisions_with_cves",
+        return_value=[123, 321],
     )
     @patch(
         "canonicalwebteam.store_api.dashboard.Dashboard.get_snap_info",
@@ -41,15 +41,15 @@ class TestModelServiceEndpoints(TestEndpoints):
     def test_has_cves_for_canonical_user(self, mock_get_snap_info, mock_get):
         self._set_user_is_canonical(True)
 
-        response = self.client.get("api/test/cves/available")
+        response = self.client.get("api/test/cves")
         data = response.json
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data["success"], True)
 
     @patch(
-        "webapp.publisher.cve.cve_helper.CveHelper.has_cve_data",
-        return_value=False,
+        "webapp.publisher.cve.cve_helper.CveHelper.has_revisions_with_cves",
+        return_value=[],
     )
     @patch(
         "canonicalwebteam.store_api.dashboard.Dashboard.get_snap_info",
@@ -58,14 +58,14 @@ class TestModelServiceEndpoints(TestEndpoints):
     def test_has_cves_no_data(self, mock_get_snap_info, mock_get):
         self._set_user_is_canonical(True)
 
-        response = self.client.get("api/test/cves/available")
+        response = self.client.get("api/test/cves")
         data = response.json
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(data["success"], False)
 
     def test_has_cves_for_non_canonical_user(self):
-        response = self.client.get("api/test/cves/available")
+        response = self.client.get("api/test/cves")
         data = response.json
 
         self.assertEqual(response.status_code, 403)

--- a/webapp/publisher/cve/cve_helper.py
+++ b/webapp/publisher/cve/cve_helper.py
@@ -1,6 +1,7 @@
 import json
 from os import getenv
 import requests
+import re
 
 from werkzeug.exceptions import NotFound
 
@@ -110,14 +111,24 @@ class CveHelper:
             raise NotFound
 
     @staticmethod
-    def has_cve_data(snap_name):
+    def has_revisions_with_cves(snap_name):
         try:
-            CveHelper._get_cve_file_metadata(
-                "snap-cves/{}.json".format(snap_name)
+            contents = CveHelper._get_cve_file_metadata(
+                f"snap-cves/{snap_name}"
             )
-            return True
+
+            # find all revision YAML files in the folder
+            # e.g., 123.yaml, 456.yaml, 789.yaml
+            # and extract the revision numbers
+            revision_files = [
+                int(match.group(1))
+                for item in contents
+                if (match := re.match(r"(\d+)\.yaml$", item["name"]))
+            ]
+
+            return revision_files
         except NotFound:
-            return False
+            return []
 
     @staticmethod
     def get_cve_with_revision(snap_name, revision):

--- a/webapp/publisher/cve/cve_helper.py
+++ b/webapp/publisher/cve/cve_helper.py
@@ -111,7 +111,7 @@ class CveHelper:
             raise NotFound
 
     @staticmethod
-    def has_revisions_with_cves(snap_name):
+    def get_revisions_with_cves(snap_name):
         try:
             contents = CveHelper._get_cve_file_metadata(
                 f"snap-cves/{snap_name}"

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -48,21 +48,21 @@ def get_revisions_with_cves(snap_name):
     )
     if not has_access:
         return (
-            flask.jsonify({"success": False, "error": error_message}),
+            flask.jsonify({"success": False, "message": error_message}),
             status_code,
         )
 
     revisions_with_cves = CveHelper.get_revisions_with_cves(snap_name)
     if len(revisions_with_cves) > 0:
         return flask.jsonify(
-            {"success": True, "revisions": revisions_with_cves}
+            {"success": True, "data": {"revisions": revisions_with_cves}}
         )
     else:
         return (
             flask.jsonify(
                 {
                     "success": False,
-                    "error": f"CVEs data for '{snap_name}' snap not found.",
+                    "message": f"CVEs data for '{snap_name}' snap not found.",
                 }
             ),
             404,

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -40,7 +40,7 @@ def can_user_access_cve_data(snap_name):
 
 
 @login_required
-def has_cves(snap_name):
+def get_revisions_with_cves(snap_name):
 
     # Check if the user has access to CVE data for the given snap
     has_access, error_message, status_code = can_user_access_cve_data(
@@ -52,9 +52,11 @@ def has_cves(snap_name):
             status_code,
         )
 
-    snap_has_cves = CveHelper.has_cve_data(snap_name)
-    if snap_has_cves:
-        return flask.jsonify({"success": True})
+    revisions_with_cves = CveHelper.has_revisions_with_cves(snap_name)
+    if len(revisions_with_cves) > 0:
+        return flask.jsonify(
+            {"success": True, "revisions": revisions_with_cves}
+        )
     else:
         return (
             flask.jsonify(

--- a/webapp/publisher/cve/cve_views.py
+++ b/webapp/publisher/cve/cve_views.py
@@ -52,7 +52,7 @@ def get_revisions_with_cves(snap_name):
             status_code,
         )
 
-    revisions_with_cves = CveHelper.has_revisions_with_cves(snap_name)
+    revisions_with_cves = CveHelper.get_revisions_with_cves(snap_name)
     if len(revisions_with_cves) > 0:
         return flask.jsonify(
             {"success": True, "revisions": revisions_with_cves}

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -286,8 +286,8 @@ publisher_snaps.add_url_rule(
 )
 
 publisher_snaps.add_url_rule(
-    "/api/<snap_name>/cves/available",
-    view_func=cve_views.has_cves,
+    "/api/<snap_name>/cves",
+    view_func=cve_views.get_revisions_with_cves,
 )
 
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -281,12 +281,12 @@ publisher_snaps.add_url_rule(
 
 # CVE API
 publisher_snaps.add_url_rule(
-    "/api/snaps/cve/<snap_name>/<revision>",
+    "/api/<snap_name>/<revision>/cves",
     view_func=cve_views.get_cves,
 )
 
 publisher_snaps.add_url_rule(
-    "/api/snaps/cve/<snap_name>",
+    "/api/<snap_name>/cves/available",
     view_func=cve_views.has_cves,
 )
 


### PR DESCRIPTION
## Done

- renames previous `/api/cve/[SNAP]` endpoints to `/api/[SNAP]/cves` for consistency with other snap based endpoints
- replaces previous endpoint that only checked for CVEs availability with an endpoint that returns list of revisions that have CVEs data

Current CVEs endpoints are:

- `/api/[SNAP]/cves` - returns list of revisions that have CVEs data, or error if not found
- `/api/[SNAP]/[REVISION/cves` - returns list of revisions for given revision of a snap


## How to QA

- go to [demo](https://snapcraft-io-5108.demos.haus/), and sign in (ideally with canonical account with superuser access)
- check cves endpoint for a snap that doesn't have data, it should error: https://snapcraft-io-5108.demos.haus/api/firefox/cves
- check CVEs endpoint for a snap that has CVE data: https://snapcraft-io-5108.demos.haus/api/docker/cves
- take one of the revisions from the list in previous step, and check if it returns CVEs: https://snapcraft-io-5108.demos.haus/api/docker/3213/cves
## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes [WD-21559](https://warthogs.atlassian.net/browse/WD-21559)



[WD-21559]: https://warthogs.atlassian.net/browse/WD-21559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ