### PR TITLE
Expose status of CVE in API response

### DIFF
--- a/tests/publisher/cve/test_cve_get_by_revision.py
+++ b/tests/publisher/cve/test_cve_get_by_revision.py
@@ -112,6 +112,7 @@ class CveHGetByRevisionTest(unittest.TestCase):
 
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0]["id"], "CVE-2014-9984")
+        self.assertEqual(result[0]["status"], "fixed")
         self.assertEqual(result[0]["cvss_score"], 9)
         self.assertEqual(result[0]["cvss_severity"], "high")
         self.assertEqual(result[0]["description"], "description-2")
@@ -130,6 +131,7 @@ class CveHGetByRevisionTest(unittest.TestCase):
         )
 
         self.assertEqual(result[1]["id"], "CVE-2023-31486")
+        self.assertEqual(result[1]["status"], "fixed")
         self.assertEqual(result[1]["cvss_score"], 5.5)
         self.assertEqual(result[1]["cvss_severity"], "medium")
         self.assertEqual(result[1]["description"], "description-1")
@@ -150,6 +152,7 @@ class CveHGetByRevisionTest(unittest.TestCase):
         self.assertEqual(result[1]["usns"][0]["id"], "3009-1")
 
         self.assertEqual(result[2]["id"], "CVE-2024-52005")
+        self.assertEqual(result[2]["status"], "unfixed")
         self.assertEqual(result[2]["cvss_score"], 2.1)
         self.assertEqual(result[2]["cvss_severity"], "negligible")
         self.assertEqual(result[2]["description"], "description-3")

--- a/webapp/publisher/cve/cve_helper.py
+++ b/webapp/publisher/cve/cve_helper.py
@@ -35,7 +35,7 @@ class CveHelper:
             raise NotFound
 
     @staticmethod
-    def _format_cve_response(cve_list, cve_details, usn_details):
+    def _format_cve_response(cve_list, cve_details, usn_details, status):
         cves = []
 
         for cve_id, cve in cve_list.items():
@@ -61,6 +61,7 @@ class CveHelper:
             cves.append(
                 {
                     "id": cve_id,
+                    "status": status,
                     "cvss_score": cve_detail["cvss_score"],
                     "cvss_severity": cve_detail["cvss_severity"],
                     "description": cve_detail["description"],
@@ -98,10 +99,10 @@ class CveHelper:
                 usn_details = content["security_issues"]["usns"]
 
                 unfixed = CveHelper._format_cve_response(
-                    unfixed_cves, cve_details, usn_details
+                    unfixed_cves, cve_details, usn_details, "unfixed"
                 )
                 fixed = CveHelper._format_cve_response(
-                    fixed_cves, cve_details, usn_details
+                    fixed_cves, cve_details, usn_details, "fixed"
                 )
 
                 return fixed + unfixed


### PR DESCRIPTION
## Done

Exposes CVE status as part of API, to avoid digging this information out of more nested data.

## How to QA

- Code review
- Check if updated python tests pass on CI.

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

