### PR TITLE
WD-21811 - snap icon causes Internal Server Error

### DIFF
--- a/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/AdditionalInformation.test.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/AdditionalInformation.test.tsx
@@ -3,28 +3,33 @@ import "@testing-library/jest-dom";
 
 import { mockListingData } from "../../../../test-utils";
 import AdditionalInformation from "../AdditionalInformation";
+import { FieldValues, useForm } from "react-hook-form";
+import { getDefaultListingData } from "../../../../utils";
 
-const useFormMocks = {
-  register: jest.fn(),
-  getValues: jest.fn(),
-  setValue: jest.fn(),
-  watch: jest.fn(),
-};
+function TestAdditionalInformation() {
+  const { register, setValue, watch, getValues } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  return (
+    <form>
+      <AdditionalInformation
+        data={mockListingData}
+        register={register}
+        getValues={getValues}
+        setValue={setValue}
+        watch={watch}
+      />
+    </form>
+  );
+}
 
 function renderComponent() {
   window.SNAP_LISTING_DATA = {
     DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
   };
 
-  return render(
-    <AdditionalInformation
-      data={mockListingData}
-      register={useFormMocks.register}
-      getValues={useFormMocks.getValues}
-      setValue={useFormMocks.setValue}
-      watch={useFormMocks.watch}
-    />,
-  );
+  return render(<TestAdditionalInformation />);
 }
 
 afterEach(() => {
@@ -40,7 +45,6 @@ describe("AdditionalInformation", () => {
 
   test("Fields displayed and registered with useForm", () => {
     renderComponent();
-    expect(useFormMocks.register).toHaveBeenCalledTimes(3);
     expect(
       screen.getByLabelText("Display public popularity charts"),
     ).toBeVisible();
@@ -48,19 +52,16 @@ describe("AdditionalInformation", () => {
     expect(screen.getByLabelText("Linux distributions")).toBeVisible();
   });
 
-  test("if public metrics is disabled all other fields are disabled", () => {
-    useFormMocks.getValues.mockImplementation((valueKey: string) =>
-      valueKey === "public_metrics_enabled" ? false : true,
-    );
+  test("if public metrics is unchecked all other fields are disabled", () => {
     renderComponent();
     expect(
-      screen.getByRole("checkbox", { name: "public-metrics-checkbox" }),
-    ).toBeDisabled();
+      screen.getByRole("checkbox", {
+        name: "Display public popularity charts",
+      }),
+    ).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "World map" })).toBeDisabled();
     expect(
-      screen.getByRole("checkbox", { name: "world-map-checkbox" }),
-    ).toBeDisabled();
-    expect(
-      screen.getByRole("checkbox", { name: "linux-distributions-checkbox" }),
+      screen.getByRole("checkbox", { name: "Linux distributions" }),
     ).toBeDisabled();
   });
 });

--- a/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/AdditionalInformation.test.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/AdditionalInformation.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { mockListingData } from "../../../../test-utils";
+import AdditionalInformation from "../AdditionalInformation";
+
+const useFormMocks = {
+  register: jest.fn(),
+  getValues: jest.fn(),
+  setValue: jest.fn(),
+  watch: jest.fn(),
+};
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  return render(
+    <AdditionalInformation
+      data={mockListingData}
+      register={useFormMocks.register}
+      getValues={useFormMocks.getValues}
+      setValue={useFormMocks.setValue}
+      watch={useFormMocks.watch}
+    />,
+  );
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AdditionalInformation", () => {
+  test("LicenseInputs is rendered", () => {
+    renderComponent();
+    expect(screen.getByText("License:")).toBeVisible();
+    expect(screen.getByLabelText("Simple")).toBeVisible();
+  });
+
+  test("Fields displayed and registered with useForm", () => {
+    renderComponent();
+    expect(useFormMocks.register).toHaveBeenCalledTimes(3);
+    expect(
+      screen.getByLabelText("Display public popularity charts"),
+    ).toBeVisible();
+    expect(screen.getByLabelText("World map")).toBeVisible();
+    expect(screen.getByLabelText("Linux distributions")).toBeVisible();
+  });
+
+  test("if public metrics is disabled all other fields are disabled", () => {
+    useFormMocks.getValues.mockImplementation((valueKey: string) =>
+      valueKey === "public_metrics_enabled" ? false : true,
+    );
+    renderComponent();
+    expect(
+      screen.getByRole("checkbox", { name: "public-metrics-checkbox" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("checkbox", { name: "world-map-checkbox" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("checkbox", { name: "linux-distributions-checkbox" }),
+    ).toBeDisabled();
+  });
+});

--- a/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/LicenseInputs.test.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/LicenseInputs.test.tsx
@@ -5,29 +5,34 @@ import "@testing-library/jest-dom";
 import { mockListingData } from "../../../../test-utils";
 import LicenseInputs from "../LicenseInputs";
 import LicenseSearch from "../LicenseSearch";
-
-const useFormMocks = {
-  register: jest.fn(),
-  getValues: jest.fn(),
-  setValue: jest.fn(),
-  watch: jest.fn(),
-};
+import { FieldValues, useForm } from "react-hook-form";
+import { getDefaultListingData } from "../../../../utils";
 
 jest.mock("../LicenseSearch");
+
+function TestLicenseInputs() {
+  const { register, setValue, watch } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  return (
+    <form>
+      <LicenseInputs
+        listingData={mockListingData}
+        register={register}
+        setValue={setValue}
+        watch={watch}
+      />
+    </form>
+  );
+}
 
 function renderComponent() {
   window.SNAP_LISTING_DATA = {
     DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
   };
 
-  return render(
-    <LicenseInputs
-      listingData={mockListingData}
-      register={useFormMocks.register}
-      setValue={useFormMocks.setValue}
-      watch={useFormMocks.watch}
-    />,
-  );
+  return render(<TestLicenseInputs />);
 }
 
 afterEach(() => {
@@ -38,7 +43,7 @@ describe("LicenseInputs", () => {
   test("if license is simple the search is displayed", () => {
     renderComponent();
     expect(screen.getByLabelText("Simple")).toBeChecked();
-    expect(screen.getByText("The license(s) under which")).toBeVisible();
+    expect(screen.getByText(/^The license\(s\) under which/)).toBeVisible();
     expect(LicenseSearch).toHaveBeenCalled();
   });
 

--- a/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/LicenseInputs.test.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/LicenseInputs.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { mockListingData } from "../../../../test-utils";
+import LicenseInputs from "../LicenseInputs";
+import LicenseSearch from "../LicenseSearch";
+
+const useFormMocks = {
+  register: jest.fn(),
+  getValues: jest.fn(),
+  setValue: jest.fn(),
+  watch: jest.fn(),
+};
+
+jest.mock("../LicenseSearch");
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  return render(
+    <LicenseInputs
+      listingData={mockListingData}
+      register={useFormMocks.register}
+      setValue={useFormMocks.setValue}
+      watch={useFormMocks.watch}
+    />,
+  );
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("LicenseInputs", () => {
+  test("if license is simple the search is displayed", () => {
+    renderComponent();
+    expect(screen.getByLabelText("Simple")).toBeChecked();
+    expect(screen.getByText("The license(s) under which")).toBeVisible();
+    expect(LicenseSearch).toHaveBeenCalled();
+  });
+
+  test("when switching license type to custom a textarea is displayed", async () => {
+    renderComponent();
+    const user = userEvent.setup();
+
+    expect(screen.getByLabelText("Simple")).toBeChecked();
+    await user.click(screen.getByLabelText("Custom SPDX expression"));
+    expect(
+      await screen.findByLabelText("Custom SPDX expression"),
+    ).toBeChecked();
+    expect(document.getElementsByTagName("textarea")).toHaveLength(1);
+  });
+});

--- a/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/LicenseSearch.test.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/LicenseSearch.test.tsx
@@ -1,0 +1,80 @@
+import { getByText, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { mockListingData } from "../../../../test-utils";
+import LicenseSearch from "../LicenseSearch";
+
+const mocks = {
+  register: jest.fn(),
+  setValue: jest.fn(),
+  setLicense: jest.fn(),
+};
+
+function renderComponent(license = mockListingData.license) {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  return render(
+    <LicenseSearch
+      licenses={mockListingData.licenses}
+      license={license}
+      register={mocks.register}
+      setValue={mocks.setValue}
+      setLicense={mocks.setLicense}
+      originalLicense={mockListingData.license}
+    />,
+  );
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("LicenseSearch", () => {
+  test("the search field displays the currently selected license", () => {
+    renderComponent();
+    expect(screen.getByText("testing-license")).toBeVisible();
+  });
+
+  test("click on search field opens list of licenses", async () => {
+    renderComponent();
+    const user = userEvent.setup();
+    await user.click(
+      document.getElementsByClassName("p-multiselect__input").item(0)!,
+    );
+
+    const suggestions = await waitFor(() => {
+      const suggestionsElem = document.getElementsByClassName("p-list");
+      expect(suggestionsElem).toBeVisible();
+      expect(suggestionsElem).toHaveLength(1);
+      return suggestionsElem[0] as HTMLUListElement;
+    });
+    expect(getByText(suggestions, "random-license")).toBeVisible();
+    // the current license should be filtered and not displayed in the dropdown
+    expect(getByText(suggestions, "testing-license")).not.toBeInTheDocument();
+  });
+
+  test("removing focus from search field closes the licenses list", async () => {
+    const { container } = renderComponent();
+    const user = userEvent.setup();
+    await user.click(
+      document.getElementsByClassName("p-multiselect__input").item(0)!,
+    );
+
+    expect(await screen.findByText("random-license")).toBeVisible();
+    user.click(container);
+    expect(await screen.findByText("random-license")).not.toBeVisible();
+  });
+
+  test("remove license from list", async () => {
+    renderComponent();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button"));
+
+    expect(await screen.findByText("testing-license")).not.toBeVisible();
+    expect(mocks.setLicense).toHaveBeenCalled();
+    expect(mocks.setValue).toHaveBeenCalled();
+  });
+});

--- a/static/js/publisher/pages/Listing/ContactInformation/ContactFields.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/ContactFields.tsx
@@ -58,6 +58,7 @@ function ContactFields({
           <Col size={5} emptyLarge={index === 0 ? undefined : 3}>
             <div className="p-form__control">
               <input
+                id={fieldName}
                 type="url"
                 {...register(`${fieldName}.${index}.url`)}
                 defaultValue={getValues(`${fieldName}.${index}.url`)}

--- a/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactFields.test.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactFields.test.tsx
@@ -1,0 +1,112 @@
+import { Control, FieldValues } from "react-hook-form";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ContactFields from "../ContactFields";
+import userEvent from "@testing-library/user-event";
+
+const propsMocks = {
+  register: jest.fn(),
+  control: {} as Control<FieldValues>,
+  getValues: jest.fn(),
+};
+
+const useFieldArrayMock = jest.fn();
+
+jest.mock("react-hook-form", () => ({
+  ...jest.requireActual("react-hook-form"),
+  useFieldArray: useFieldArrayMock,
+}));
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  return render(
+    <ContactFields
+      register={propsMocks.register}
+      control={propsMocks.control}
+      labelName={"Test"}
+      fieldName={"test"}
+      getValues={propsMocks.getValues}
+    />,
+  );
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ContactFields", () => {
+  test("when no data, add field is displayed", () => {
+    const useFieldArrayResult = {
+      fields: [],
+      append: jest.fn(),
+      remove: jest.fn(),
+    };
+    useFieldArrayMock.mockReturnValue(useFieldArrayResult);
+    renderComponent();
+
+    expect(screen.getByRole("button", { name: "Add field" })).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Remove this link" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("data displayed and add field at the bottom", () => {
+    const exampleUrl = "https://example.com/contact";
+    const useFieldArrayResult = {
+      fields: [{ url: exampleUrl }],
+      append: jest.fn(),
+      remove: jest.fn(),
+    };
+    useFieldArrayMock.mockReturnValue(useFieldArrayResult);
+    propsMocks.getValues.mockReturnValue(exampleUrl);
+    renderComponent();
+
+    const fieldElement = screen.getByDisplayValue(exampleUrl);
+    const addFieldElement = screen.getByRole("button", { name: "Add field" });
+    expect(fieldElement).toBeVisible();
+    expect(addFieldElement).toBeVisible();
+    expect(fieldElement.compareDocumentPosition(addFieldElement)).toEqual(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  test("data can be removed", async () => {
+    const exampleUrl = "https://example.com/contact";
+    const useFieldArrayResult = {
+      fields: [{ url: exampleUrl }],
+      append: jest.fn(),
+      remove: jest.fn(),
+    };
+    useFieldArrayMock.mockReturnValue(useFieldArrayResult);
+    propsMocks.getValues.mockReturnValue(exampleUrl);
+    const user = userEvent.setup();
+    renderComponent();
+
+    const deleteButton = screen.getByRole("button", {
+      name: "Remove this link",
+    });
+    expect(deleteButton).toBeVisible();
+
+    await user.click(deleteButton);
+    await waitFor(() => expect(useFieldArrayResult.remove).toHaveBeenCalled());
+  });
+
+  test("data can be added", async () => {
+    const useFieldArrayResult = {
+      fields: [],
+      append: jest.fn(),
+      remove: jest.fn(),
+    };
+    useFieldArrayMock.mockReturnValue(useFieldArrayResult);
+    const user = userEvent.setup();
+    renderComponent();
+
+    const addButton = screen.getByRole("button", { name: "Add field" });
+    await user.click(addButton);
+    await waitFor(() => expect(useFieldArrayResult.append).toHaveBeenCalled());
+  });
+});

--- a/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactInformation.test.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactInformation.test.tsx
@@ -1,41 +1,50 @@
-import { Control, FieldValues } from "react-hook-form";
+import { FieldValues, useForm } from "react-hook-form";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import ContactInformation from "../ContactInformation";
 import { mockListingData } from "../../../../test-utils";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { getDefaultListingData } from "../../../../utils";
 
-const mocks = {
-  register: jest.fn(),
-  control: {} as Control<FieldValues>,
-  getFieldState: jest.fn(),
-  getValues: jest.fn(),
-};
+function TestContactInformation() {
+  const { register, control, getFieldState, getValues } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  const queryClient = new QueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <form>
+        <ContactInformation
+          data={mockListingData}
+          register={register}
+          control={control}
+          getFieldState={getFieldState}
+          getValues={getValues}
+        />
+      </form>
+    </QueryClientProvider>
+  );
+}
 
 function renderComponent() {
   window.SNAP_LISTING_DATA = {
     DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
   };
 
-  return render(
-    <ContactInformation
-      data={mockListingData}
-      register={mocks.register}
-      control={mocks.control}
-      getFieldState={mocks.getFieldState}
-      getValues={mocks.getValues}
-    />,
-  );
+  return render(<TestContactInformation />);
 }
 
 describe("ContactInformation", () => {
   test("all fields are displayed", () => {
     renderComponent();
-    expect(screen.getByLabelText("Primary website:")).toBeVisible();
-    expect(screen.getByLabelText("Other websites")).toBeVisible();
-    expect(screen.getByLabelText("Contacts")).toBeVisible();
-    expect(screen.getByLabelText("Donations")).toBeVisible();
-    expect(screen.getByLabelText("Source code")).toBeVisible();
-    expect(screen.getByLabelText("Issues")).toBeVisible();
+    expect(screen.getByLabelText(/^Primary website/)).toBeVisible();
+    expect(screen.getByLabelText(/^Other websites/)).toBeVisible();
+    expect(screen.getByLabelText(/^Contacts/)).toBeVisible();
+    expect(screen.getByLabelText(/^Donations/)).toBeVisible();
+    expect(screen.getByLabelText(/^Source code/)).toBeVisible();
+    expect(screen.getByLabelText(/^Issues/)).toBeVisible();
   });
 });

--- a/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactInformation.test.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/__tests__/ContactInformation.test.tsx
@@ -1,0 +1,41 @@
+import { Control, FieldValues } from "react-hook-form";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import ContactInformation from "../ContactInformation";
+import { mockListingData } from "../../../../test-utils";
+
+const mocks = {
+  register: jest.fn(),
+  control: {} as Control<FieldValues>,
+  getFieldState: jest.fn(),
+  getValues: jest.fn(),
+};
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  return render(
+    <ContactInformation
+      data={mockListingData}
+      register={mocks.register}
+      control={mocks.control}
+      getFieldState={mocks.getFieldState}
+      getValues={mocks.getValues}
+    />,
+  );
+}
+
+describe("ContactInformation", () => {
+  test("all fields are displayed", () => {
+    renderComponent();
+    expect(screen.getByLabelText("Primary website:")).toBeVisible();
+    expect(screen.getByLabelText("Other websites")).toBeVisible();
+    expect(screen.getByLabelText("Contacts")).toBeVisible();
+    expect(screen.getByLabelText("Donations")).toBeVisible();
+    expect(screen.getByLabelText("Source code")).toBeVisible();
+    expect(screen.getByLabelText("Issues")).toBeVisible();
+  });
+});

--- a/static/js/publisher/pages/Listing/ListingDetails/ListingDetails.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/ListingDetails.tsx
@@ -241,7 +241,7 @@ function ListingDetails({
 
       <Row className="p-form__group" data-tour="listing-summary">
         <Col size={2}>
-          <label htmlFor="video_urls">Summary:</label>
+          <label htmlFor="summary">Summary:</label>
         </Col>
         <Col size={8}>
           <div className="p-form__control">
@@ -257,7 +257,7 @@ function ListingDetails({
 
       <Row className="p-form__group" data-tour="listing-description">
         <Col size={2}>
-          <label htmlFor="video_urls">Description:</label>
+          <label htmlFor="description">Description:</label>
         </Col>
         <Col size={8}>
           <div className="p-form__control">

--- a/static/js/publisher/pages/Listing/ListingDetails/__tests__/ImageUpload.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/__tests__/ImageUpload.test.tsx
@@ -1,0 +1,93 @@
+import { FieldValues, useForm } from "react-hook-form";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import ListingDetails from "../ListingDetails";
+import { mockListingData } from "../../../../test-utils";
+import { getDefaultListingData } from "../../../../utils";
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  const { register, getValues, setValue, control } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  return render(
+    <ListingDetails
+      data={mockListingData}
+      register={register}
+      getValues={getValues}
+      setValue={setValue}
+      control={control}
+    />,
+  );
+}
+
+describe("ImageUpload", () => {
+  test("icon is displayed on page", () => {
+    renderComponent();
+
+    waitFor(() => {
+      expect(screen.getByAltText("test_id icon")).toBeInTheDocument();
+    });
+  });
+
+  test("icon can be removed", () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    waitFor(async () => {
+      await user.click(screen.getByRole("button", { name: "Remove icon" }));
+      expect(screen.queryByAltText("test_id icon")).not.toBeInTheDocument();
+    });
+  });
+
+  test("icon image restrictions toggle works", () => {
+    const user = userEvent.setup();
+
+    renderComponent();
+
+    waitFor(async () => {
+      await user.click(
+        screen.getByRole("button", {
+          name: "Show image restrictions for icon",
+        }),
+      );
+
+      expect(
+        screen.queryByRole("button", {
+          name: "Show image restrictions for icon",
+        }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", {
+          name: "Hide image restrictions for icon",
+        }),
+      ).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Hide image restrictions for icon",
+        }),
+      );
+
+      expect(
+        screen.queryByRole("button", {
+          name: "Hide image restrictions for icon",
+        }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", {
+          name: "Show image restrictions for icon",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/static/js/publisher/pages/Listing/ListingDetails/__tests__/ImageUpload.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/__tests__/ImageUpload.test.tsx
@@ -7,24 +7,30 @@ import ListingDetails from "../ListingDetails";
 import { mockListingData } from "../../../../test-utils";
 import { getDefaultListingData } from "../../../../utils";
 
+function TestImageUpload() {
+  const { register, getValues, setValue, control } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  return (
+    <form>
+      <ListingDetails
+        data={mockListingData}
+        register={register}
+        getValues={getValues}
+        setValue={setValue}
+        control={control}
+      />
+    </form>
+  );
+}
+
 function renderComponent() {
   window.SNAP_LISTING_DATA = {
     DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
   };
 
-  const { register, getValues, setValue, control } = useForm<FieldValues>({
-    defaultValues: getDefaultListingData(mockListingData),
-  });
-
-  return render(
-    <ListingDetails
-      data={mockListingData}
-      register={register}
-      getValues={getValues}
-      setValue={setValue}
-      control={control}
-    />,
-  );
+  return render(<TestImageUpload />);
 }
 
 describe("ImageUpload", () => {

--- a/static/js/publisher/pages/Listing/ListingDetails/__tests__/ListingDetails.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/__tests__/ListingDetails.test.tsx
@@ -7,24 +7,30 @@ import ListingDetails from "../ListingDetails";
 import { mockListingData } from "../../../../test-utils";
 import { getDefaultListingData } from "../../../../utils";
 
+function TestListingDetails() {
+  const { register, getValues, setValue, control } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  return (
+    <form>
+      <ListingDetails
+        data={mockListingData}
+        register={register}
+        getValues={getValues}
+        setValue={setValue}
+        control={control}
+      />
+    </form>
+  );
+}
+
 function renderComponent() {
   window.SNAP_LISTING_DATA = {
     DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
   };
 
-  const { register, getValues, setValue, control } = useForm<FieldValues>({
-    defaultValues: getDefaultListingData(mockListingData),
-  });
-
-  return render(
-    <ListingDetails
-      data={mockListingData}
-      register={register}
-      getValues={getValues}
-      setValue={setValue}
-      control={control}
-    />,
-  );
+  return render(<TestListingDetails />);
 }
 
 describe("ListingDetails", () => {

--- a/static/js/publisher/pages/Listing/ListingDetails/__tests__/ListingDetails.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/__tests__/ListingDetails.test.tsx
@@ -1,0 +1,58 @@
+import { FieldValues, useForm } from "react-hook-form";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import ListingDetails from "../ListingDetails";
+import { mockListingData } from "../../../../test-utils";
+import { getDefaultListingData } from "../../../../utils";
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+
+  const { register, getValues, setValue, control } = useForm<FieldValues>({
+    defaultValues: getDefaultListingData(mockListingData),
+  });
+
+  return render(
+    <ListingDetails
+      data={mockListingData}
+      register={register}
+      getValues={getValues}
+      setValue={setValue}
+      control={control}
+    />,
+  );
+}
+
+describe("ListingDetails", () => {
+  test("secondary category renders correct data", () => {
+    renderComponent();
+
+    waitFor(() => {
+      expect(screen.getByLabelText("Secondary category:")).toHaveValue(
+        mockListingData.secondary_category,
+      );
+    });
+  });
+
+  test("secondary category can be removed", () => {
+    renderComponent();
+
+    waitFor(async () => {
+      const user = userEvent.setup();
+
+      renderComponent();
+
+      await user.click(
+        screen.getByRole("button", { name: "Remove secondary category" }),
+      );
+
+      expect(
+        screen.queryByLabelText("Secondary category:"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/js/publisher/pages/Listing/ListingForm/ListingForm.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/ListingForm.tsx
@@ -177,14 +177,7 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
           />
         </Strip>
       </form>
-      {snapId && (
-        <PreviewForm
-          snapName={snapId}
-          getValues={getValues}
-          watch={watch}
-          data={data}
-        />
-      )}
+      {snapId && <PreviewForm snapName={snapId} watch={watch} data={data} />}
     </>
   );
 }

--- a/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider, useMutation } from "react-query";
+import { BrowserRouter } from "react-router-dom";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import ListingForm from "../ListingForm";
+import { mockListingData } from "../../../../test-utils";
+import { shouldShowUpdateMetadataWarning } from "../../../../utils";
+import { useMutateListingData } from "../../../../hooks";
+
+jest.mock("react-router-dom", () => {
+  return {
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+      snapId: "test_id",
+    }),
+  };
+});
+
+jest.mock("../../../../utils");
+jest.mock("../../../../hooks");
+
+function renderComponent(updateMetadataOnRelease = false) {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+  const data = {
+    ...mockListingData,
+    update_metadata_on_release: updateMetadataOnRelease,
+  };
+  const queryClient = new QueryClient();
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <ListingForm data={data} refetch={jest.fn()} />
+      </BrowserRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  server.use(
+    http.post("/api/test_id/listing", () => {
+      return HttpResponse.json({ success: true }, { status: 200 });
+    }),
+  );
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("ListingForm", () => {
+  test("Tour is rendered", () => {
+    renderComponent();
+    expect(screen.getByRole("button", { name: "Start tour" })).toBeVisible();
+  });
+
+  test("notification displayed when update_metadata_on_release", () => {
+    renderComponent(true);
+    expect(
+      screen.getByText("Information here was automatically"),
+    ).toBeVisible();
+    expect(screen.getByRole("link", { name: "Learn more" })).toBeVisible();
+  });
+
+  test("warning modal displayed on save when update_metadata_on_release", async () => {
+    (shouldShowUpdateMetadataWarning as jest.Mock).mockReturnValue(true);
+    const mutate = jest.fn();
+    (useMutateListingData as jest.Mock).mockReturnValue({
+      mutate: mutate,
+      isLoading: false,
+    });
+    renderComponent(true);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.findByRole("modal")).toBeVisible();
+    expect(screen.findByRole("heading", { name: "Warning" })).toBeVisible();
+    expect(screen.findByText("Making these changes means")).toBeVisible();
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  test("warning modal submits form data on save", async () => {
+    (shouldShowUpdateMetadataWarning as jest.Mock).mockReturnValue(true);
+    const mutate = jest.fn();
+    (useMutateListingData as jest.Mock).mockReturnValue({
+      mutate: mutate,
+      isLoading: false,
+    });
+    renderComponent(true);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await screen.findByRole("button", { name: "Save changes" });
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(
+      screen.findByRole("heading", { name: "Warning" }),
+    ).not.toBeInTheDocument();
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  test("show success notification on save", async () => {
+    (shouldShowUpdateMetadataWarning as jest.Mock).mockReturnValue(false);
+    const mockUseMutateListingData =
+      useMutateListingData as jest.MockedFunction<typeof useMutateListingData>;
+    mockUseMutateListingData.mockImplementation((options) => {
+      options.setShowSuccessNotification(true);
+      return useMutation({});
+    });
+    renderComponent();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(screen.findByText("Changes applied successfully")).toBeVisible();
+  });
+
+  test("ListingDetails is rendered", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("heading", { name: "Listing details" }),
+    ).toBeVisible();
+  });
+
+  test("ContactInformation is rendered", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("heading", { name: "Contact information" }),
+    ).toBeVisible();
+  });
+
+  test("AdditionalInformation is rendered", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("heading", { name: "Additional information" }),
+    ).toBeVisible();
+  });
+
+  test("PreviewForm is rendered", () => {
+    renderComponent();
+    expect(document.getElementById("preview-form")).toBeVisible();
+  });
+});

--- a/static/js/publisher/pages/Listing/PreviewForm/PreviewForm.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/PreviewForm.tsx
@@ -1,9 +1,8 @@
-import { UseFormGetValues, FieldValues, UseFormWatch } from "react-hook-form";
+import { FieldValues, UseFormWatch } from "react-hook-form";
 import { Form } from "@canonical/react-components";
 
 type Props = {
   snapName: string;
-  getValues: UseFormGetValues<FieldValues>;
   watch: UseFormWatch<FieldValues>;
   data: {
     categories: { name: string; slug: string }[];
@@ -32,12 +31,23 @@ type ListingData = {
   license: string;
 };
 
-function PreviewForm({ snapName, getValues, watch, data }: Props) {
+function PreviewForm({ snapName, watch, data }: Props) {
   const watchWebsites = watch("websites");
   const watchContacts = watch("contacts");
   const watchDonations = watch("donations");
   const watchSource = watch("source_code");
   const watchIssues = watch("issues");
+  const watchTitle = watch("title");
+  const watchBannerUrls = watch("banner_urls");
+  const watchIconUrl = watch("icon_url");
+  const watchSummary = watch("summary");
+  const watchDescription = watch("description");
+  const watchScreenshotUrls = watch("screenshot_urls");
+  const watchPrimaryCategory = watch("primary_category");
+  const watchSecondaryCategory = watch("secondary_category");
+  const watchVideoUrls = watch("video_urls");
+  const watchLicense = watch("license");
+  const watchPrimaryWebsite = watch("primary_website");
 
   const listingData: ListingData = {
     categories: [],
@@ -59,26 +69,26 @@ function PreviewForm({ snapName, getValues, watch, data }: Props) {
         : [],
     },
     snap_name: snapName,
-    title: getValues("title"),
+    title: watchTitle,
     images: [
       {
-        url: getValues("banner_url"),
+        url: watchBannerUrls ? watchBannerUrls : null,
         type: "banner",
         status: "uploaded",
       },
       {
-        url: getValues("icon_url"),
+        url: watchIconUrl,
         type: "icon",
         status: "uploaded",
       },
     ],
-    summary: getValues("summary"),
-    description: getValues("description"),
+    summary: watchSummary,
+    description: watchDescription,
     video: null,
     license: "",
   };
 
-  const screenshotUrls = getValues("screenshot_urls");
+  const screenshotUrls = watchScreenshotUrls;
 
   if (screenshotUrls.length) {
     screenshotUrls.forEach((screenshotUrl: string) => {
@@ -90,8 +100,8 @@ function PreviewForm({ snapName, getValues, watch, data }: Props) {
     });
   }
 
-  const primaryCategory = getValues("primary_category");
-  const secondaryCategory = getValues("secondary_category");
+  const primaryCategory = watchPrimaryCategory;
+  const secondaryCategory = watchSecondaryCategory;
 
   if (primaryCategory) {
     const primaryCategoryData = data.categories.find(
@@ -113,16 +123,17 @@ function PreviewForm({ snapName, getValues, watch, data }: Props) {
     }
   }
 
-  const videoUrl = getValues("video_urls");
+  const videoUrl = watchVideoUrls;
 
   if (videoUrl) {
     listingData.video = [{ type: "video", status: "uploaded", url: videoUrl }];
   }
 
-  listingData.license = getValues("license");
+  listingData.license = watchLicense;
 
-  if (getValues("primary_website")) {
-    listingData.links.website.unshift(getValues("primary_website"));
+  const primaryWebsite = watchPrimaryWebsite;
+  if (primaryWebsite) {
+    listingData.links.website.unshift(primaryWebsite);
   }
 
   return (

--- a/static/js/publisher/pages/Listing/PreviewForm/PreviewForm.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/PreviewForm.tsx
@@ -150,6 +150,7 @@ function PreviewForm({ snapName, watch, data }: Props) {
       <input
         type="hidden"
         name="state"
+        data-testid="state-input"
         defaultValue={JSON.stringify(listingData)}
       />
     </Form>

--- a/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
@@ -64,31 +64,71 @@ afterAll(() => {
   server.close();
 });
 
-const expectedListingData = {};
+const expectedListingData = {
+  categories: [
+    { name: "Test select", slug: "test-select" },
+    { name: "Test select secondary", slug: "test-select-secondary" },
+  ],
+  links: {
+    website: ["https://www.modified.com", "https://example.com"],
+    contact: ["https://example.com/contact"],
+    donations: ["https://example.com/donate"],
+    source: ["https://example.com/code"],
+    issues: ["https://example.com/issues"],
+  },
+  snap_name: "test_id",
+  title: "title modified",
+  images: [
+    {
+      url: ["https://example.com/screenshot"],
+      type: "banner",
+      status: "uploaded",
+    },
+    { url: "", type: "icon", status: "uploaded" },
+    {
+      url: "https://example.com/screenshot",
+      type: "screenshot",
+      status: "uploaded",
+    },
+  ],
+  summary: "summary modified",
+  description: "description modified",
+  video: [
+    { type: "video", status: "uploaded", url: "https://example.com/video" },
+  ],
+  license: "testing-license",
+};
 
-describe("PreviewForm", async () => {
+describe("PreviewForm", () => {
   test("PreviewForm status matches ListingForm data", async () => {
     const user = userEvent.setup();
     renderComponent();
-    const stateInput = screen.getByTestId("state-input") as HTMLInputElement;
+    const stateInput = (await screen.findByTestId(
+      "state-input",
+    )) as HTMLInputElement;
 
-    const title = screen.getByLabelText("Title");
-    const summary = screen.getByLabelText("Summary");
-    const description = screen.getByLabelText("Description");
-    const category = screen.getByLabelText("Category");
-    const secondaryCategory = screen.getByLabelText("Secondary category");
-    const primaryWebsite = screen.getByLabelText("Primary website");
+    const title = screen.getByLabelText(/Title/);
+    const summary = screen.getByLabelText(/Summary/); //todo check
+    const description = screen.getByLabelText(/Description/); //todo check
+    const category = screen.getByLabelText(/Category/);
+    const secondaryCategory = screen.getByLabelText(/Secondary category/);
+    const primaryWebsite = screen.getByLabelText(/Primary website/);
     const iconDeleteButton = screen.getByRole("button", {
       name: "Remove icon",
     });
 
     // change all the properties
+    await user.clear(title);
     await user.type(title, "title modified");
+    await user.clear(summary);
     await user.type(summary, "summary modified");
+    await user.clear(description);
     await user.type(description, "description modified");
+    await user.clear(primaryWebsite);
+    await user.type(primaryWebsite, "https://www.modified.com");
+
     await user.selectOptions(category, "test-select");
     await user.selectOptions(secondaryCategory, "test-select-secondary");
-    await user.type(primaryWebsite, "https://www.modified.com");
     await user.click(iconDeleteButton);
 
     expect(stateInput.value).toEqual(JSON.stringify(expectedListingData));

--- a/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
@@ -108,8 +108,8 @@ describe("PreviewForm", () => {
     )) as HTMLInputElement;
 
     const title = screen.getByLabelText(/Title/);
-    const summary = screen.getByLabelText(/Summary/); //todo check
-    const description = screen.getByLabelText(/Description/); //todo check
+    const summary = screen.getByLabelText(/Summary/);
+    const description = screen.getByLabelText(/Description/);
     const category = screen.getByLabelText(/Category/);
     const secondaryCategory = screen.getByLabelText(/Secondary category/);
     const primaryWebsite = screen.getByLabelText(/Primary website/);
@@ -132,5 +132,5 @@ describe("PreviewForm", () => {
     await user.click(iconDeleteButton);
 
     expect(stateInput.value).toEqual(JSON.stringify(expectedListingData));
-  });
+  }, 10000);
 });

--- a/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "react-query";
+import { BrowserRouter } from "react-router-dom";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import Listing from "../../Listing";
+import { mockListingData } from "../../../../test-utils";
+
+jest.mock("react-router-dom", () => {
+  return {
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+      snapId: "test_id",
+    }),
+  };
+});
+
+const testListingData = {
+  message: "",
+  success: true,
+  data: mockListingData,
+};
+
+function renderComponent() {
+  window.SNAP_LISTING_DATA = {
+    DNS_VERIFICATION_TOKEN: "test-dns-verification-token",
+  };
+  const queryClient = new QueryClient();
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Listing />
+      </BrowserRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  server.use(
+    http.get("/api/test_id/listing", () => {
+      return HttpResponse.json(testListingData);
+    }),
+    http.post("/api/test_id/listing", () => {
+      return HttpResponse.json({ success: true }, { status: 200 });
+    }),
+  );
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+const expectedListingData = {};
+
+describe("PreviewForm", async () => {
+  test("PreviewForm status matches ListingForm data", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    const stateInput = screen.getByTestId("state-input") as HTMLInputElement;
+
+    const title = screen.getByLabelText("Title");
+    const summary = screen.getByLabelText("Summary");
+    const description = screen.getByLabelText("Description");
+    const category = screen.getByLabelText("Category");
+    const secondaryCategory = screen.getByLabelText("Secondary category");
+    const primaryWebsite = screen.getByLabelText("Primary website");
+    const iconDeleteButton = screen.getByRole("button", {
+      name: "Remove icon",
+    });
+
+    // change all the properties
+    await user.type(title, "title modified");
+    await user.type(summary, "summary modified");
+    await user.type(description, "description modified");
+    await user.selectOptions(category, "test-select");
+    await user.selectOptions(secondaryCategory, "test-select-secondary");
+    await user.type(primaryWebsite, "https://www.modified.com");
+    await user.click(iconDeleteButton);
+
+    expect(stateInput.value).toEqual(JSON.stringify(expectedListingData));
+  });
+});

--- a/static/js/publisher/pages/Listing/__tests__/Listing.test.tsx
+++ b/static/js/publisher/pages/Listing/__tests__/Listing.test.tsx
@@ -1,61 +1,24 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter } from "react-router-dom";
-import { http, HttpResponse } from "msw";
+import { delay, http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import Listing from "../Listing";
+import { mockListingData } from "../../../test-utils/mockListingData";
 
 const testListingData = {
   message: "",
   success: true,
-  data: {
-    banner_urls: [],
-    categories: [
-      { name: "Art and design", slug: "art-and-design" },
-      { name: "Books and Reference", slug: "books-and-reference" },
-      { name: "Development", slug: "development" },
-      { name: "Devices and IoT", slug: "devices-and-iot" },
-      { name: "Education", slug: "education" },
-    ],
-    contacts: [
-      { url: "https://example.com/contact" },
-      { url: "mailto:john.doe@example.com" },
-    ],
-    description: "Test snap description",
-    donations: [{ url: "https://example.com/donations" }],
-    icon_url: "https://placehold.co/512x512",
-    issues: [{ url: "https://example.com/issues" }],
-    license: "ANTLR-PD-fallback",
-    license_type: "simple",
-    licenses: [
-      { key: "AFL-2.0", name: "Academic Free License v2.0" },
-      { key: "AAL", name: "Attribution Assurance License" },
-      {
-        key: "ANTLR-PD-fallback",
-        name: "ANTLR Software Rights Notice with license fallback",
-      },
-    ],
-    primary_category: "art-and-design",
-    primary_website: "https://example.com",
-    public_metrics_blacklist: ["installed_base_by_country_percent"],
-    public_metrics_enabled: true,
-    screenshot_urls: [],
-    secondary_category: "books-and-reference",
-    snap_id: "test-snap-id",
-    source_code: [{ url: "https://example.com/source-code" }],
-    summary: "Test snap summary",
-    title: "Test snap title",
-  },
+  data: mockListingData,
 };
 
 jest.mock("react-router-dom", () => {
   return {
     ...jest.requireActual("react-router-dom"),
     useParams: () => ({
-      snapId: "test-snap-id",
+      snapId: "test_id",
     }),
   };
 });
@@ -84,7 +47,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   server.use(
-    http.get("/api/test-snap-id/listing", () => {
+    http.get("/api/test_id/listing", () => {
       return HttpResponse.json(testListingData);
     }),
   );
@@ -99,193 +62,59 @@ afterAll(() => {
 });
 
 describe("Listing", () => {
-  test("revert button disabled by default", () => {
+  test("page title is set", async () => {
     renderComponent();
-
-    waitFor(() => {
-      expect(screen.getByRole("button", { name: "Revert" })).toHaveAttribute(
-        "aria-disabled",
-        "true",
-      );
+    await waitFor(() => {
+      expect(document.title).toEqual("Listing data for test_id");
     });
   });
 
-  test("revert button enabled if changes made", () => {
-    const user = userEvent.setup();
-
+  test("heading is displayed", async () => {
     renderComponent();
-
-    waitFor(() => {
-      user.type(screen.getByLabelText("Title:"), "edit");
-      expect(
-        screen.getByRole("button", { name: "Revert" }),
-      ).not.toHaveAttribute("aria-disabled", "true");
-    });
+    expect(
+      await screen.findByRole("link", { name: "My snaps" }),
+    ).toHaveProperty("href", "/snaps");
+    expect(screen.findByRole("link", { name: "test_id" })).toHaveProperty(
+      "href",
+      "/test_id",
+    );
+    expect(await screen.findByText("Listing")).toBeInstanceOf(
+      HTMLHeadingElement,
+    );
   });
 
-  test("save button disabled by default", () => {
+  test("ListingForm and PreviewForm are rendered", async () => {
+    renderComponent();
+    expect(await screen.findAllByRole("form")).toHaveLength(2);
+  });
+
+  test("isLoading is displayed while loading data", async () => {
+    server.resetHandlers();
     server.use(
-      http.get("/api/test-snap-id/listing", () => {
+      http.get("/api/test_id/listing", async () => {
+        await delay(500);
         return HttpResponse.json(testListingData);
       }),
     );
 
+    const loadingText = "Loading test_id listing data";
     renderComponent();
-
-    waitFor(() => {
-      expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
-        "aria-disabled",
-        "true",
-      );
-    });
+    expect(screen.getByText(loadingText)).toBeVisible();
+    // findByText uses waitFor under the hood
+    await screen.findByText("Listing details");
+    expect(screen.getByText(loadingText)).not.toBeInTheDocument();
   });
 
-  test("save button enabled if changes made", () => {
-    const user = userEvent.setup();
-
-    renderComponent();
-
-    waitFor(() => {
-      user.type(screen.getByLabelText("Title:"), "edit");
-      expect(screen.getByRole("button", { name: "Save" })).not.toHaveAttribute(
-        "aria-disabled",
-        "true",
-      );
-    });
-  });
-
-  test("icon is displayed on page", () => {
-    renderComponent();
-
-    waitFor(() => {
-      expect(screen.getByAltText("test-snap-id icon")).toBeInTheDocument();
-    });
-  });
-
-  test("icon can be removed", () => {
-    const user = userEvent.setup();
-
-    renderComponent();
-
-    waitFor(async () => {
-      await user.click(screen.getByRole("button", { name: "Remove icon" }));
-      expect(
-        screen.queryByAltText("test-snap-id icon"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  test("icon image restrictions toggle works", () => {
-    const user = userEvent.setup();
-
-    renderComponent();
-
-    waitFor(async () => {
-      await user.click(
-        screen.getByRole("button", {
-          name: "Show image restrictions for icon",
-        }),
-      );
-
-      expect(
-        screen.queryByRole("button", {
-          name: "Show image restrictions for icon",
-        }),
-      ).not.toBeInTheDocument();
-
-      expect(
-        screen.getByRole("button", {
-          name: "Hide image restrictions for icon",
-        }),
-      ).toBeInTheDocument();
-
-      await user.click(
-        screen.getByRole("button", {
-          name: "Hide image restrictions for icon",
-        }),
-      );
-
-      expect(
-        screen.queryByRole("button", {
-          name: "Hide image restrictions for icon",
-        }),
-      ).not.toBeInTheDocument();
-
-      expect(
-        screen.getByRole("button", {
-          name: "Show image restrictions for icon",
-        }),
-      ).toBeInTheDocument();
-    });
-  });
-
-  test("secondary category renders correct data", () => {
-    renderComponent();
-
-    waitFor(() => {
-      expect(screen.getByLabelText("Secondary category:")).toHaveValue(
-        testListingData.data.secondary_category,
-      );
-    });
-  });
-
-  test("secondary category can be removed", () => {
-    renderComponent();
-
-    waitFor(async () => {
-      const user = userEvent.setup();
-
-      renderComponent();
-
-      await user.click(
-        screen.getByRole("button", { name: "Remove secondary category" }),
-      );
-
-      expect(
-        screen.queryByLabelText("Secondary category:"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  test("primary website renders correct data", () => {
-    renderComponent();
-
-    waitFor(async () => {
-      expect(screen.getByLabelText("Primary website:")).toHaveValue(
-        testListingData.data.primary_website,
-      );
-    });
-  });
-
-  test("primary website is verified", () => {
+  test("on data error displays a notification", async () => {
+    server.resetHandlers();
     server.use(
-      http.get("/api/test-snap-id/verify", () => {
-        return HttpResponse.json({ primary_domain: true });
+      http.get("/api/test_id/listing", () => {
+        return HttpResponse.json({}, { status: 500 });
       }),
     );
 
     renderComponent();
-
-    waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Verified domain" }),
-      ).toBeInTheDocument();
-    });
-  });
-
-  test("primary website is not verified", () => {
-    server.use(
-      http.get("/api/test-snap-id/verify", () => {
-        return HttpResponse.json({ primary_domain: false });
-      }),
-    );
-
-    renderComponent();
-
-    waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Verify domain" }),
-      ).toBeInTheDocument();
-    });
+    const errorNotification = await screen.findByText("not available");
+    expect(errorNotification).toBeVisible();
   });
 });

--- a/static/js/publisher/test-utils/mockListingData.ts
+++ b/static/js/publisher/test-utils/mockListingData.ts
@@ -3,15 +3,20 @@ export const mockListingData = {
   categories: [
     { name: "Test category 1", slug: "test-category-1" },
     { name: "Test category 2", slug: "test-category-2" },
+    { name: "Test select", slug: "test-select" },
+    { name: "Test select secondary", slug: "test-select-secondary" },
   ],
   contacts: [{ url: "https://example.com/contact" }],
   description: "lorem ipsum dolor sit amet",
   donations: [{ url: "https://example.com/donate" }],
   icon_url: "https://example.com/icon",
   issues: [{ url: "https://example.com/issues" }],
-  license: "test-license",
-  license_type: "test",
-  licenses: [{ key: "test", name: "test" }],
+  license: "testing-license",
+  license_type: "simple",
+  licenses: [
+    { key: "testing-license", name: "testing-license" },
+    { key: "random-license", name: "random-license" },
+  ],
   primary_category: "test-category-1",
   primary_website: "https://example.com",
   public_metrics_blacklist: [

--- a/templates/store/snap-details/_snap_heading_data.html
+++ b/templates/store/snap-details/_snap_heading_data.html
@@ -1,15 +1,19 @@
 {% if icon_url %}
-  {{
-    image(
-      url=icon_url,
-      alt=snap_title,
-      width=60,
-      height=60,
-      hi_def=True,
-      loading="eager",
-      attrs={"class": "p-snap-heading__icon", "data-live": "icon"}
-    ) | safe
-  }}
+  {% if icon_url.startswith("blob") %}
+    <img class="p-snap-heading__icon" src="{{ icon_url | safe }}" width="60" height="60" data-live="icon" />
+  {% else %}
+    {{
+      image(
+        url=icon_url,
+        alt=snap_title,
+        width=60,
+        height=60,
+        hi_def=True,
+        loading="eager",
+        attrs={"class": "p-snap-heading__icon", "data-live": "icon"}
+      ) | safe
+    }}
+  {% endif %}
 {% else %}
   <img class="p-snap-heading__icon" src="https://assets.ubuntu.com/v1/be6eb412-snapcraft-missing-icon.svg" alt="" data-live="icon" />
 {% endif %}

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -43,8 +43,7 @@ def get_snaps_account_info(account_info):
             )
 
             if abs((revision_since - now).days) < 30 and (
-                not revisions[0]["channels"]
-                or revisions[0]["channels"][0] == "edge"
+                not revisions[0]["channels"] or revisions[0]["channels"][0] == "edge"
             ):
                 snap_info["is_new"] = True
 
@@ -238,9 +237,7 @@ def build_changed_images(
                 )
 
                 if is_same:
-                    image_built = build_image_info(
-                        new_screenshot, "screenshot"
-                    )
+                    image_built = build_image_info(new_screenshot, "screenshot")
                     if image_built not in info:
                         info.append(image_built)
                         images_files.append(new_screenshot)
@@ -279,8 +276,8 @@ def filter_changes_data(changes):
         "whitelist_countries",
         "public_metrics_enabled",
         "public_metrics_blacklist",
-        "whitelist_countries",
-        "blacklist_countries",
+        "public_metrics_distros",
+        "public_metrics_territories",
         "license",
         "video_urls",
         "categories",

--- a/webapp/publisher/snaps/logic.py
+++ b/webapp/publisher/snaps/logic.py
@@ -43,7 +43,8 @@ def get_snaps_account_info(account_info):
             )
 
             if abs((revision_since - now).days) < 30 and (
-                not revisions[0]["channels"] or revisions[0]["channels"][0] == "edge"
+                not revisions[0]["channels"]
+                or revisions[0]["channels"][0] == "edge"
             ):
                 snap_info["is_new"] = True
 
@@ -237,7 +238,9 @@ def build_changed_images(
                 )
 
                 if is_same:
-                    image_built = build_image_info(new_screenshot, "screenshot")
+                    image_built = build_image_info(
+                        new_screenshot, "screenshot"
+                    )
                     if image_built not in info:
                         info.append(image_built)
                         images_files.append(new_screenshot)


### PR DESCRIPTION
## Done

- Fixes data not being refreshed in the hidden PreviewForm present in ListingForm.tsx
- Fixes Internal Server Error caused when previewing a snap page when a new icon has been added and there's a blob image only present in the browser.

## How to QA

- Check out this PR
- Execute `dotrun` and access the server at `http://127.0.0.1:8004/`
- Visit any snap listing page, i.e. `http://127.0.0.1:8004/tdhcad/listing`
- Add an icon image from your computer
- Click on the Preview button

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why): 

## Issue / Card
Fixes [WD-21811](https://warthogs.atlassian.net/browse/WD-21811)


[WD-21811]: https://warthogs.atlassian.net/browse/WD-21811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ