### PR TITLE
fix: ensure progressive releases show in release ui

### DIFF
--- a/static/js/publisher/pages/Metrics/metrics/graphs/activeDevicesGraph/tooltips.ts
+++ b/static/js/publisher/pages/Metrics/metrics/graphs/activeDevicesGraph/tooltips.ts
@@ -166,8 +166,8 @@ export function tooltips(this: any) {
     const windowWidth = window.innerWidth;
     let adjustedLeft = mousePosition[0] + this.margin.left;
 
-    if (tooltipBounding.right > (windowWidth - 15)) {
-      adjustedLeft -= (tooltipBounding.right - windowWidth) + 15;
+    if (tooltipBounding.right > windowWidth - 15) {
+      adjustedLeft -= tooltipBounding.right - windowWidth + 15;
     }
 
     if (tooltipBounding.left < 0) {

--- a/static/js/publisher/pages/Releases/Releases.tsx
+++ b/static/js/publisher/pages/Releases/Releases.tsx
@@ -1,6 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "react-query";
-import { Strip, Link } from "@canonical/react-components";
+import { Link, Strip } from "@canonical/react-components";
 
 import SectionNav from "../../components/SectionNav";
 import Release from "./Release";

--- a/static/js/publisher/pages/Releases/components/revisionsList.js
+++ b/static/js/publisher/pages/Releases/components/revisionsList.js
@@ -48,11 +48,10 @@ class RevisionsList extends Component {
     isPending,
     isActive,
     showBuildRequest,
-    progressiveBeingCancelled
+    progressiveBeingCancelled,
   ) {
-    const rowKey = `revision-row-${revision.revision}-${
-      revision.release ? revision.release.channel : new Date().getTime()
-    }`;
+    const rowKey = `revision-row-${revision.revision}-${revision.release ? revision.release.channel : new Date().getTime()
+      }`;
 
     const risk = this.props.filters.risk;
     const track = this.props.filters.track;
@@ -78,7 +77,7 @@ class RevisionsList extends Component {
   getSortedRevisions(activeRevision, revisions) {
     const activeRevisionIndex = revisions.findIndex(
       (revision) =>
-        activeRevision && revision.revision === activeRevision.revision
+        activeRevision && revision.revision === activeRevision.revision,
     );
 
     let indexToMove = 1;
@@ -95,7 +94,7 @@ class RevisionsList extends Component {
     activeRevision,
     showBuildRequest,
     hasPendingRelease,
-    progressiveReleaseBeingCancelled
+    progressiveReleaseBeingCancelled,
   ) {
     const sortedRevisions = this.getSortedRevisions(activeRevision, revisions);
 
@@ -105,7 +104,7 @@ class RevisionsList extends Component {
 
       const progressiveBeingCancelled =
         progressiveReleaseBeingCancelled &&
-        progressiveReleaseBeingCancelled.revision.revision === revision.revision
+          progressiveReleaseBeingCancelled.revision.revision === revision.revision
           ? true
           : false;
 
@@ -119,7 +118,7 @@ class RevisionsList extends Component {
         false,
         isActive,
         showBuildRequest,
-        progressiveBeingCancelled
+        progressiveBeingCancelled,
       );
     });
   }
@@ -163,7 +162,7 @@ class RevisionsList extends Component {
     if (filters && filters.arch) {
       if (filters.risk === AVAILABLE) {
         filteredRevisions = this.props.getFilteredAvailableRevisionsForArch(
-          filters.arch
+          filters.arch,
         );
 
         if (availableRevisionsSelect === AVAILABLE_REVISIONS_SELECT_ALL) {
@@ -214,7 +213,7 @@ class RevisionsList extends Component {
 
         pendingRelease = getPendingRelease(
           `${filters.track}/${filters.risk}`,
-          filters.arch
+          filters.arch,
         );
       }
 
@@ -226,25 +225,24 @@ class RevisionsList extends Component {
           if (
             revision.version === selectedRevision.version &&
             revision.architectures.some(
-              (arch) => selectedVersionRevisionsArchs.indexOf(arch) === -1
+              (arch) => selectedVersionRevisionsArchs.indexOf(arch) === -1,
             )
           ) {
             selectedVersionRevisions.push(revision);
-            selectedVersionRevisionsArchs = selectedVersionRevisionsArchs.concat(
-              revision.architectures
-            );
+            selectedVersionRevisionsArchs =
+              selectedVersionRevisionsArchs.concat(revision.architectures);
           }
         });
 
         // filter out revisions that are already selected
         selectedVersionRevisions = selectedVersionRevisions.filter(
           (revision) =>
-            this.props.selectedRevisions.indexOf(revision.revision) === -1
+            this.props.selectedRevisions.indexOf(revision.revision) === -1,
         );
 
         // filter out current architecture
         selectedVersionRevisions = selectedVersionRevisions.filter(
-          (revision) => revision.architectures.indexOf(filters.arch) === -1
+          (revision) => revision.architectures.indexOf(filters.arch) === -1,
         );
 
         // recalculate list of architectures from current list of revisions
@@ -252,7 +250,7 @@ class RevisionsList extends Component {
 
         selectedVersionRevisions.forEach((revision) => {
           selectedVersionRevisionsArchs = selectedVersionRevisionsArchs.concat(
-            revision.architectures
+            revision.architectures,
           );
         });
 
@@ -282,7 +280,7 @@ class RevisionsList extends Component {
     }
 
     const showBuildRequest = filteredRevisions.some((revision) =>
-      getBuildId(revision)
+      getBuildId(revision),
     );
 
     const showProgressiveReleases =
@@ -353,7 +351,7 @@ class RevisionsList extends Component {
                 className="p-button--positive is-inline u-no-margin--bottom"
                 onClick={this.selectVersionClick.bind(
                   this,
-                  selectedVersionRevisions
+                  selectedVersionRevisions,
                 )}
               >
                 {"Select in available architectures"}
@@ -392,7 +390,7 @@ class RevisionsList extends Component {
                 true,
                 activeRevision.revision === pendingRelease.revision.revision,
                 showBuildRequest,
-                false
+                false,
               )}
             {filteredRevisions.length > 0 ? (
               this.renderRows(
@@ -404,7 +402,7 @@ class RevisionsList extends Component {
                 activeRevision,
                 showBuildRequest,
                 showPendingRelease,
-                progressiveReleaseBeingCancelled
+                progressiveReleaseBeingCancelled,
               )
             ) : (
               <tr>

--- a/static/js/publisher/pages/Releases/components/revisionsListRow.js
+++ b/static/js/publisher/pages/Releases/components/revisionsListRow.js
@@ -42,7 +42,8 @@ const RevisionsListRow = (props) => {
 
   const isProgressive =
     revision.prog_channels &&
-    revision.prog_channels.includes(`${track}/${risk}`)
+    revision.prog_channels.includes(`${track}/${risk}`) &&
+    revision.progressive
       ? true
       : false;
   const isPreviousProgressive =

--- a/static/js/publisher/pages/Releases/releasesState.js
+++ b/static/js/publisher/pages/Releases/releasesState.js
@@ -36,8 +36,8 @@ function initReleasesData(revisionsMap, releases) {
           if (
             rev.prog_channels.indexOf(channel) === -1 &&
             release.progressive &&
-            release.progressive.percentage &&
-            release.progressive["current-percentage"]
+            (release.progressive.percentage ||
+              release.progressive["current-percentage"])
           ) {
             rev.prog_channels.push(channel);
           }
@@ -150,9 +150,9 @@ function getUnassignedRevisions(revisionsMap, arch) {
 }
 
 export {
-  getUnassignedRevisions,
-  getTrackingChannel,
-  getRevisionsMap,
-  initReleasesData,
   getReleaseDataFromChannelMap,
+  getRevisionsMap,
+  getTrackingChannel,
+  getUnassignedRevisions,
+  initReleasesData,
 };


### PR DESCRIPTION
## Done
- Updated logic around showing progressive releases
- prettier went ham, sorry

## How to QA
- Visit https://snapcraft-io-5119.demos.haus/snapd/releases and compare progressive release data with https://snapcraft.io/snapd/releases
  - The demo should display the data, the live site does not
- Visit https://snapcraft-io-5119.demos.haus/snapd/releases and compare progressive releases data with to `snapcraft status snapd`
  - The information in both should match

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Legacy, none of this has tests :(

## Issue / Card
Fixes #

## Screenshots
