### PR TITLE
fix: Update lodash version in resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,6 @@
   "resolutions": {
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
-    "lodash": "4.17.12"
+    "lodash": "4.17.21"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6165,10 +6165,10 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.12, lodash@^3.5.0, lodash@^4.17.21, lodash@~1.0.1:
-  version "4.17.12"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.12.tgz#a712c74fdc31f7ecb20fe44f157d802d208097ef"
-  integrity sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA==
+lodash@4.17.21, lodash@^3.5.0, lodash@^4.17.21, lodash@~1.0.1:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## Done
Adds lodash to resolutions to address Dependabot security notifications, e.g. https://github.com/canonical/snapcraft.io/security/dependabot/46

## How to QA
- All checks should pass
- Can't check if it fixes issue until merged

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes
