### PR TITLE
Wd 18956/stores filter

### DIFF
--- a/static/js/publisher/components/StoreSelector/StoreSelector.tsx
+++ b/static/js/publisher/components/StoreSelector/StoreSelector.tsx
@@ -14,6 +14,7 @@ function StoreSelector({ nativeNavLink }: Props): React.JSX.Element {
   const { id } = useParams();
   const brandStoresList = useRecoilValue(brandStoresState);
   const [showStoreSelector, setShowStoreSelector] = useState<boolean>(false);
+  const [searchValue, setSearchValue] = useState("");
   const [filteredBrandStores, setFilteredBrandstores] =
     useState<Store[]>(brandStoresList);
 
@@ -57,9 +58,10 @@ function StoreSelector({ nativeNavLink }: Props): React.JSX.Element {
               id="search-stores"
               name="search-stores"
               placeholder="Search"
+              value={searchValue}
               onInput={(e) => {
                 const value = (e.target as HTMLInputElement).value;
-
+                setSearchValue(value);
                 if (value.length > 0) {
                   setFilteredBrandstores(
                     brandStoresList.filter((store) => {
@@ -72,7 +74,14 @@ function StoreSelector({ nativeNavLink }: Props): React.JSX.Element {
                 }
               }}
             />
-            <button type="reset" className="p-search-box__reset">
+            <button
+              type="reset"
+              className="p-search-box__reset"
+              onClick={() => {
+                setSearchValue("");
+                setFilteredBrandstores(brandStoresList);
+              }}
+            >
               <i className="p-icon--close">Close</i>
             </button>
             <button type="submit" className="p-search-box__button">

--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -137,7 +137,7 @@
     }
 
     .p-search-box__input:focus {
-      color: $color-x-dark;
+      color: $color-x-light;
     }
 
     .p-search-box__input:hover::placeholder,


### PR DESCRIPTION
## Done
- Makes sure "x" button clears input
- Makes sure input text is light in colour

## How to QA
- Go to https://snapcraft-io-5136.demos.haus/snaps
- Click the `My Stores` dropdown
- Search for something - make sure the text input is light in colour
- Click the "X", make sure the input clears

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): bug fix

## Issue / Card
Fixes [WD-18956](https://warthogs.atlassian.net/browse/WD-18956)


[WD-18956]: https://warthogs.atlassian.net/browse/WD-18956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ