### PR TITLE
chore: optimize bundle

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -37,6 +37,8 @@
       });
     </script>
 
+    <script src="{{ static_url('js/dist/vendors.js') }}" ></script>
+    <script src="{{ static_url('js/dist/runtime.js') }}" ></script>
     <script src="{{ static_url('js/dist/base.js') }}" defer></script>
     {% block scripts_includes %}{% endblock %}
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,4 +19,21 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".tsx", ".js"],
   },
+  optimization: {
+    splitChunks: {
+      chunks: "all",
+      minSize: 20000,
+      automaticNameDelimiter: "-",
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          name: "vendors",
+          chunks: "all",
+        },
+      },
+    },
+    runtimeChunk: {
+      name: "runtime",
+    },
+  },
 };


### PR DESCRIPTION
## Done
- Add webpack config to share common dependencies into a "vendors.js" file that can be cached
- webpack runtime (the code Webpack uses to load modules) gets a separate chunk, also to improve caching
- cut bundle size by about 50% by sharing common dependencies.

## How to QA
- Make sure all our javascript still works. check publisher and store pages, brand store, etc.
## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): webpack config


## Screenshots
Before:
Notice some repeated dependencies like react-components
Bundle size: **10.2Mb**
![image](https://github.com/user-attachments/assets/4d6265f5-d208-42aa-ac3b-f0642a60acf6)

After:
Bundle size: **5.52Mb**
![image](https://github.com/user-attachments/assets/7660827c-05b5-48c6-846a-b6991b29a906)
