### PR TITLE
fix: Fix releases data disappearing on second mount

### DIFF
--- a/static/js/publisher/publisher.tsx
+++ b/static/js/publisher/publisher.tsx
@@ -95,6 +95,7 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
+      refetchOnMount: false,
     },
   },
 });


### PR DESCRIPTION
## Done
Fixes issue where releases data doesn't load when navigating back from another tab

## How to QA
- Go to a snaps release page on the demo: https://snapcraft-io-5153.demos.haus/
- Click to any other tab and wait for it to fully load
- Go back to the releases page using the tabs navigation
- The releases data should be on the page

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #5152