### PR TITLE
redirect snapcraft root

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -8,6 +8,7 @@ tutorials(.*?): /docs/snap-tutorials
 search(.*?): /store
 
 # documentation.ubuntu.com/snapcraft redirects
+docs/snapcraft/?: https://documentation.ubuntu.com/snapcraft
 docs/using-gdb-gdbserver/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/debug-with-gdb/
 docs/python-apps/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-a-python-app/
 docs/snapcraft-yaml-schema/?: https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/snapcraft-yaml/


### PR DESCRIPTION
## Done

Now that the old Snapcraft docs are removed from the index, the root page must be redirected to the RTD root.

## How to QA

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Public redirect

## Issue / Card

## Screenshots
