### PR TITLE
WD-22439 - change set to dict to fix make_response call

### DIFF
--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -260,7 +260,7 @@ def post_listing_data(snap_name):
 
             snap_categories = logic.filter_categories(snap_categories)
 
-            res = {"success", True}
+            res = {"success": True}
 
             return flask.make_response(res, 200)
 


### PR DESCRIPTION
## Done

Transform set into dict to fix the error triggered when calling make_response.

## How to QA

You need to own a snap so that you can write changes to it -> [Craft a snap](https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap/)

- Run `dotrun`
- Go to your snap listing page: 127.0.0.1:8004/{your-snap}/listing
- Add a valid image
- Open the network tab or check the log output of dotrun
- Click on 'Save'

The network response to the POST should contain a 200.
No error stack trace should be on the output of dotrun.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): can't mock dashboard API responses in legacy test suite

## Issue / Card
Fixes [ISSUE-5146](https://github.com/canonical/snapcraft.io/issues/5146)
