### PR TITLE
fix: Refetch releases data on mount

### DIFF
--- a/static/js/publisher/pages/Releases/Releases.tsx
+++ b/static/js/publisher/pages/Releases/Releases.tsx
@@ -9,7 +9,7 @@ import { setPageTitle } from "../../utils";
 
 function Releases(): React.JSX.Element {
   const { snapId } = useParams();
-  const { isLoading, isFetched, data } = useQuery({
+  const { isLoading, isFetched, data, isRefetching } = useQuery({
     queryKey: ["releases"],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/releases`);
@@ -39,16 +39,17 @@ function Releases(): React.JSX.Element {
 
       <SectionNav snapName={snapId} activeTab="releases" />
 
-      {isLoading && (
-        <Strip shallow>
-          <p>
-            <i className="p-icon--spinner u-animation--spin"></i>&nbsp;Loading{" "}
-            {snapId} builds data
-          </p>
-        </Strip>
-      )}
+      {isLoading ||
+        (isRefetching && (
+          <Strip shallow>
+            <p>
+              <i className="p-icon--spinner u-animation--spin"></i>&nbsp;Loading{" "}
+              {snapId} releases data
+            </p>
+          </Strip>
+        ))}
 
-      {isFetched && data && (
+      {isFetched && data && !isRefetching && (
         <Release
           snapName={snapId || ""}
           releasesData={data.release_history}

--- a/static/js/publisher/pages/Releases/releasesController.js
+++ b/static/js/publisher/pages/Releases/releasesController.js
@@ -46,7 +46,7 @@ const ReleasesController = ({
         setReady(true);
       },
     );
-  }, []);
+  }, [releasesData]);
 
   const { visible } = notification;
   return (

--- a/static/js/publisher/publisher.tsx
+++ b/static/js/publisher/publisher.tsx
@@ -95,7 +95,6 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
-      refetchOnMount: false,
     },
   },
 });


### PR DESCRIPTION
## Done
Made a change which will reload the data when re-visiting the "Releases" view so that it always has the latest data

## How to QA
- Go to https://snapcraft-io-5157.demos.haus/<SNAP_NAME>/releases
- Use the tabbed navigation to go to any other tab and wait for it to load
- Use the tabbed navigation to go back to "Releases"
- The data should reload

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Follow up to issue addressed here: https://github.com/canonical/snapcraft.io/issues/5152