### PR TITLE
chore: add missing redirect for robotics docs

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -22,6 +22,7 @@ https://forum.snapcraft.io/t/install-snapcraft-on-macos/9607/?: https://document
 docs/package-repositories/?: https://documentation.ubuntu.com/snapcraft/stable/reference/package-repositories/
 docs/snapcraft-intermediate-example/?: https://documentation.ubuntu.com/snapcraft/stable/reference/project-file/anatomy-of-snapcraft-yaml/
 docs/creating-snapcraft-yaml/?: https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap/
+docs/robotics/?: https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/snaps/
 docs/ros-architectures-with-snaps/?: https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/snaps/ros-architectures-with-snaps/
 docs/ros-with-github-actions/?: https://canonical-robotics.readthedocs-hosted.com/en/latest/how-to-guides/packaging/build-and-publish-snap-with-github-actions/
 docs/ros2-shared-memory-in-snaps/?: https://canonical-robotics.readthedocs-hosted.com/en/latest/how-to-guides/packaging/ros-2-shared-memory-in-snaps/


### PR DESCRIPTION
## Done
- Adds missing redirect for /docs/robotics

## How to QA
- Go to https://snapcraft-io-5158.demos.haus/docs/robotics
- Make sure it redirects to https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/snaps/

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): redirect
