### PR TITLE
fix: Use brand account ID rather than store ID in model service requests

### DIFF
--- a/static/js/publisher/components/Navigation/Navigation.tsx
+++ b/static/js/publisher/components/Navigation/Navigation.tsx
@@ -32,6 +32,8 @@ function Navigation({
   useEffect(() => {
     if (brand) {
       setBrandId(brand?.["account-id"]);
+    } else {
+      setBrandId("");
     }
   }, [brand]);
 

--- a/static/js/publisher/hooks/__tests__/usePolicies.test.tsx
+++ b/static/js/publisher/hooks/__tests__/usePolicies.test.tsx
@@ -33,21 +33,21 @@ const policiesResponse = [
 ];
 
 const handlers = [
-  http.get("/api/store/test-brand-id/models/test-id-success/policies", () => {
+  http.get("/api/store/test-store-id/models/test-id-success/policies", () => {
     return HttpResponse.json({
       data: policiesResponse,
       message: "",
       success: true,
     });
   }),
-  http.get("/api/store/test-brand-id/models/test-id-fail/policies", () => {
+  http.get("/api/store/test-store-id/models/test-id-fail/policies", () => {
     return HttpResponse.json({
       data: [],
       message: "Unable to fetch policies",
       success: false,
     });
   }),
-  http.get("/api/store/test-brand-id/models/test-id-error/policies", () => {
+  http.get("/api/store/test-store-id/models/test-id-error/policies", () => {
     return HttpResponse.error();
   }),
 ];
@@ -70,7 +70,7 @@ afterAll(() => {
 describe("usePolicies", () => {
   test("returns policies data", async () => {
     const { result } = renderHook(
-      () => usePolicies("test-brand-id", "test-id-success"),
+      () => usePolicies("test-store-id", "test-id-success"),
       { wrapper: createWrapper() },
     );
 
@@ -83,7 +83,7 @@ describe("usePolicies", () => {
 
   test("returns no data if request fails", async () => {
     const { result } = renderHook(
-      () => usePolicies("test-brand-id", "test-id-fail"),
+      () => usePolicies("test-store-id", "test-id-fail"),
       { wrapper: createWrapper() },
     );
 
@@ -96,7 +96,7 @@ describe("usePolicies", () => {
 
   test("returns no data if error", async () => {
     const { result } = renderHook(
-      () => usePolicies("test-brand-id", "test-id-error"),
+      () => usePolicies("test-store-id", "test-id-error"),
       { wrapper: createWrapper() },
     );
 

--- a/static/js/publisher/hooks/usePolicies.ts
+++ b/static/js/publisher/hooks/usePolicies.ts
@@ -3,14 +3,14 @@ import type { Policy } from "../types/shared";
 import { UsePoliciesResponse, ApiError } from "../types/shared";
 
 function usePolicies(
-  brandId: string | undefined,
+  storeId: string | undefined,
   modelId: string | undefined,
 ): UsePoliciesResponse {
   return useQuery<Policy[], ApiError>({
-    queryKey: ["policies", brandId],
+    queryKey: ["policies", storeId],
     queryFn: async () => {
       const response = await fetch(
-        `/api/store/${brandId}/models/${modelId}/policies`,
+        `/api/store/${storeId}/models/${modelId}/policies`,
       );
 
       if (!response.ok) {

--- a/static/js/publisher/hooks/useSigningKeys.ts
+++ b/static/js/publisher/hooks/useSigningKeys.ts
@@ -2,12 +2,12 @@ import { useQuery, UseQueryResult } from "react-query";
 import type { SigningKey } from "../types/shared";
 
 const useSigningKeys = (
-  brandId: string | undefined,
+  storeId: string | undefined,
 ): UseQueryResult<SigningKey[], Error> => {
   return useQuery<SigningKey[], Error>({
-    queryKey: ["signingKeys", brandId],
+    queryKey: ["signingKeys", storeId],
     queryFn: async () => {
-      const response = await fetch(`/api/store/${brandId}/signing-keys`);
+      const response = await fetch(`/api/store/${storeId}/signing-keys`);
 
       if (!response.ok) {
         throw new Error("There was a problem fetching signing keys");

--- a/static/js/publisher/pages/Model/CreatePolicyForm.tsx
+++ b/static/js/publisher/pages/Model/CreatePolicyForm.tsx
@@ -28,7 +28,7 @@ function CreatePolicyForm({
   const brandId = useRecoilValue(brandIdState);
   const navigate = useNavigate();
   const location = useLocation();
-  const { isLoading, isError, error, data } = useSigningKeys(brandId);
+  const { isLoading, isError, error, data } = useSigningKeys(id);
   const [signingKeys, setSigningKeys] = useRecoilState(signingKeysListState);
   const [newSigningKey, setNewSigningKey] = useRecoilState(newSigningKeyState);
   const brandStore = useRecoilValue(brandStoreState(id));

--- a/static/js/publisher/pages/Model/Policies.tsx
+++ b/static/js/publisher/pages/Model/Policies.tsx
@@ -26,7 +26,7 @@ import {
   signingKeysListState,
   newSigningKeyState,
 } from "../../state/signingKeysState";
-import { brandIdState, brandStoreState } from "../../state/brandStoreState";
+import { brandStoreState } from "../../state/brandStoreState";
 
 import { isClosedPanel, setPageTitle } from "../../utils";
 
@@ -34,12 +34,11 @@ import type { Policy, SigningKey } from "../../types/shared";
 
 function Policies(): React.JSX.Element {
   const { id, model_id } = useParams();
-  const brandId = useRecoilValue(brandIdState);
   const location = useLocation();
   const navigate = useNavigate();
   const { isLoading, isError, error, refetch, data }: UsePoliciesResponse =
-    usePolicies(brandId, model_id);
-  const signingKeys = useSigningKeys(brandId);
+    usePolicies(id, model_id);
+  const signingKeys = useSigningKeys(id);
   const setPoliciesList = useSetRecoilState<Array<Policy>>(policiesListState);
   const setFilter = useSetRecoilState<string>(policiesListFilterState);
   const setNewSigningKey = useSetRecoilState(newSigningKeyState);

--- a/static/js/publisher/pages/Model/PoliciesTable.tsx
+++ b/static/js/publisher/pages/Model/PoliciesTable.tsx
@@ -22,7 +22,7 @@ function ModelsTable({
   setShowDeletePolicyNotification,
   setShowDeletePolicyErrorNotification,
 }: Props): React.JSX.Element {
-  const { model_id } = useParams();
+  const { id, model_id } = useParams();
   const brandId = useRecoilValue(brandIdState);
   const [policiesList, setPoliciesList] = useRecoilState(
     filteredPoliciesListState,
@@ -31,7 +31,7 @@ function ModelsTable({
   const [showModal, setShowModal] = useState<boolean>(false);
   const [selectedPolicy, setSelectedPolicy] = useState<number | undefined>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { refetch } = usePolicies(brandId, model_id) as UsePoliciesResponse;
+  const { refetch } = usePolicies(id, model_id) as UsePoliciesResponse;
 
   const deletePolicy = async (policyRevision: number | undefined) => {
     if (policyRevision === undefined) {

--- a/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
+++ b/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
@@ -44,7 +44,7 @@ function SigningKeys(): React.JSX.Element {
     error,
     data,
     refetch,
-  }: UseQueryResult<SigningKey[], Error> = useSigningKeys(brandId);
+  }: UseQueryResult<SigningKey[], Error> = useSigningKeys(id);
   const setSigningKeysList =
     useSetRecoilState<Array<SigningKey>>(signingKeysListState);
   const setPolicies = useSetRecoilState<Array<Policy>>(policiesListState);
@@ -70,7 +70,8 @@ function SigningKeys(): React.JSX.Element {
 
   useEffect(() => {
     if (!isLoading && !error && data) {
-      setSigningKeysList([...data.sort(sortByDateDescending)]);
+      const newData = [...data];
+      setSigningKeysList(newData.sort(sortByDateDescending));
       setFilter(searchParams.get("filter") || "");
     }
   }, [isLoading, error, data]);

--- a/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
+++ b/static/js/publisher/pages/SigningKeys/SigningKeys.tsx
@@ -74,7 +74,7 @@ function SigningKeys(): React.JSX.Element {
       setSigningKeysList(newData.sort(sortByDateDescending));
       setFilter(searchParams.get("filter") || "");
     }
-  }, [isLoading, error, data]);
+  }, [isLoading, error, data, brandId, id]);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/static/js/publisher/pages/SigningKeys/SigningKeysTable.tsx
+++ b/static/js/publisher/pages/SigningKeys/SigningKeysTable.tsx
@@ -1,4 +1,4 @@
-import { SetStateAction, useState, Dispatch } from "react";
+import { SetStateAction, useState, Dispatch, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useRecoilValue, useSetRecoilState } from "recoil";
 import { format } from "date-fns";
@@ -89,6 +89,12 @@ function SigningKeysTable({
       setShowDisableSuccessNotification(false);
     }, 5000);
   };
+
+  useEffect(() => {
+    return () => {
+      setSigningKeysList([]);
+    };
+  }, []);
 
   return (
     <>

--- a/static/js/publisher/utils/sortByDateDescending.ts
+++ b/static/js/publisher/utils/sortByDateDescending.ts
@@ -1,4 +1,4 @@
-function sortByDateAscending(
+function sortByDateDescending(
   a: { "created-at": string },
   b: { "created-at": string },
 ) {
@@ -13,4 +13,4 @@ function sortByDateAscending(
   return 0;
 }
 
-export default sortByDateAscending;
+export default sortByDateDescending;

--- a/tests/admin/tests_models.py
+++ b/tests/admin/tests_models.py
@@ -15,6 +15,9 @@ candid = CandidClient(api_publisher_session)
 class TestModelServiceEndpoints(TestAdminEndpoints):
     def setUp(self):
         self.api_key = "qwertyuioplkjhgfdsazxcvbnmkiopuytrewqasdfghjklmnbv"
+        self.mock_get_store = patch(
+            "webapp.admin.views.dashboard.get_store"
+        ).start()
         super().setUp()
 
 

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -32,6 +32,11 @@ SNAPSTORE_DASHBOARD_API_URL = os.getenv(
 context = {"api_url": SNAPSTORE_DASHBOARD_API_URL}
 
 
+def get_brand_id(session, store_id):
+    store = dashboard.get_store(session, store_id)
+    return store["brand-id"]
+
+
 @admin.route("/admin", defaults={"path": ""})
 @admin.route("/admin/<path:path>")
 @login_required
@@ -409,11 +414,12 @@ def get_policies(store_id: str, model_name: str):
     Returns:
         dict: A dictionary containing the response message and success
     """
+    brand_id = get_brand_id(flask.session, store_id)
     res = {}
 
     try:
         policies = publisher_gateway.get_store_model_policies(
-            flask.session, store_id, model_name
+            flask.session, brand_id, model_name
         )
         res["success"] = True
         res["data"] = policies
@@ -509,9 +515,10 @@ def delete_policy(store_id: str, model_name: str, revision: str):
 @login_required
 @exchange_required
 def get_brand_store(store_id: str):
+    brand_id = get_brand_id(flask.session, store_id)
     res = {}
     try:
-        brand = publisher_gateway.get_brand(flask.session, store_id)
+        brand = publisher_gateway.get_brand(flask.session, brand_id)
 
         res["data"] = brand
         res["success"] = True
@@ -536,10 +543,11 @@ def get_brand_store(store_id: str):
 @login_required
 @exchange_required
 def get_signing_keys(store_id: str):
+    brand_id = get_brand_id(flask.session, store_id)
     res = {}
     try:
         signing_keys = publisher_gateway.get_store_signing_keys(
-            flask.session, store_id
+            flask.session, brand_id
         )
         res["data"] = signing_keys
         res["success"] = True


### PR DESCRIPTION
## Done
- Extracts call to the store endpoint to a custom hook
- Uses the brand ID rather than the store ID for model service requests

## How to QA
- Go to https://snapcraft-io-5160.demos.haus/admin/ahnuP3quahti9vis8aiw/settings
- Check that you are able to make and save changes
- Go to https://snapcraft-io-5160.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps
- Check that the side navigation has links for "Models" and "Signing keys"
- With the network tab open, click the "Models" link
- Check that the models table loads and is populated
- In the network tab, check that calls to the policies endpoint are successful (not all models have them so won't all show in the table)
- Check that you can successfully create a new model
- Click through to a model with policies (e.g. https://snapcraft-io-5160.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test_model_without_api_key)
- Check that you can update the API key of a model and save it successfully
- Go to the "Policies" tab
- Check that the policies table loads and is populated
- Check that you can successfully create a policy
- Check that you can successfully delete a policy
- Click the "Signing keys" link in the navigation
- Check that the signing keys table loads and is populated
- Check that you can successfully create a new signing key
- Check that you can successfully deactivate a new signing key

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-22645