### PR TITLE
redirects: remove supported-snap-hooks

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -116,7 +116,6 @@ docs/ros2-jazzy-content-extension/?: https://documentation.ubuntu.com/snapcraft/
 docs/ros2-foxy-extension/?: https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-extensions/
 docs/ros2-humble-extension/?: https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-extensions/
 docs/ros2-jazzy-extension/?: https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/ros-2-extensions/
-docs/supported-snap-hooks/?: https://documentation.ubuntu.com/snapcraft/stable/reference/hooks/
 docs/snapcraft-hook-support/?: https://documentation.ubuntu.com/snapcraft/stable/reference/hooks/
 docs/snap-layouts/?: https://documentation.ubuntu.com/snapcraft/stable/reference/layouts/
 docs/linters/?: https://documentation.ubuntu.com/snapcraft/stable/reference/linters/


### PR DESCRIPTION
## Done

Removed a redirect. This page was retired prematurely and has been restored for customers.

## How to QA

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): production redirect
