### PR TITLE
Remove search input color overrides

### DIFF
--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -136,15 +136,6 @@
       z-index: 1;
     }
 
-    .p-search-box__input:focus {
-      color: $color-x-light;
-    }
-
-    .p-search-box__input:hover::placeholder,
-    .p-search-box__input:focus::placeholder {
-      color: $color-mid-dark;
-    }
-
     .store-selector__list {
       background-color: #2d2d2d;
       margin: 0;


### PR DESCRIPTION
## Done
Fixes text color for search inputs inside the dashboard: previously the text color styles were overwritten and wouldn't respect the application theme (i.e. dark text on light background and vice versa), leading to unreadable text in some cases.

## How to QA
- Go to https://snapcraft-io-5166.demos.haus/snaps
- In the left navigation, open the "My stores" dropdown and write something in the Search input -> text should be light
- Open the ["My validations sets" section](https://snapcraft-io-5166.demos.haus/validation-sets) and write something in the Search input at the top -> text should be dark
- Open the ["Store snaps" section](https://snapcraft-io-5166.demos.haus/admin/ahnuP3quahti9vis8aiw/snaps) of a brand store
  - write something in the Search input at the top -> text should be dark
  - click on "Include snap" and write something in the Search input in the modal -> text should be dark
- Open the ["Members" section](https://snapcraft-io-5166.demos.haus/admin/ahnuP3quahti9vis8aiw/members) of a brand store
  - write something in the Search input at the top -> text should be dark

_(There might be other sections where search inputs are present that I don't have access to and I don't know of.)_

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): visual bug fix

## Issue / Card
Fixes [WD-22766](https://warthogs.atlassian.net/browse/WD-22766)

## Screenshots
Before:
![immagine](https://github.com/user-attachments/assets/5a4df15c-ee54-4a91-bb88-2764160b9809)
After:
![immagine](https://github.com/user-attachments/assets/8f8499cc-99b6-4a39-8ace-0b59d4f53417)


[WD-22766]: https://warthogs.atlassian.net/browse/WD-22766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ