### PR TITLE
fix: add missing "distro-install.js" script

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -263,6 +263,10 @@
   {% include "store/snap-details/_templates.html" %}
 {% endblock %}
 
+{% block scripts_includes %}
+  <script src="{{ static_url('js/dist/distro-install.js') }}" defer></script>
+{% endblock %}
+
 {% block scripts %}
   <script>
     window.addEventListener("DOMContentLoaded", function() {


### PR DESCRIPTION
## Done
Added a missing "distro-install.js" script in the Distro install page template.

## How to QA
- navigate to https://snapcraft-io-5168.demos.haus/install/pinta/arch
- interact with the image carousel:
  - the arrows and swiping (click and drag) should work
  - clicking on an image should open the clicked image in full screen

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #5167 

## Screenshots
