### PR TITLE
WD-23027 - feat: add error to snap/listing page when save fails

### DIFF
--- a/static/js/publisher/components/UpdateMetadataModal/UpdateMetadataModal.tsx
+++ b/static/js/publisher/components/UpdateMetadataModal/UpdateMetadataModal.tsx
@@ -3,10 +3,16 @@ import { Modal, Button } from "@canonical/react-components";
 import type { Dispatch, SetStateAction } from "react";
 import type { FieldValues } from "react-hook-form";
 import type { UseMutateFunction } from "react-query";
+import { MutationResponse } from "../../hooks/useMutateListingData";
 
 type Props = {
   setShowMetadataWarningModal: Dispatch<SetStateAction<boolean>>;
-  submitForm: UseMutateFunction<void, unknown, FieldValues, unknown>;
+  submitForm: UseMutateFunction<
+    MutationResponse,
+    unknown,
+    FieldValues,
+    unknown
+  >;
   formData: Record<string, unknown>;
 };
 

--- a/static/js/publisher/hooks/__tests__/useMutateListingData.test.ts
+++ b/static/js/publisher/hooks/__tests__/useMutateListingData.test.ts
@@ -15,7 +15,7 @@ describe("useMutateListingData", () => {
         getDefaultData: jest.fn(),
         refetch: jest.fn(),
         reset: jest.fn(),
-        setShowSuccessNotification: jest.fn(),
+        setStatusNotification: jest.fn(),
         setUpdateMetadataOnRelease: jest.fn(),
         shouldShowUpdateMetadataWarning: jest.fn(),
         snapName: "test-snap",

--- a/static/js/publisher/pages/Listing/ListingForm/ListingForm.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/ListingForm.tsx
@@ -19,7 +19,7 @@ import {
 
 import { useMutateListingData } from "../../../hooks";
 
-import type { ListingData } from "../../../types";
+import type { ListingData, StatusNotification } from "../../../types";
 
 type Props = {
   data: ListingData;
@@ -45,8 +45,8 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
 
   const { dirtyFields } = useFormState({ control });
 
-  const [showSuccessNotification, setShowSuccessNotification] =
-    useState<boolean>(false);
+  const [notificationStrip, setNotificationStrip] =
+    useState<StatusNotification>({});
 
   const [updateMetadataOnRelease, setUpdateMetadataOnRelease] =
     useState<boolean>(data.update_metadata_on_release);
@@ -64,11 +64,26 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
     getDefaultData: getDefaultListingData,
     refetch,
     reset,
-    setShowSuccessNotification,
+    setStatusNotification: setNotificationStrip,
     setUpdateMetadataOnRelease,
     shouldShowUpdateMetadataWarning,
     snapName: snapId,
   });
+
+  let notificationStripContent: string | JSX.Element | undefined;
+  if (notificationStrip.message) {
+    if (typeof notificationStrip.message === "string") {
+      notificationStripContent = notificationStrip.message;
+    } else {
+      notificationStripContent = (
+        <ul>
+          {notificationStrip.message.map((message, index) => (
+            <li key={index}>{message}</li>
+          ))}
+        </ul>
+      );
+    }
+  }
 
   return (
     <>
@@ -125,16 +140,16 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
           </>
         )}
 
-        {showSuccessNotification && (
+        {notificationStrip.message !== undefined && (
           <Strip shallow className="u-no-padding--bottom">
             <Notification
-              severity="positive"
+              severity={notificationStrip.success ? "positive" : "negative"}
               onDismiss={() => {
-                setShowSuccessNotification(false);
+                setNotificationStrip({ message: undefined });
               }}
               className="u-no-margin--bottom"
             >
-              Changes applied successfully.
+              {notificationStripContent}
             </Notification>
           </Strip>
         )}

--- a/static/js/publisher/types/index.ts
+++ b/static/js/publisher/types/index.ts
@@ -90,3 +90,8 @@ export interface ISnap {
   unlisted: boolean;
   is_new?: boolean;
 }
+
+export type StatusNotification = {
+  success?: boolean;
+  message?: string | string[];
+};

--- a/webapp/publisher/snaps/listing_views.py
+++ b/webapp/publisher/snaps/listing_views.py
@@ -260,11 +260,11 @@ def post_listing_data(snap_name):
 
             snap_categories = logic.filter_categories(snap_categories)
 
-            res = {"success": True}
+            res = {"success": True, "errors": error_list}
 
             return flask.make_response(res, 200)
 
-    return flask.make_response({}, 200)
+    return flask.make_response({"success": True}, 200)
 
 
 @login_required

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -20,8 +20,8 @@ module.exports = [
         loader: "sass-loader",
         options: {
           sassOptions: {
-               quietDeps: true,
-               silenceDeprecations: ["import", "global-builtin"],
+            quietDeps: true,
+            silenceDeprecations: ["import", "global-builtin"],
           },
         },
       },


### PR DESCRIPTION
## Done

Add error message when the Save action of a snap listing fails; this way we let the user know what went wrong.

## How to QA

- Go to the [issue](https://github.com/canonical/snapcraft.io/issues/5171) page and download the image in there.
- Go to [Demos](https://snapcraft-io-5172.demos.haus/) and visit the listing of a snap you are able to modify.
- Add the image you downloaded in the first step.
- Click Save.

You should see an error message saying that the aspect ratio is not valid.

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card

Fixes #5171
[WD-23027](https://warthogs.atlassian.net/browse/WD-23027)

## Screenshots


[WD-23027]: https://warthogs.atlassian.net/browse/WD-23027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ