### PR TITLE
feat: Add explore page recommendation sections

### DIFF
--- a/static/js/store/pages/Explore/CardsLoader.tsx
+++ b/static/js/store/pages/Explore/CardsLoader.tsx
@@ -1,0 +1,26 @@
+import { Row, Col } from "@canonical/react-components";
+import { LoadingCard } from "@canonical/store-components";
+import { v4 as uuidv4 } from "uuid";
+
+function CardsLoader(): JSX.Element {
+  const elementIds: string[] = Array.of(
+    uuidv4(),
+    uuidv4(),
+    uuidv4(),
+    uuidv4(),
+    uuidv4(),
+    uuidv4(),
+  );
+
+  return (
+    <Row>
+      {elementIds.map((id) => (
+        <Col size={4} key={id}>
+          <LoadingCard height={157} />
+        </Col>
+      ))}
+    </Row>
+  );
+}
+
+export default CardsLoader;

--- a/static/js/store/pages/Explore/Explore.tsx
+++ b/static/js/store/pages/Explore/Explore.tsx
@@ -1,14 +1,86 @@
 import { useRef } from "react";
+import { useQueries } from "react-query";
 
 import Banner from "../../components/Banner";
+import RecommendationsSection from "./RecommendationsSection";
 
-function Explore(): React.JSX.Element {
+import type { UseQueryResult } from "react-query";
+import type { RecommendationData } from "../../types";
+
+function Explore(): JSX.Element {
   const searchRef = useRef<HTMLInputElement | null>(null);
   const searchSummaryRef = useRef<HTMLDivElement | null>(null);
+  const categories: string[] = ["popular", "recent", "trending"];
+
+  const recommendations: UseQueryResult<{
+    name: string;
+    snaps: RecommendationData[];
+  }>[] = useQueries(
+    categories.map((category) => ({
+      queryKey: ["recommendations", category],
+      queryFn: async () => {
+        const response = await fetch(
+          `https://recommendations.snapcraft.io/api/category/${category}`,
+        );
+
+        if (!response.ok) {
+          throw Error(`Unable to fetch ${category} data`);
+        }
+
+        const responseData = await response.json();
+
+        return {
+          name: category,
+          snaps: responseData,
+        };
+      },
+    })),
+  );
+
+  const isLoading: boolean =
+    !recommendations || recommendations.some((r) => r.isLoading);
+
+  const snaps: Record<string, RecommendationData[]> = {};
+
+  if (recommendations) {
+    recommendations.forEach((recommendation) => {
+      if (recommendation.data) {
+        snaps[recommendation.data.name] = recommendation.data.snaps.slice(0, 6);
+      }
+    });
+  }
 
   return (
     <>
       <Banner searchRef={searchRef} searchSummaryRef={searchSummaryRef} />
+
+      {recommendations && (
+        <>
+          {snaps.recent && (
+            <RecommendationsSection
+              snaps={snaps.recent}
+              title="Recently updated snaps"
+              isLoading={isLoading}
+            />
+          )}
+
+          {snaps.popular && (
+            <RecommendationsSection
+              snaps={snaps.popular}
+              title="Most popular snaps"
+              isLoading={isLoading}
+            />
+          )}
+
+          {snaps.trending && (
+            <RecommendationsSection
+              snaps={snaps.trending}
+              title="Trending snaps"
+              isLoading={isLoading}
+            />
+          )}
+        </>
+      )}
     </>
   );
 }

--- a/static/js/store/pages/Explore/RecommendationsSection.tsx
+++ b/static/js/store/pages/Explore/RecommendationsSection.tsx
@@ -1,0 +1,49 @@
+import { Strip, Row, Col } from "@canonical/react-components";
+import { DefaultCard } from "@canonical/store-components";
+
+import CardsLoader from "./CardsLoader";
+
+import { formatCardData } from "../../utils";
+
+import type { RecommendationData } from "../../types";
+
+type Props = {
+  isLoading: boolean;
+  snaps: RecommendationData[];
+  title: string;
+};
+
+function RecommendationsSection({
+  isLoading,
+  snaps,
+  title,
+}: Props): JSX.Element {
+  return (
+    <>
+      <Strip shallow className="u-no-padding--bottom">
+        <div className="u-fixed-width">
+          <h2>{title}</h2>
+        </div>
+      </Strip>
+      <Strip shallow>
+        {isLoading && <CardsLoader />}
+
+        {!isLoading && (
+          <Row>
+            {snaps.map((item: RecommendationData) => (
+              <Col
+                size={4}
+                key={item.details.snap_id}
+                style={{ marginBottom: "1.5rem" }}
+              >
+                <DefaultCard data={formatCardData(item)} />
+              </Col>
+            ))}
+          </Row>
+        )}
+      </Strip>
+    </>
+  );
+}
+
+export default RecommendationsSection;

--- a/static/js/store/pages/Explore/__tests__/Explore.test.tsx
+++ b/static/js/store/pages/Explore/__tests__/Explore.test.tsx
@@ -1,0 +1,97 @@
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import Explore from "../Explore";
+
+import { mockRecommendations } from "../../../test-utils";
+
+const queryClient = new QueryClient();
+
+function renderComponent() {
+  return render(
+    <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
+        <Explore />
+      </QueryClientProvider>
+      ,
+    </BrowserRouter>,
+  );
+}
+
+const handlers = [
+  http.get("https://recommendations.snapcraft.io/api/category/popular", () => {
+    return HttpResponse.json(mockRecommendations);
+  }),
+  http.get("https://recommendations.snapcraft.io/api/category/recent", () => {
+    return HttpResponse.json(mockRecommendations);
+  }),
+  http.get("https://recommendations.snapcraft.io/api/category/trending", () => {
+    return HttpResponse.json(mockRecommendations);
+  }),
+];
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("Explore", () => {
+  test("renders hero", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "The app store for Linux",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders search", () => {
+    renderComponent();
+    expect(screen.getByLabelText("Search Snapcraft")).toBeInTheDocument();
+  });
+
+  test("renders updated snaps", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", {
+          level: 2,
+          name: "Recently updated snaps",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("renders popular snaps", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 2, name: "Most popular snaps" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("renders trending snaps", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { level: 2, name: "Trending snaps" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/static/js/store/pages/Explore/__tests__/RecommendationsSection.test.tsx
+++ b/static/js/store/pages/Explore/__tests__/RecommendationsSection.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import RecommendationsSection from "../RecommendationsSection";
+
+import { mockRecommendations } from "../../../test-utils";
+
+function renderComponent(isLoading?: boolean) {
+  return render(
+    <RecommendationsSection
+      isLoading={isLoading || false}
+      snaps={mockRecommendations}
+      title="Section title"
+    />,
+  );
+}
+describe("RecommendationsSection", () => {
+  test("displays title if loading", () => {
+    renderComponent(true);
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Section title" }),
+    ).toBeInTheDocument();
+  });
+
+  test("displays title if not loading", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Section title" }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders the correct number of cards", () => {
+    renderComponent();
+    expect(
+      screen.getAllByRole("heading", { level: 2, name: /Test snap title/ }),
+    ).toHaveLength(6);
+  });
+});

--- a/static/js/store/test-utils/index.ts
+++ b/static/js/store/test-utils/index.ts
@@ -1,3 +1,4 @@
 import { testPackageData } from "./testPackageData";
+import mockRecommendations from "./mockRecommendations";
 
-export { testPackageData };
+export { mockRecommendations, testPackageData };

--- a/static/js/store/test-utils/mockRecommendations.ts
+++ b/static/js/store/test-utils/mockRecommendations.ts
@@ -1,0 +1,68 @@
+export default [
+  {
+    details: {
+      developer_validation: "starred",
+      icon: "https://example.com/icon.png",
+      snap_id: "test-snap-id-1",
+      name: "test-snap-name-1",
+      publisher: "Canonical",
+      summary: "Test snap summary 1",
+      title: "Test snap title 1",
+    },
+  },
+  {
+    details: {
+      developer_validation: "starred",
+      icon: "https://example.com/icon.png",
+      snap_id: "test-snap-id-2",
+      name: "test-snap-name-2",
+      publisher: "Canonical",
+      summary: "Test snap summary 2",
+      title: "Test snap title 2",
+    },
+  },
+  {
+    details: {
+      developer_validation: "starred",
+      icon: "https://example.com/icon.png",
+      snap_id: "test-snap-id-3",
+      name: "test-snap-name-3",
+      publisher: "Canonical",
+      summary: "Test snap summary 3",
+      title: "Test snap title 3",
+    },
+  },
+  {
+    details: {
+      developer_validation: "starred",
+      icon: "https://example.com/icon.png",
+      snap_id: "test-snap-id-4",
+      name: "test-snap-name-4",
+      publisher: "Canonical",
+      summary: "Test snap summary 4",
+      title: "Test snap title 4",
+    },
+  },
+  {
+    details: {
+      developer_validation: "starred",
+      icon: "https://example.com/icon.png",
+      snap_id: "test-snap-id-5",
+      name: "test-snap-name-5",
+      publisher: "Canonical",
+      summary: "Test snap summary 5",
+      title: "Test snap title 5",
+    },
+  },
+  {
+    details: {
+      developer_validation: "starred",
+      icon: "https://example.com/icon.png",
+      snap_id: "test-snap-id-6",
+      name: "test-snap-name-6",
+      publisher: "Canonical",
+      summary: "Test snap summary 6",
+      title: "Test snap title 6",
+    },
+  },
+];

--- a/static/js/store/types/CardData.ts
+++ b/static/js/store/types/CardData.ts
@@ -1,0 +1,13 @@
+export type CardData = {
+  package: {
+    description: string;
+    display_name: string;
+    icon_url: string;
+    name: string;
+  };
+  publisher: {
+    display_name: string;
+    name: string;
+    validation: string;
+  };
+};

--- a/static/js/store/types/RecommendationData.ts
+++ b/static/js/store/types/RecommendationData.ts
@@ -1,0 +1,11 @@
+export type RecommendationData = {
+  details: {
+    developer_validation: string;
+    icon: string;
+    snap_id: string;
+    name: string;
+    publisher: string;
+    summary: string;
+    title: string;
+  };
+};

--- a/static/js/store/types/index.ts
+++ b/static/js/store/types/index.ts
@@ -1,5 +1,7 @@
+import type { CardData } from "./CardData";
 import type { Category } from "./Category";
 import type { Package } from "./Package";
 import type { Packages } from "./Packages";
+import type { RecommendationData } from "./RecommendationData";
 
-export type { Category, Package, Packages };
+export type { CardData, Category, Package, Packages, RecommendationData };

--- a/static/js/store/utils/__tests__/formatCardData.test.ts
+++ b/static/js/store/utils/__tests__/formatCardData.test.ts
@@ -1,0 +1,31 @@
+import formatCardData from "../formatCardData";
+
+const mockRecommendationData = {
+  details: {
+    developer_validation: "starred",
+    icon: "https://example.com/icon.png",
+    snap_id: "test-snap-id",
+    name: "test-snap-name",
+    publisher: "Canonical",
+    summary: "Test snap summary",
+    title: "Test snap title",
+  },
+};
+
+describe("formatCardData", () => {
+  test("formats recommendation data into card data format", () => {
+    expect(formatCardData(mockRecommendationData)).toEqual({
+      package: {
+        description: "Test snap summary",
+        display_name: "Test snap title",
+        icon_url: "https://example.com/icon.png",
+        name: "test-snap-name",
+      },
+      publisher: {
+        display_name: "Canonical",
+        name: "Canonical",
+        validation: "starred",
+      },
+    });
+  });
+});

--- a/static/js/store/utils/formatCardData.ts
+++ b/static/js/store/utils/formatCardData.ts
@@ -1,0 +1,19 @@
+import type { CardData, RecommendationData } from "../types";
+
+function formatCardData(data: RecommendationData): CardData {
+  return {
+    package: {
+      description: data.details.summary,
+      display_name: data.details.title,
+      icon_url: data.details.icon,
+      name: data.details.name,
+    },
+    publisher: {
+      display_name: data.details.publisher,
+      name: data.details.publisher,
+      validation: data.details.developer_validation,
+    },
+  };
+}
+
+export default formatCardData;

--- a/static/js/store/utils/index.ts
+++ b/static/js/store/utils/index.ts
@@ -1,4 +1,5 @@
+import formatCardData from "./formatCardData";
 import getArchitectures from "./getArchitectures";
 import getCategoryOrder from "./getCategoryOrder";
 
-export { getArchitectures, getCategoryOrder };
+export { formatCardData, getArchitectures, getCategoryOrder };

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -102,6 +102,7 @@ CSP = {
         "*.crazyegg.com",
         "www.facebook.com",
         "px.ads.linkedin.com",
+        "*.snapcraft.io",
     ],
     "frame-src": [
         "'self'",


### PR DESCRIPTION
## Done
Adds a recommendations section component to show recommendation categories

## How to QA
- Go to https://snapcraft-io-5173.demos.haus/explore
- Check that there is a section for "Recently updated snaps"
- Check that there is a section for "Most popular snaps"
- Check that there is a section for "Trending snaps"

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes:
- https://warthogs.atlassian.net/browse/WD-22662
- https://warthogs.atlassian.net/browse/WD-22663
- https://warthogs.atlassian.net/browse/WD-22664