### PR TITLE
redirects: add 'supported extensions' for snapcraft

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -72,6 +72,7 @@ docs/debugging-building-snaps/?: https://documentation.ubuntu.com/snapcraft/stab
 docs/linters-classic/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-classic-linter/
 docs/linters-library/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/debugging/use-the-library-linter/
 docs/snapcraft-extensions/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/extensions/
+docs/supported-extensions/?: https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/
 docs/cross-compile-an-autotools-project/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-a-cross-compiled-app/
 docs/dotnet-apps/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-a-dotnet-app/
 docs/flutter-applications/?: https://documentation.ubuntu.com/snapcraft/stable/how-to/integrations/craft-a-flutter-app/


### PR DESCRIPTION
## Done

## How to QA

Test if https://snapcraft.io/docs/supported-extensions redirects to https://documentation.ubuntu.com/snapcraft/stable/reference/extensions/

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): change to production