### PR TITLE
fix: Adds border radius to right edge of progressive chart

### DIFF
--- a/static/sass/_snapcraft_release.scss
+++ b/static/sass/_snapcraft_release.scss
@@ -882,8 +882,7 @@
 
   .progressive-progress-bar__inner {
     background-color: #652466;
-    border-bottom-left-radius: 10px;
-    border-top-left-radius: 10px;
+    border-radius: 10px;
     height: 10px;
 
     .previous-progressive-progress-chart & {


### PR DESCRIPTION
## Done

Fixes issue where progressive releases chart has a square edge instead of rounded

## How to QA
- Go to https://snapcraft-io-5184.demos.haus/snapd/releases
- Expand a cell containing a progressive release
- Check that the right edge of the green progressive bar is rounded

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual fix

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-22660

## Screenshots

### Before

<img width="1403" alt="451890909-e39e9160-0e74-470e-af8d-c0f05913f66e" src="https://github.com/user-attachments/assets/9fcd8fee-8b51-4d13-89fa-90ba9ea21d99" />

### After

![Screenshot 2025-06-27 at 10 51 04](https://github.com/user-attachments/assets/9beeaa34-faeb-4a4f-80c4-0aaadb6132c3)
