### PR TITLE
fix(release ui): update all data on successful release

### DIFF
--- a/static/js/publisher/pages/Releases/actions/__tests__/releases.test.js
+++ b/static/js/publisher/pages/Releases/actions/__tests__/releases.test.js
@@ -304,11 +304,6 @@ describe("releases actions", () => {
     });
 
     it("should remove progressive release if percentage is 100", () => {
-      const revision = {
-        architectures: ["amd64"],
-        revision: 3,
-      };
-
       const release = {
         architecture: "amd64",
         branch: null,
@@ -316,6 +311,12 @@ describe("releases actions", () => {
         risk: "edge",
         track: "latest",
       };
+
+      const revision = {
+        architectures: ["amd64"],
+        revision: 3,
+      };
+
       const store = mockStore({
         options: {
           snapName: "test",
@@ -366,8 +367,21 @@ describe("releases actions", () => {
         // fetchReleasesHistory API Response
         .mockResolvedValueOnce({
           json: () => ({
-            releases: [release],
-            revisions: [revision],
+            data: {
+              release_history: {
+                releases: [release],
+                revisions: [revision],
+              },
+              channel_map: [
+                {
+                  channel: "edge",
+                  info: "specific",
+                  revision: 3,
+                  version: "test",
+                  architecture: "amd64",
+                },
+              ],
+            },
           }),
         });
 
@@ -403,6 +417,23 @@ describe("releases actions", () => {
               architectures: ["amd64"],
             },
             type: "UPDATE_ARCHITECTURES",
+          },
+          {
+            payload: {
+              channelMap: {
+                edge: {
+                  amd64: {
+                    architectures: ["amd64"],
+                    channels: ["latest/edge"],
+                    expiration: undefined,
+                    progressive: undefined,
+                    prog_channels: [],
+                    revision: 3,
+                  },
+                },
+              },
+            },
+            type: "INIT_CHANNEL_MAP",
           },
           {
             type: "CANCEL_PENDING_RELEASES",
@@ -445,7 +476,6 @@ describe("releases actions", () => {
         architectures: ["amd64"],
         revision: 3,
       };
-
       const release = {
         architecture: "amd64",
         branch: null,
@@ -483,7 +513,6 @@ describe("releases actions", () => {
         },
         architectures: [],
       });
-
       global.fetch = jest
         .fn()
         // fetchReleases API Response
@@ -499,6 +528,7 @@ describe("releases actions", () => {
                       info: "specific",
                       revision: 3,
                       version: "test",
+                      architecture: "amd64",
                     },
                   ],
                 },
@@ -516,8 +546,21 @@ describe("releases actions", () => {
         // fetchReleasesHistory API Response
         .mockResolvedValueOnce({
           json: () => ({
-            releases: [release],
-            revisions: [revision],
+            data: {
+              release_history: {
+                releases: [release],
+                revisions: [revision],
+              },
+              channel_map: [
+                {
+                  channel: "edge",
+                  info: "specific",
+                  revision: 3,
+                  version: "test",
+                  architecture: "amd64",
+                },
+              ],
+            },
           }),
         });
 
@@ -559,6 +602,23 @@ describe("releases actions", () => {
               architectures: ["amd64"],
             },
             type: "UPDATE_ARCHITECTURES",
+          },
+          {
+            payload: {
+              channelMap: {
+                edge: {
+                  amd64: {
+                    architectures: ["amd64"],
+                    channels: ["latest/edge"],
+                    expiration: undefined,
+                    progressive: undefined,
+                    prog_channels: ["latest/edge"],
+                    revision: 3,
+                  },
+                },
+              },
+            },
+            type: "INIT_CHANNEL_MAP",
           },
           {
             type: "CANCEL_PENDING_RELEASES",

--- a/static/js/publisher/pages/Releases/actions/releases.ts
+++ b/static/js/publisher/pages/Releases/actions/releases.ts
@@ -6,36 +6,69 @@ import {
 import { updateArchitectures } from "./architectures";
 import { hideNotification, showNotification } from "./globalNotification";
 import { cancelPendingReleases } from "./pendingReleases";
-import { releaseRevisionSuccess, closeChannelSuccess } from "./channelMap";
+import {
+  releaseRevisionSuccess,
+  closeChannelSuccess,
+  initChannelMap,
+} from "./channelMap";
 import { updateRevisions } from "./revisions";
 import { closeHistory } from "./history";
 
 import {
-  fetchReleasesHistory,
+  fetchSnapReleaseStatus,
   fetchReleases,
   fetchCloses,
 } from "../api/releases";
 
-import { getRevisionsMap, initReleasesData } from "../releasesState";
+import {
+  getReleaseDataFromChannelMap,
+  getRevisionsMap,
+  initReleasesData,
+} from "../releasesState";
 
 export const UPDATE_RELEASES = "UPDATE_RELEASES";
 
-function updateReleasesData(releasesData: { revisions: any; releases: any }) {
+interface FetchReleaseResponse {
+  data: {
+    release_history: {
+      revisions: any[];
+      releases: any[];
+    };
+    channel_map: any;
+    snap_name: string;
+  };
+}
+
+function updateReleasesData(apiData: FetchReleaseResponse) {
+  const {
+    release_history: releasesData,
+    channel_map: channelMap,
+    snap_name: snapName,
+  } = apiData.data;
   return (
     dispatch: (arg0: {
       type: string;
       payload:
         | { releases: any }
         | { revisions: any }
-        | { architectures: any[] };
+        | { architectures: any[] }
+        | { channelMap: any };
     }) => void,
   ) => {
-    // init channel data in revisions list
-    const revisionsMap = getRevisionsMap(releasesData.revisions);
-    initReleasesData(revisionsMap, releasesData.releases);
-    dispatch(updateRevisions(revisionsMap));
-    dispatch(updateReleases(releasesData.releases));
-    dispatch(updateArchitectures(releasesData.revisions));
+    const revisionsList = releasesData.revisions;
+    const releases = releasesData.releases;
+
+    getReleaseDataFromChannelMap(channelMap, revisionsList, snapName).then(
+      ([transformedChannelMap, revisionsListAdditions]) => {
+        revisionsList.push(...revisionsListAdditions);
+        const revisionsMap = getRevisionsMap(revisionsList);
+        initReleasesData(revisionsMap, releases);
+        dispatch(updateRevisions(revisionsMap));
+        dispatch(updateReleases(releases));
+        dispatch(updateArchitectures(revisionsList));
+        dispatch(initChannelMap(transformedChannelMap));
+      },
+    );
   };
 }
 
@@ -225,8 +258,10 @@ export function releaseRevisions() {
       .then(() =>
         fetchCloses(_handleCloseResponse, csrfToken, snapName, pendingCloses),
       )
-      .then(() => fetchReleasesHistory(csrfToken, snapName))
-      .then((json) => dispatch(updateReleasesData(json)))
+      .then(() => fetchSnapReleaseStatus(csrfToken, snapName))
+      .then((json) =>
+        dispatch(updateReleasesData(json as unknown as FetchReleaseResponse)),
+      )
       .catch((error) =>
         dispatch(
           showNotification({

--- a/static/js/publisher/pages/Releases/api/releases.js
+++ b/static/js/publisher/pages/Releases/api/releases.js
@@ -21,8 +21,8 @@ export function fetchReleases(onComplete, releases, csrfToken, snapName) {
   return queue;
 }
 
-export function fetchReleasesHistory(csrfToken, snapName) {
-  return fetch(`/${snapName}/releases/json`, {
+export function fetchSnapReleaseStatus(csrfToken, snapName) {
+  return fetch(`/api/${snapName}/releases`, {
     method: "GET",
     mode: "cors",
     cache: "no-cache",

--- a/static/js/publisher/pages/Releases/releasesController.js
+++ b/static/js/publisher/pages/Releases/releasesController.js
@@ -35,7 +35,7 @@ const ReleasesController = ({
   useEffect(() => {
     getReleaseDataFromChannelMap(channelMap, revisionsList, snapName).then(
       ([transformedChannelMap, revisionsListAdditions]) => {
-        Array.prototype.push.apply(revisionsList, revisionsListAdditions);
+        revisionsList.push(...revisionsListAdditions);
         const revisionsMap = getRevisionsMap(revisionsList);
 
         initReleasesData(revisionsMap, releasesData.releases);


### PR DESCRIPTION
## Done
- Update the `updateReleasesData` to pull all information to reinitialize all state . This also ensures that the whole UI get's rerendered, fixing edge-cases where certain elements were not updated due to using selectors, which are memoized and do not always cause a rerender.
- Related to the point above, used the main `/api/<snap_name>/releases` endpoint instead of `/<snap_name>/releases/json` endpoint in `fetchReleasesHistory` (renamed to `fetchSnapReleaseStatus`) when a release has been made. Again, this ensure all state is up to date.

## How to QA
- Use the release ui as normal - there should be no obvious changes
- The tests should continue to pass

## Testing
- [x] This PR has tests - updated tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
