### PR TITLE
fix: use global csrf token

### DIFF
--- a/static/js/publisher/pages/Releases/Releases.tsx
+++ b/static/js/publisher/pages/Releases/Releases.tsx
@@ -55,7 +55,6 @@ function Releases(): React.JSX.Element {
           channelMap={data.channel_map}
           tracks={data.tracks}
           options={{
-            csrfToken: window.CSRF_TOKEN,
             defaultTrack: data.default_track,
             flags: {
               isProgressiveReleaseEnabled: true,

--- a/static/js/publisher/pages/Releases/actions/__tests__/releases.test.js
+++ b/static/js/publisher/pages/Releases/actions/__tests__/releases.test.js
@@ -215,7 +215,6 @@ describe("releases actions", () => {
       const store = mockStore({
         options: {
           snapName: "test",
-          csrfToken: "test",
           defaultTrack: "latest",
         },
         pendingReleases: {
@@ -249,7 +248,6 @@ describe("releases actions", () => {
       const store = mockStore({
         options: {
           snapName: "test",
-          csrfToken: "test",
           defaultTrack: "latest",
         },
         pendingReleases: {
@@ -320,7 +318,6 @@ describe("releases actions", () => {
       const store = mockStore({
         options: {
           snapName: "test",
-          csrfToken: "test",
           defaultTrack: "latest",
         },
         pendingReleases: {
@@ -449,7 +446,6 @@ describe("releases actions", () => {
       const store = mockStore({
         options: {
           snapName: "test",
-          csrfToken: "test",
           defaultTrack: "latest",
         },
         pendingReleases: {},
@@ -491,7 +487,6 @@ describe("releases actions", () => {
       const store = mockStore({
         options: {
           snapName: "test",
-          csrfToken: "test",
           defaultTrack: "latest",
         },
         pendingReleases: {

--- a/static/js/publisher/pages/Releases/actions/defaultTrack.js
+++ b/static/js/publisher/pages/Releases/actions/defaultTrack.js
@@ -6,7 +6,7 @@ import { showNotification } from "./globalNotification";
 export const SET_DEFAULT_TRACK_SUCCESS = "SET_DEFAULT_TRACK_SUCCESS";
 export const SET_DEFAULT_TRACK_FAILURE = "SET_DEFAULT_TRACK_FAILURE";
 
-const fetchDefaultTrack = (snapName, csrfToken, track) => {
+const fetchDefaultTrack = (snapName, track) => {
   return fetch(`/${snapName}/releases/default-track`, {
     method: "POST",
     mode: "cors",
@@ -14,7 +14,7 @@ const fetchDefaultTrack = (snapName, csrfToken, track) => {
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      "X-CSRFToken": csrfToken,
+      "X-CSRFToken": window.CSRF_TOKEN,
     },
     redirect: "follow",
     referrer: "no-referrer",
@@ -30,9 +30,9 @@ const fetchDefaultTrack = (snapName, csrfToken, track) => {
 export function clearDefaultTrack() {
   return (dispatch, getState) => {
     const { options } = getState();
-    const { snapName, csrfToken } = options;
+    const { snapName } = options;
 
-    return fetchDefaultTrack(snapName, csrfToken, null).then(() => {
+    return fetchDefaultTrack(snapName, null).then(() => {
       dispatch({
         type: SET_DEFAULT_TRACK_SUCCESS,
         payload: null,
@@ -55,9 +55,9 @@ export function clearDefaultTrack() {
 export function setDefaultTrack() {
   return (dispatch, getState) => {
     const { options, currentTrack } = getState();
-    const { snapName, csrfToken } = options;
+    const { snapName } = options;
 
-    return fetchDefaultTrack(snapName, csrfToken, currentTrack)
+    return fetchDefaultTrack(snapName, currentTrack)
       .then(() => {
         dispatch({
           type: SET_DEFAULT_TRACK_SUCCESS,

--- a/static/js/publisher/pages/Releases/actions/releases.ts
+++ b/static/js/publisher/pages/Releases/actions/releases.ts
@@ -203,7 +203,7 @@ export function releaseRevisions() {
     },
   ) => {
     const { pendingReleases, pendingCloses, revisions, options } = getState();
-    const { csrfToken, snapName } = options;
+    const { snapName } = options;
 
     // To dedupe releases
     const progressiveReleases: {
@@ -254,11 +254,11 @@ export function releaseRevisions() {
     };
 
     dispatch(hideNotification());
-    return fetchReleases(_handleReleaseResponse, releases, csrfToken, snapName)
+    return fetchReleases(_handleReleaseResponse, releases, snapName)
       .then(() =>
-        fetchCloses(_handleCloseResponse, csrfToken, snapName, pendingCloses),
+        fetchCloses(_handleCloseResponse, snapName, pendingCloses),
       )
-      .then(() => fetchSnapReleaseStatus(csrfToken, snapName))
+      .then(() => fetchSnapReleaseStatus(snapName))
       .then((json) =>
         dispatch(updateReleasesData(json as unknown as FetchReleaseResponse)),
       )

--- a/static/js/publisher/pages/Releases/api/releases.js
+++ b/static/js/publisher/pages/Releases/api/releases.js
@@ -2,14 +2,13 @@ import "whatwg-fetch";
 
 import { DEFAULT_ERROR_MESSAGE as ERROR_MESSAGE } from "../constants";
 
-export function fetchReleases(onComplete, releases, csrfToken, snapName) {
+export function fetchReleases(onComplete, releases, snapName) {
   let queue = Promise.resolve(); // Q() in q
 
   // handle releases as a queue
   releases.forEach((release) => {
     return (queue = queue.then(() => {
       return fetchRelease(
-        csrfToken,
         snapName,
         release.id,
         release.channels,
@@ -21,7 +20,7 @@ export function fetchReleases(onComplete, releases, csrfToken, snapName) {
   return queue;
 }
 
-export function fetchSnapReleaseStatus(csrfToken, snapName) {
+export function fetchSnapReleaseStatus(snapName) {
   return fetch(`/api/${snapName}/releases`, {
     method: "GET",
     mode: "cors",
@@ -29,7 +28,7 @@ export function fetchSnapReleaseStatus(csrfToken, snapName) {
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      "X-CSRFToken": csrfToken,
+      "X-CSRFToken": window.CSRF_TOKEN,
     },
     redirect: "follow",
     referrer: "no-referrer",
@@ -41,7 +40,6 @@ export function fetchSnapReleaseStatus(csrfToken, snapName) {
 }
 
 export function fetchRelease(
-  csrfToken,
   snapName,
   revision,
   channels,
@@ -64,7 +62,7 @@ export function fetchRelease(
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      "X-CSRFToken": csrfToken,
+      "X-CSRFToken": window.CSRF_TOKEN,
     },
     redirect: "follow",
     referrer: "no-referrer",
@@ -76,9 +74,9 @@ export function fetchRelease(
     });
 }
 
-export function fetchCloses(onComplete, csrfToken, snapName, channels) {
+export function fetchCloses(onComplete, snapName, channels) {
   if (channels && channels.length) {
-    return fetchClose(csrfToken, snapName, channels).then((json) => {
+    return fetchClose(snapName, channels).then((json) => {
       onComplete(json, channels);
     });
   } else {
@@ -86,7 +84,7 @@ export function fetchCloses(onComplete, csrfToken, snapName, channels) {
   }
 }
 
-export function fetchClose(csrfToken, snapName, channels) {
+export function fetchClose(snapName, channels) {
   return fetch(`/${snapName}/releases/close-channel`, {
     method: "POST",
     mode: "cors",
@@ -94,7 +92,7 @@ export function fetchClose(csrfToken, snapName, channels) {
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json; charset=utf-8",
-      "X-CSRFToken": csrfToken,
+      "X-CSRFToken": window.CSRF_TOKEN,
     },
     redirect: "follow",
     referrer: "no-referrer",

--- a/static/js/publisher/pages/Releases/components/defaultTrackModifier.js
+++ b/static/js/publisher/pages/Releases/components/defaultTrackModifier.js
@@ -138,7 +138,6 @@ DefaultTrackModifier.propTypes = {
   openModal: PropTypes.func.isRequired,
   showNotification: PropTypes.func.isRequired,
   latestTrackRevisions: PropTypes.array.isRequired,
-  csrfToken: PropTypes.string.isRequired,
   snapName: PropTypes.string.isRequired,
 };
 
@@ -146,7 +145,6 @@ const mapStateToProps = (state) => ({
   currentTrack: state.currentTrack,
   tracks: getTracks(state),
   latestTrackRevisions: getTrackRevisions(state, "latest"),
-  csrfToken: state.options.csrfToken,
   snapName: state.options.snapName,
   defaultTrack: state.defaultTrack,
 });

--- a/static/js/publisher/types/releaseTypes.ts
+++ b/static/js/publisher/types/releaseTypes.ts
@@ -85,7 +85,6 @@ export type ChannelMap = {
 
 export type Options = {
   defaultTrack: string;
-  csrfToken: string;
   flags: {
     isProgressiveReleaseEnabled: boolean;
   };


### PR DESCRIPTION
## Done
- Removed csrfToken from the store
- Removed code that was passing csrfToken around as a parameter
- Where csrf token is needed, change to `window.CSRF_TOKEN`

## How to QA
- Load the release ui and use it as normal.
- You should be able to release revision without CSRF issues.

## Testing
- [x] This PR has tests - updated tests
- [ ] No testing required (explain why):

## Issue / Card
https://warthogs.atlassian.net/browse/WD-23299

## Screenshots
