### PR TITLE
feat: allow progressive rerelease

### DIFF
--- a/static/js/publisher/pages/Releases/actions/releases.ts
+++ b/static/js/publisher/pages/Releases/actions/releases.ts
@@ -255,9 +255,7 @@ export function releaseRevisions() {
 
     dispatch(hideNotification());
     return fetchReleases(_handleReleaseResponse, releases, snapName)
-      .then(() =>
-        fetchCloses(_handleCloseResponse, snapName, pendingCloses),
-      )
+      .then(() => fetchCloses(_handleCloseResponse, snapName, pendingCloses))
       .then(() => fetchSnapReleaseStatus(snapName))
       .then((json) =>
         dispatch(updateReleasesData(json as unknown as FetchReleaseResponse)),

--- a/static/js/publisher/pages/Releases/api/releases.js
+++ b/static/js/publisher/pages/Releases/api/releases.js
@@ -39,12 +39,7 @@ export function fetchSnapReleaseStatus(snapName) {
     });
 }
 
-export function fetchRelease(
-  snapName,
-  revision,
-  channels,
-  progressive,
-) {
+export function fetchRelease(snapName, revision, channels, progressive) {
   const body = {
     name: snapName,
     revision,

--- a/static/js/publisher/pages/Releases/components/releasesTable/cellViews.js
+++ b/static/js/publisher/pages/Releases/components/releasesTable/cellViews.js
@@ -72,7 +72,6 @@ const ProgressiveTooltip = ({ revision, previousRevision }) => {
 
   if (!progressive) {
     return;
-
   }
 
   const previousRevisionData = (

--- a/static/js/publisher/pages/Releases/components/releasesTable/channelHeading.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/channelHeading.tsx
@@ -48,7 +48,6 @@ const disabledBecauseReleased = "The same revisions are already promoted.";
 
 const disabledBecauseNotSelected = "Select some revisions to promote them.";
 
-// TODO: move to selectors or helpers?
 const canReleaseToChannel = (
   currentRevisionsByArch: { [x: string]: { revision: any } },
   targetRevisionsByArch: { [x: string]: { revision: any; releases: any } },

--- a/static/js/publisher/pages/Releases/components/releasesTable/droppableRow.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/droppableRow.tsx
@@ -9,7 +9,12 @@ import { triggerGAEvent } from "../../actions/gaEventTracking";
 
 import { STABLE, CANDIDATE, BETA, EDGE } from "../../constants";
 
-import { getChannelName, isInDevmode, canBeReleased } from "../../helpers";
+import {
+  getChannelName,
+  isInDevmode,
+  canBeReleased,
+  getLatestRelease,
+} from "../../helpers";
 
 import ReleasesTableChannelRow from "./channelRow";
 
@@ -26,8 +31,16 @@ const getRevisionsToDrop = (
       if (!targetChannelArchs || !targetChannelArchs[arch]) {
         return true;
       } else {
+        const isProgressive = getLatestRelease(
+          targetChannelArchs[arch],
+          targetChannel,
+        )?.isProgressive;
         // if different revision released to an arch
-        if (revision.revision !== targetChannelArchs[arch].revision) {
+        // or if the current release in the target arch is progressive
+        if (
+          revision.revision !== targetChannelArchs[arch].revision ||
+          isProgressive
+        ) {
           return true;
         }
       }

--- a/static/js/publisher/pages/Releases/components/releasesTable/row.tsx
+++ b/static/js/publisher/pages/Releases/components/releasesTable/row.tsx
@@ -6,17 +6,22 @@ import { getRevisionsArchitectures } from "../../helpers";
 import ReleasesTableChannelHeading from "./channelHeading";
 
 // generic releases table row component
-const ReleasesTableRow = (props: {
-  canDrag?: any;
+const ReleasesTableRow = ({
+  canDrag = true,
+  risk,
+  branch,
+  revisions,
+  canDrop,
+  children,
+}: {
+  canDrag: boolean;
   risk?: any;
   branch?: any;
   revisions?: any;
   canDrop?: any;
   children?: any;
 }) => {
-  const { risk, branch, revisions, canDrop, children } = props;
-
-  const canDrag = !!revisions && props.canDrag;
+  canDrag = !!revisions && canDrag;
 
   const draggedRevisions = canDrag ? Object.values(revisions) : [];
 
@@ -67,10 +72,6 @@ const ReleasesTableRow = (props: {
       {children}
     </div>
   );
-};
-
-ReleasesTableRow.defaultProps = {
-  canDrag: true,
 };
 
 export default ReleasesTableRow;

--- a/static/js/publisher/pages/Releases/helpers.ts
+++ b/static/js/publisher/pages/Releases/helpers.ts
@@ -47,6 +47,21 @@ export function getRevisionsArchitectures(revisions: any[]) {
   return archs;
 }
 
+export function getLatestRelease(
+  revision: { releases?: any[] },
+  channel: string,
+) {
+  const releases = revision.releases;
+  if (!releases) {
+    return null;
+  }
+  const filteredReleases = releases.filter((r: any) => r.channel === channel);
+  if (filteredReleases.length === 0) {
+    return null;
+  }
+  return filteredReleases[0];
+}
+
 export function isSameVersion(revisions: { version: string }[]) {
   let hasSameVersion = false;
   const versionsMap: any = {};


### PR DESCRIPTION
## Done
- Allow releasing the same revision over a progressive release.
- This enables progressive release updates (from 30% -> 50% -> 100% for example).

## How to QA
- Create a progressive release, with a revision, create a non-progressive release with the same revision
- Ensure that dragging the revision to the progressive release is allowed, and to the non-progressive release is not allowed
- Test the channel "promote" drop down, revision "promote" drop down, and dagging both a revision and channel all work as expected.

## Testing
- [] This PR has tests
- [x] No testing required (explain why): test coverage provided in previous PRs

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23302

## Screenshots
