### PR TITLE
fix:Added handlers for errors separately

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==6.2.0
 canonicalwebteam.blog==6.4.6
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.6.0
-canonicalwebteam.store-api==6.5.0
+canonicalwebteam.store-api==6.6.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==6.2.0
 canonicalwebteam.blog==6.4.6
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.6.0
-canonicalwebteam.store-api==6.4.0
+canonicalwebteam.store-api==6.5.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0

--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -87,7 +87,10 @@ class TestGetPackageMetadata(BaseTestCases):
             [
                 {
                     "code": "permission-required",
-                    "message": "No publisher or collaborator permission for the teams-for-linux snap package",
+                    "message": (
+                        "No publisher or collaborator "
+                        "permission for the teams-for-linux snap package"
+                    ),
                 }
             ],
         )

--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -87,7 +87,7 @@ class TestGetPackageMetadata(BaseTestCases):
             [
                 {
                     "code": "permission-required",
-                    "message": "No publisher or collaborator permission for the teams-for-linux snap package"
+                    "message": "No publisher or collaborator permission for the teams-for-linux snap package",
                 }
-            ]
+            ],
         )

--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -4,6 +4,7 @@ from tests.publisher.endpoint_testing import BaseTestCases
 from canonicalwebteam.exceptions import (
     StoreApiResourceNotFound,
     StoreApiResponseErrorList,
+    StoreApiError,
 )
 
 # Make sure tests fail on stray responses.

--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -119,3 +119,25 @@ class TestGetPackageMetadata(BaseTestCases):
                 "success": False,
             },
         )
+
+    @responses.activate
+    @patch(
+        "canonicalwebteam.store_api.publishergw."
+        "PublisherGW.get_package_metadata"
+    )
+    def test_api_error(self, mock_get_package_metadata):
+        mock_get_package_metadata.side_effect = StoreApiError()
+
+        self.client.set_session_data(
+            {"publisher": {"nickname": "test_username"}}
+        )
+
+        response = self.client.get("/api/packages/test_snap")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json,
+            {
+                "error": "Error occurred while fetching snap metadata.",
+                "success": False,
+            },
+        )

--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -86,11 +86,36 @@ class TestGetPackageMetadata(BaseTestCases):
             403,
             [
                 {
-                    "code": "permission-required",
-                    "message": (
-                        "No publisher or collaborator "
-                        "permission for the teams-for-linux snap package"
-                    ),
-                }
+                    "code": "error-code-1",
+                    "message": "error 1",
+                },
+                {
+                    "code": "error-code-2",
+                    "message": "error 2",
+                },
             ],
+        )
+
+        self.client.set_session_data(
+            {"publisher": {"nickname": "test_username"}}
+        )
+
+        response = self.client.get("/api/packages/test_snap")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            response.json,
+            {
+                "error": "Error occurred while fetching snap metadata.",
+                "errors": [
+                    {
+                        "code": "error-code-1",
+                        "message": "error 1",
+                    },
+                    {
+                        "code": "error-code-2",
+                        "message": "error 2",
+                    },
+                ],
+                "success": False,
+            },
         )

--- a/tests/publisher/tests_get_package_metadata.py
+++ b/tests/publisher/tests_get_package_metadata.py
@@ -1,6 +1,10 @@
 import responses
 from unittest.mock import patch
 from tests.publisher.endpoint_testing import BaseTestCases
+from canonicalwebteam.exceptions import (
+    StoreApiResourceNotFound,
+    StoreApiResponseErrorList,
+)
 
 # Make sure tests fail on stray responses.
 responses.mock.assert_all_requests_are_fired = True
@@ -49,4 +53,41 @@ class TestGetPackageMetadata(BaseTestCases):
             self.client.session,
             "snap",
             snap_name,
+        )
+
+    @responses.activate
+    @patch(
+        "canonicalwebteam.store_api.publishergw."
+        "PublisherGW.get_package_metadata"
+    )
+    def test_package_not_found(self, mock_get_package_metadata):
+        mock_get_package_metadata.side_effect = StoreApiResourceNotFound()
+
+        self.client.set_session_data(
+            {"publisher": {"nickname": "test_username"}}
+        )
+
+        response = self.client.get("/api/packages/test_snap")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json,
+            {"error": "Package not found", "success": False},
+        )
+
+    @responses.activate
+    @patch(
+        "canonicalwebteam.store_api.publishergw."
+        "PublisherGW.get_package_metadata"
+    )
+    def test_api_error_with_list(self, mock_get_package_metadata):
+        mock_get_package_metadata.side_effect = StoreApiResponseErrorList(
+            "The api returned a list of errors",
+            403,
+            [
+                {
+                    "code": "permission-required",
+                    "message": "No publisher or collaborator permission for the teams-for-linux snap package"
+                }
+            ]
         )

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -453,7 +453,7 @@ def get_package_metadata(snap_name):
             ),
             error.status_code,
         )
-    except StoreApiError as api_error:
+    except StoreApiError:
         return (
             jsonify(
                 {

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -6,6 +6,7 @@ from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import (
     StoreApiError,
     StoreApiResponseErrorList,
+    StoreApiResponseError,
     StoreApiResourceNotFound,
 )
 from flask.json import jsonify
@@ -448,6 +449,16 @@ def get_package_metadata(snap_name):
                 {
                     "error": "Error occurred while fetching snap metadata.",
                     "errors": error.errors,
+                    "success": False,
+                }
+            ),
+            error.status_code,
+        )
+    except StoreApiResponseError as error:
+        return (
+            jsonify(
+                {
+                    "error": "Error occurred while fetching snap metadata.",
                     "success": False,
                 }
             ),

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -6,6 +6,7 @@ from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import (
     StoreApiError,
     StoreApiResponseErrorList,
+    StoreApiResourceNotFound,
 )
 from flask.json import jsonify
 
@@ -438,13 +439,20 @@ def get_package_metadata(snap_name):
         package_metadata = publisher_gateway.get_package_metadata(
             flask.session, snap_name
         )
-
         return jsonify({"data": package_metadata, "success": True})
-    except StoreApiError:
+    except StoreApiResourceNotFound:
+        return (jsonify({"error": "Package not found", "success": False}), 404)
+    except StoreApiResponseErrorList as error:
         return (
-            jsonify({"error": "Package metadata not found", "success": False}),
-            404,
+            jsonify(
+                {"error": str(error), "errors": error.errors, "success": False}
+            ),
+            error.status_code,
         )
+    except StoreApiError as api_error:
+        return (jsonify({"error": str(api_error), "success": False}), 500)
+    except Exception:
+        return (jsonify({"error": "Unexpected error", "success": False}), 500)
 
 
 @publisher_snaps.route("/packages/<package_name>", methods=["DELETE"])

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -445,12 +445,24 @@ def get_package_metadata(snap_name):
     except StoreApiResponseErrorList as error:
         return (
             jsonify(
-                {"error": str(error), "errors": error.errors, "success": False}
+                {
+                    "error": "Error occurred while fetching snap metadata.",
+                    "errors": error.errors,
+                    "success": False,
+                }
             ),
             error.status_code,
         )
     except StoreApiError as api_error:
-        return (jsonify({"error": str(api_error), "success": False}), 500)
+        return (
+            jsonify(
+                {
+                    "error": "Error occurred while fetching snap metadata.",
+                    "success": False,
+                }
+            ),
+            500,
+        )
     except Exception:
         return (jsonify({"error": "Unexpected error", "success": False}), 500)
 


### PR DESCRIPTION
## Done
Added handlers for errors separately  for 
/api/packages/<snap_name> endpoint returns 500 with " metadata cannot be fetched" error. 
[ttps://snapcraft.io/api/packages/teams-for-linux](https://sentry.is.canonical.com/canonical/snapcraft-io/?query=url%3A%22https%3A%2F%2Fsnapcraft.io%2Fapi%2Fpackages%2Fteams-for-linux%22)

## How to QA
- go to 'https://snapcraft-io-5196.demos.haus/api/packages/some-random-snap-24525235'
- verify the response returns: {"error":"Package not found","success":false}
- go to the same url with the snap id that you have access to 'https://snapcraft-io-5196.demos.haus/api/packages/(your-snap-id)'
- verify the metadata returns
- go to the same url with the snap id that you DONT have access to 'https://snapcraft-io-5196.demos.haus/api/packages/teams-for-linux'
- verify 401 is returned

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-13136
](https://warthogs.atlassian.net/browse/WD-13136?atlOrigin=eyJpIjoiNWE4ZGI2NjBkY2Q2NGIxZmE5MGExY2JhOWI5MDk4NjAiLCJwIjoiaiJ9)
## Screenshots
