### PR TITLE
Update openSUSE snapd repository installation instructions.

### DIFF
--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -9,12 +9,20 @@ install:
       Snap can be installed from the command line on openSUSE Leap 15.x and Tumbleweed.
   -
     action: |
-      You need first add the <em>snappy</em> repository from the terminal. Leap 15.2 users, for example, can do this with the following command:
-    command: |
-      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.2 snappy
+      You need first add the <em>snappy</em> repository from the terminal. Choose the appropriate command depending on your installed openSUSE flavor.
   -
     action: |
-      Swap out <code>openSUSE_Leap_15.2</code> for <code>openSUSE_Leap_15.1</code>, <code>openSUSE_Leap_15.0</code>, or <code>openSUSE_Tumbleweed</code> if you’re using a different version of openSUSE.
+      Tumbleweed:
+    command: |
+      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Tumbleweed snappy
+  -
+    action: |
+      Leap 15.x:
+    command: |
+      sudo zypper addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_15.6 snappy
+  -
+    action: |
+      If needed, Swap out <code>openSUSE_Leap_15.</code> for, <code>openSUSE_Leap_16.0</code> if you’re using a different version of openSUSE.
   -
     action: |
       With the repository added, import its GPG key:


### PR DESCRIPTION
Users often forget to replace Leap for Tumbleweed or vice versa in the command.

## Done

## How to QA

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why): just a trivial web content update

## Issue / Card
Fixes #

## Screenshots
