### PR TITLE
fix: Fix empty included stores list

### DIFF
--- a/static/js/publisher/pages/Snaps/Snaps.tsx
+++ b/static/js/publisher/pages/Snaps/Snaps.tsx
@@ -476,16 +476,17 @@ function Snaps() {
                                     </p>
                                     <ul>
                                       {includedStores.map((store: Store) => (
-                                        <li key={store.id}>
+                                        <li key={store?.includedStore?.id}>
                                           {store.userHasAccess ? (
                                             <Link
-                                              to={`/admin/${store.id}/snaps`}
+                                              to={`/admin/${store?.includedStore?.id}/snaps`}
                                             >
-                                              {store.name}
+                                              {store?.includedStore?.name}
                                             </Link>
                                           ) : (
                                             <>
-                                              {store.name} ({store.id})
+                                              {store?.includedStore?.name} (
+                                              {store?.includedStore?.id})
                                             </>
                                           )}
                                         </li>

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -56,6 +56,11 @@ export type Store = {
   roles?: Array<"admin" | "review" | "view" | "access">;
   snaps: SnapsList;
   userHasAccess?: boolean;
+  includedStore?: {
+    id: string;
+    name: string;
+    userHasAccess: boolean;
+  };
 };
 
 export type Model = {


### PR DESCRIPTION
## Done
Fixes an issue where the name and ID of a store in the fully included list is not displayed

## How to QA
- Go to https://snapcraft-io-5199.demos.haus/admin/nah4ahShap8aefie6pha/snaps
- Scroll down to "Fully included stores"
- Expand the panel and check that the store in the list displays it's name and ID

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Exiting tests in place

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23315