### PR TITLE
feat: Improved progressive release experience

### DIFF
--- a/static/js/publisher/pages/Releases/actions/__tests__/pendingReleases.test.js
+++ b/static/js/publisher/pages/Releases/actions/__tests__/pendingReleases.test.js
@@ -36,7 +36,7 @@ describe("pendingReleases actions", () => {
     architectures: ["test64"],
   };
   const channel = "test/edge";
-  const previousRevisions = [];
+  const previousReleases = [];
   const initialState = reducers(undefined, {});
   const stateWithRevisions = {
     ...initialState,
@@ -107,12 +107,12 @@ describe("pendingReleases actions", () => {
       const store = mockStore(stateWithRevisions);
       expect(
         store.dispatch(releaseRevision(revision, channel)).payload
-          .previousRevisions,
+          .previousReleases,
       ).toEqual([]);
     });
 
     describe("if previous revisions", () => {
-      const stateWithPreviousRevisions = {
+      const stateWithPreviousReleases = {
         ...initialState,
         releases: [
           {
@@ -133,7 +133,7 @@ describe("pendingReleases actions", () => {
       };
 
       it("should return previous revisions, if available", () => {
-        const store = mockStore(stateWithPreviousRevisions);
+        const store = mockStore(stateWithPreviousReleases);
 
         const revisionWithRelease = {
           ...revision,
@@ -149,9 +149,9 @@ describe("pendingReleases actions", () => {
           ),
         );
 
-        expect(dispatch.payload.previousRevisions).toEqual([
+        expect(dispatch.payload.previousReleases).toEqual([
           {
-            ...stateWithPreviousRevisions.revisions["2"],
+            ...stateWithPreviousReleases.revisions["2"],
           },
         ]);
       });
@@ -237,7 +237,7 @@ describe("pendingReleases actions", () => {
           payload: {
             revision,
             channel: targetChannel,
-            previousRevisions,
+            previousReleases,
             progressive: actions.find(
               (action) =>
                 action.payload.revision.revision === revision.revision &&
@@ -255,7 +255,7 @@ describe("pendingReleases actions", () => {
             ).payload.progressive,
             revision: revision2,
             channel: targetChannel,
-            previousRevisions: [],
+            previousReleases: [],
           },
         });
       });

--- a/static/js/publisher/pages/Releases/actions/pendingReleases.js
+++ b/static/js/publisher/pages/Releases/actions/pendingReleases.js
@@ -19,6 +19,9 @@ export function releaseRevision(revision, channel, progressive) {
     const { revisions, pendingReleases } = state;
 
     const previousReleases = getReleases(state, revision.architectures, channel)
+      // Find all revision releases for this channel and architecture
+      // that do not share the same revision number as the previous release.
+      // for example [1, 1, 2, 2, 3, 2, 2, 2, 1] will return [1, 2, 3, 2, 1]
       .reduce((acc, release) => {
         if (!acc.length || acc[acc.length - 1].revision !== release.revision) {
           acc.push(release);

--- a/static/js/publisher/pages/Releases/actions/pendingReleases.js
+++ b/static/js/publisher/pages/Releases/actions/pendingReleases.js
@@ -65,7 +65,7 @@ export function releaseRevision(revision, channel, progressive) {
         revision: revisionToRelease,
         channel,
         progressive,
-        previousReleases: previousReleases,
+        previousReleases,
       },
     });
   };

--- a/static/js/publisher/pages/Releases/actions/pendingReleases.js
+++ b/static/js/publisher/pages/Releases/actions/pendingReleases.js
@@ -18,17 +18,19 @@ export function releaseRevision(revision, channel, progressive) {
     const state = getState();
     const { revisions, pendingReleases } = state;
 
-    const previousRevisions = getReleases(
-      state,
-      revision.architectures,
-      channel,
-    )
-      .filter((release) => release.revision !== revision.revision)
+    const previousReleases = getReleases(state, revision.architectures, channel)
+      .reduce((acc, release) => {
+        if (!acc.length || acc[acc.length - 1].revision !== release.revision) {
+          acc.push(release);
+        }
+
+        return acc;
+      }, [])
       .map((release) => revisions[release.revision]);
 
     let revisionToRelease = revision;
 
-    if (!progressive && previousRevisions.length > 0 && previousRevisions[0]) {
+    if (!progressive && previousReleases.length > 0 && previousReleases[0]) {
       revisionToRelease = revisions[revision.revision];
 
       let percentage = 100;
@@ -60,7 +62,7 @@ export function releaseRevision(revision, channel, progressive) {
         revision: revisionToRelease,
         channel,
         progressive,
-        previousRevisions,
+        previousReleases: previousReleases,
       },
     });
   };

--- a/static/js/publisher/pages/Releases/components/progressiveBar.js
+++ b/static/js/publisher/pages/Releases/components/progressiveBar.js
@@ -4,8 +4,9 @@ import PropTypes from "prop-types";
 const ProgressiveBar = ({
   percentage,
   targetPercentage,
-  readonly,
+  readonly = true,
   disabled,
+  minPercentage = 0,
 }) => {
   let current = percentage;
 
@@ -50,12 +51,14 @@ const ProgressiveBar = ({
         }`}
         style={{ width: `${current}%` }}
       />
+      {minPercentage > 1 && (
+        <div
+          className="progressive-bar__min"
+          style={{ width: `${minPercentage}%` }}
+        ></div>
+      )}
     </div>
   );
-};
-
-ProgressiveBar.defaultProps = {
-  readonly: true,
 };
 
 ProgressiveBar.propTypes = {
@@ -63,6 +66,7 @@ ProgressiveBar.propTypes = {
   targetPercentage: PropTypes.number,
   readonly: PropTypes.bool,
   disabled: PropTypes.bool,
+  minPercentage: PropTypes.number,
 };
 
 class InteractiveProgressiveBar extends React.Component {
@@ -218,7 +222,7 @@ class InteractiveProgressiveBar extends React.Component {
   }
 
   render() {
-    const { disabled, singleDirection } = this.props;
+    const { disabled, singleDirection, minPercentage } = this.props;
     const { current, scrubTarget, scrubStart } = this.state;
     const classes = ["progressive-bar__interactive-wrapper"];
     if (scrubStart) {
@@ -243,6 +247,7 @@ class InteractiveProgressiveBar extends React.Component {
           targetPercentage={scrubTarget}
           readonly={false}
           disabled={disabled}
+          minPercentage={minPercentage}
         />
       </div>
     );

--- a/static/js/publisher/pages/Releases/components/progressiveBarControl.js
+++ b/static/js/publisher/pages/Releases/components/progressiveBarControl.js
@@ -7,6 +7,7 @@ import { updateProgressiveReleasePercentage } from "../actions/pendingReleases";
 import progressiveTypes from "./releasesConfirmDetails/types";
 
 import { InteractiveProgressiveBar } from "./progressiveBar";
+import { min } from "date-fns";
 
 class ProgressiveBarControl extends React.Component {
   constructor(props) {
@@ -26,7 +27,7 @@ class ProgressiveBarControl extends React.Component {
   }
 
   render() {
-    const { release, type, globalPercentage } = this.props;
+    const { release, type, globalPercentage, minPercentage } = this.props;
 
     if (!release.progressive) {
       return false;
@@ -54,13 +55,15 @@ class ProgressiveBarControl extends React.Component {
     return (
       <div className="progressive-release-control">
         <div className="progressive-release-control__inner">
-          <div>Release all to</div>
+          <div>
+            <b>Release all to</b>
+          </div>
           <div className="p-release-details-row__progress">
             <InteractiveProgressiveBar
               percentage={startingPercentage}
               onChange={this.onChangeHandler}
               targetPercentage={targetPercentage}
-              minPercentage={1}
+              minPercentage={minPercentage}
               singleDirection={type === progressiveTypes.UPDATE ? 1 : 0}
             />
             <span>
@@ -83,7 +86,16 @@ class ProgressiveBarControl extends React.Component {
         <div className="p-release-details-row__notes">
           <small>
             {100 - targetPercentage}% of devices will stay on the current
-            version
+            version.
+            {minPercentage !== 1 ? (
+              <>
+                <br />
+                {minPercentage}% is the lowest percentage all revisions can be
+                released to.
+              </>
+            ) : (
+              ""
+            )}
           </small>
         </div>
       </div>
@@ -97,6 +109,7 @@ ProgressiveBarControl.propTypes = {
   globalPercentage: PropTypes.number,
   updateGlobalPercentage: PropTypes.func,
   updateProgressiveReleasePercentage: PropTypes.func,
+  minPercentage: PropTypes.number,
 };
 
 const mapDispatchToProps = (dispatch) => {

--- a/static/js/publisher/pages/Releases/components/progressiveBarControl.js
+++ b/static/js/publisher/pages/Releases/components/progressiveBarControl.js
@@ -7,8 +7,6 @@ import { updateProgressiveReleasePercentage } from "../actions/pendingReleases";
 import progressiveTypes from "./releasesConfirmDetails/types";
 
 import { InteractiveProgressiveBar } from "./progressiveBar";
-import { min } from "date-fns";
-
 class ProgressiveBarControl extends React.Component {
   constructor(props) {
     super(props);

--- a/static/js/publisher/pages/Releases/components/progressiveBarControl.js
+++ b/static/js/publisher/pages/Releases/components/progressiveBarControl.js
@@ -85,14 +85,12 @@ class ProgressiveBarControl extends React.Component {
           <small>
             {100 - targetPercentage}% of devices will stay on the current
             version.
-            {minPercentage > 1 ? (
+            {minPercentage > 1 && (
               <>
                 <br />
                 {minPercentage}% is the lowest percentage all revisions can be
                 released to.
               </>
-            ) : (
-              ""
             )}
           </small>
         </div>

--- a/static/js/publisher/pages/Releases/components/progressiveBarControl.js
+++ b/static/js/publisher/pages/Releases/components/progressiveBarControl.js
@@ -85,7 +85,7 @@ class ProgressiveBarControl extends React.Component {
           <small>
             {100 - targetPercentage}% of devices will stay on the current
             version.
-            {minPercentage !== 1 ? (
+            {minPercentage > 1 ? (
               <>
                 <br />
                 {minPercentage}% is the lowest percentage all revisions can be

--- a/static/js/publisher/pages/Releases/components/releasesConfirmDetails/cancelProgressiveRow.js
+++ b/static/js/publisher/pages/Releases/components/releasesConfirmDetails/cancelProgressiveRow.js
@@ -5,7 +5,7 @@ const CancelProgressiveRow = ({ release }) => {
   const revisionInfo = release.revision;
 
   return revisionInfo.architectures.map((arch) => {
-    const previousRevision = release.previousRevisions[0];
+    const previousRelease = release.previousReleases[0];
     return (
       <div
         className="p-release-details-row is-closing"
@@ -14,7 +14,7 @@ const CancelProgressiveRow = ({ release }) => {
         <span>Cancel</span>
         <span>
           <b>{revisionInfo.revision}</b> in <b>{release.channel}</b> on{" "}
-          <b>{arch}</b>. Revert to <b>{previousRevision.revision}</b>.
+          <b>{arch}</b>. Revert to <b>{previousRelease.revision}</b>.
         </span>
       </div>
     );

--- a/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.js
+++ b/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.js
@@ -32,6 +32,25 @@ const ReleasesConfirmDetails = ({ updates, isProgressiveReleaseEnabled }) => {
   const showNewReleases = Object.keys(newReleases).length > 0;
   const showPendingCloses = pendingCloses.length > 0;
 
+  const lowestPercentage = Object.entries(updates.newReleasesToProgress).reduce(
+    (min, update) => {
+      const release = update[1];
+      const previousRelease = release.previousReleases?.[0];
+      if (previousRelease?.revision !== release.revision.revision) {
+        return min;
+      }
+      const percentage =
+        previousRelease?.releases?.[0]?.progressive?.percentage || 1;
+
+      if (percentage > min) {
+        return percentage;
+      }
+
+      return min;
+    },
+    1,
+  );
+
   const updatePercentage = (percentage) => {
     setGlobalPercentage(percentage);
     updateProgressiveReleasePercentage(percentage);
@@ -84,6 +103,7 @@ const ReleasesConfirmDetails = ({ updates, isProgressiveReleaseEnabled }) => {
               type={progressiveTypes.RELEASE}
               release={progressiveReleases[Object.keys(progressiveReleases)[0]]}
               updateGlobalPercentage={updatePercentage}
+              minPercentage={lowestPercentage}
             />
           </Col>
         </Row>

--- a/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.js
+++ b/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.js
@@ -32,20 +32,22 @@ const ReleasesConfirmDetails = ({ updates, isProgressiveReleaseEnabled }) => {
   const showNewReleases = Object.keys(newReleases).length > 0;
   const showPendingCloses = pendingCloses.length > 0;
 
+  // Find the highest release target percentage among previous progressive releases:
+  // this will be the lowest percentage for the new release
   const lowestPercentage = Object.values(updates.newReleasesToProgress).reduce(
-    (min, release) => {
+    (max, release) => {
       const previousRelease = release.previousReleases?.[0];
       if (previousRelease?.revision !== release.revision.revision) {
-        return min;
+        return max;
       }
       const percentage =
         previousRelease?.releases?.[0]?.progressive?.percentage || 1;
 
-      if (percentage > min) {
+      if (percentage > max) {
         return percentage;
       }
 
-      return min;
+      return max;
     },
     1,
   );

--- a/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.js
+++ b/static/js/publisher/pages/Releases/components/releasesConfirmDetails/index.js
@@ -32,9 +32,8 @@ const ReleasesConfirmDetails = ({ updates, isProgressiveReleaseEnabled }) => {
   const showNewReleases = Object.keys(newReleases).length > 0;
   const showPendingCloses = pendingCloses.length > 0;
 
-  const lowestPercentage = Object.entries(updates.newReleasesToProgress).reduce(
-    (min, update) => {
-      const release = update[1];
+  const lowestPercentage = Object.values(updates.newReleasesToProgress).reduce(
+    (min, release) => {
       const previousRelease = release.previousReleases?.[0];
       if (previousRelease?.revision !== release.revision.revision) {
         return min;

--- a/static/js/publisher/pages/Releases/components/revisionsList.js
+++ b/static/js/publisher/pages/Releases/components/revisionsList.js
@@ -385,7 +385,7 @@ class RevisionsList extends Component {
             {showPendingRelease &&
               this.renderRow(
                 pendingRelease.revision,
-                pendingRelease.previousRevisions[0],
+                pendingRelease.previousReleases[0],
                 !isReleaseHistory,
                 showChannels,
                 true,

--- a/static/js/publisher/pages/Releases/reducers/__tests__/pendingReleases.test.js
+++ b/static/js/publisher/pages/Releases/reducers/__tests__/pendingReleases.test.js
@@ -156,13 +156,13 @@ describe("pendingReleases", () => {
       });
     });
 
-    describe("when previousRevisions are passed", () => {
-      let releaseRevisionPreviousRevisionsAction = {
+    describe("when previousReleases are passed", () => {
+      let releaseRevisionPreviousReleasesAction = {
         type: RELEASE_REVISION,
         payload: {
           revision: { revision: 1, architectures: ["abc42", "test64"] },
           channel: "test/edge",
-          previousRevisions: {
+          previousReleases: {
             abc42: { revision: 0, architectures: ["abc42"] },
           },
         },
@@ -172,7 +172,7 @@ describe("pendingReleases", () => {
         const state = {
           1: {
             "test/edge": {
-              revision: releaseRevisionPreviousRevisionsAction.payload.revision,
+              revision: releaseRevisionPreviousReleasesAction.payload.revision,
               channel: "test/edge",
             },
           },
@@ -180,15 +180,15 @@ describe("pendingReleases", () => {
 
         const result = pendingReleases(
           state,
-          releaseRevisionPreviousRevisionsAction,
+          releaseRevisionPreviousReleasesAction,
         );
 
         expect(result).toEqual({
           1: {
             "test/edge": {
-              revision: releaseRevisionPreviousRevisionsAction.payload.revision,
+              revision: releaseRevisionPreviousReleasesAction.payload.revision,
               channel: "test/edge",
-              previousRevisions: {
+              previousReleases: {
                 abc42: { revision: 0, architectures: ["abc42"] },
               },
             },
@@ -626,7 +626,7 @@ describe("pendingReleases", () => {
           "test/edge": {
             revision: { revision: 1, architectures: ["abc42", "test64"] },
             channel: "test/edge",
-            previousRevisions: {
+            previousReleases: {
               abc42: { revision: 0, architectures: ["abc42"] },
             },
           },
@@ -737,7 +737,7 @@ describe("pendingReleases", () => {
               percentage: 20,
               paused: true,
             },
-            previousRevisions: {
+            previousReleases: {
               abc42: { revision: 0, architectures: ["abc42"] },
             },
           },

--- a/static/js/publisher/pages/Releases/reducers/pendingReleases.ts
+++ b/static/js/publisher/pages/Releases/reducers/pendingReleases.ts
@@ -37,7 +37,7 @@ function releaseRevision(
   revision: { architectures: any[]; revision: number },
   channel: string,
   progressive: null,
-  previousRevisions: undefined,
+  previousReleases: undefined,
 ) {
   state = { ...state };
 
@@ -72,8 +72,8 @@ function releaseRevision(
     };
   }
 
-  if (previousRevisions) {
-    state[revision.revision][channel].previousRevisions = previousRevisions;
+  if (previousReleases) {
+    state[revision.revision][channel].previousReleases = previousReleases;
   }
 
   if (progressive && !state[revision.revision][channel].progressive) {
@@ -108,12 +108,12 @@ function setProgressiveRelease(
 
   Object.values(nextState).forEach((pendingRelease: any) => {
     Object.values(pendingRelease).forEach((channel: any) => {
-      const hasPreviousRevisions =
-        channel.previousRevisions &&
-        Object.keys(channel.previousRevisions).length > 0;
+      const hasPreviousReleases =
+        channel.previousReleases &&
+        Object.keys(channel.previousReleases).length > 0;
 
       if (
-        hasPreviousRevisions &&
+        hasPreviousReleases &&
         !channel.progressive &&
         progressive.percentage < 100
       ) {
@@ -205,7 +205,7 @@ function cancelProgressiveRelease(
 //       revision: { revision: <revisionId>, version, ... },
 //       channel: <channel>,
 //       progressive: { key, percentage, paused },
-//       previousRevisions: {
+//       previousReleases: {
 //         <arch>: { revision: <revisionId>, version, ... }
 //       },
 //       replaces: <revision>
@@ -225,7 +225,7 @@ export default function pendingReleases(
         action.payload.revision,
         action.payload.channel,
         action.payload.progressive,
-        action.payload.previousRevisions,
+        action.payload.previousReleases,
       );
     case UNDO_RELEASE:
       return removePendingRelease(

--- a/static/js/publisher/pages/Releases/selectors/__tests__/selectors.test.js
+++ b/static/js/publisher/pages/Releases/selectors/__tests__/selectors.test.js
@@ -1106,7 +1106,7 @@ describe("hasRelease", () => {
                 percentage: 100,
                 paused: false,
               },
-              previousRevisions: [{ revision: 2 }],
+              previousReleases: [{ revision: 2 }],
             },
           },
         },
@@ -1142,7 +1142,7 @@ describe("hasRelease", () => {
                 percentage: 40,
                 paused: false,
               },
-              previousRevisions: [
+              previousReleases: [
                 {
                   revision: 2,
                 },

--- a/static/js/publisher/pages/Releases/selectors/index.ts
+++ b/static/js/publisher/pages/Releases/selectors/index.ts
@@ -619,7 +619,7 @@ export function getProgressiveState(
         previousRevision = revisions[previousRevision.revision];
       }
     } else if (isPending) {
-      previousRevision = allReleases[0];
+      previousRevision = revisions[allReleases[0]?.revision];
     }
 
     let pendingMatch: any;

--- a/static/js/publisher/pages/Releases/selectors/index.ts
+++ b/static/js/publisher/pages/Releases/selectors/index.ts
@@ -618,6 +618,8 @@ export function getProgressiveState(
       if (previousRevision && previousRevision.revision) {
         previousRevision = revisions[previousRevision.revision];
       }
+    } else if (isPending) {
+      previousRevision = allReleases[0];
     }
 
     let pendingMatch: any;
@@ -719,9 +721,9 @@ export function getSeparatePendingReleases(
       } else if (
         isProgressiveEnabled &&
         pendingRelease.progressive &&
-        pendingRelease.previousRevisions &&
-        pendingRelease.previousRevisions.length > 0 &&
-        pendingRelease.previousRevisions[0]
+        pendingRelease.previousReleases &&
+        pendingRelease.previousReleases.length > 0 &&
+        pendingRelease.previousReleases[0]
       ) {
         // What are the differences between the previous progressive state
         // and the new state.

--- a/static/sass/_snapcraft_p-progressive-bar.scss
+++ b/static/sass/_snapcraft_p-progressive-bar.scss
@@ -1,9 +1,9 @@
 @use "sass:color";
 
 @mixin snapcraft-p-progressive-bar {
-  $inactive: color.scale($color-link, $lightness: 90%);
-  $active: $color-link;
-  $target: color.scale($color-link, $lightness: -20%);
+  $color-inactive: color.scale($color-link, $lightness: 90%);
+  $color-active: $color-link;
+  $color-target: color.scale($color-link, $lightness: -20%);
 
   %bar {
     border-radius: 9px 0 0 9px;
@@ -16,7 +16,7 @@
   }
 
   .progressive-bar {
-    background: $inactive;
+    background: $color-inactive;
     border-radius: 9px;
     height: 9px;
     margin-top: 7px;
@@ -33,13 +33,19 @@
   .progressive-bar__current {
     @extend %bar;
 
-    background: $active;
+    background: $color-active;
   }
 
   .progressive-bar__target {
     @extend %bar;
 
-    background: $target;
+    background: $color-target;
+  }
+
+  .progressive-bar__min {
+    @extend %bar;
+
+    background: $color-negative;
   }
 
   .progressive-bar.is-disabled {
@@ -47,11 +53,11 @@
     pointer-events: none;
 
     .progressive-bar__current {
-      background: color.adjust(color.grayscale($active), $lightness: 20%, $space: hsl);
+      background: color.adjust(color.grayscale($color-active), $lightness: 20%, $space: hsl);
     }
 
     .progressive-bar__target {
-      background: color.adjust(color.grayscale($target), $lightness: 20%, $space: hsl);
+      background: color.adjust(color.grayscale($color-target), $lightness: 20%, $space: hsl);
     }
   }
 


### PR DESCRIPTION
## Done
- When updating a progressive release, ensure you can't release to a lower percentage than is currently set.
- Added some extra text to the Review panel around minimum progressive releases.
- Updated the way we get the previous release, to ensure that if you:
  1. create a progressive release rev 1 -> rev 2
  2. overwrite the release with rev 1
  3. Create another progressive release rev 1 -> rev 2

  The minimum percentage from step 1. isn't shown in step 3.
- Renamed `previousRevisions` to `previousReleases` throughout (as this is what is actually stored in the variable).
- Fixed defaultProp deprecation warning.

## How to QA
- Pull the branch or view the demo
- Play with progressive releases. Create them, remove them, overwrite them. Things should work as expected.
- Try doing some strange things, like described above in the "Done" section.

## Testing
- [x] This PR has tests - updated current tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-23301

## Screenshots
![image](https://github.com/user-attachments/assets/ed7e084d-b133-492a-9648-5ded29360eeb)
