### PR TITLE
WD-23838 - update store_api package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==6.3.0
 canonicalwebteam.blog==6.4.6
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.6.0
-canonicalwebteam.store-api==6.6.0
+canonicalwebteam.store-api==6.7.0
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0


### PR DESCRIPTION
## Done
Unregistering a snap currently returns the following error: “Unregistering snaps requires Snapcraft credentials”

This is because for Snap packages, the `unregister_package` API actually uses SCA's API under the hood: if we pass the authentication header in the wrong format the API errors out. When the name_space is "snap" we should pass the authorization header as if we were calling SCA.

This issue was fixed within the `store_api` package, this PR bumps up its version in the `requirements.txt` file

## How to QA
1. go to https://snapcraft-io-5218.demos.haus/snaps
2. register a new snap name
2.1. you should be redirected to https://snapcraft-io-5218.demos.haus/snaps
3. open the dev tools
4. in the table at the bottom of the page press the "Unregister" button
4.1. the DELETE request should return a 200 status
4.2. you should be redirected to https://snapcraft-io-5218.demos.haus/snaps

You can also unregister the snap from its settings page (https://snapcraft-io-5218.demos.haus/< snap name >/settings)


## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): dependency version bump

## Issue / Card
Fixes WD-23838

## Screenshots
