### PR TITLE
fix: replace hardcoded 'latest' with currentTrack

### DIFF
--- a/static/js/publisher/pages/Releases/components/releasesTable/releaseMenuItem.js
+++ b/static/js/publisher/pages/Releases/components/releasesTable/releaseMenuItem.js
@@ -7,7 +7,7 @@ import { getPendingChannelMap } from "../../selectors";
 import { canBeReleased, isInDevmode } from "../../helpers";
 
 function ReleaseMenuItem(props) {
-  const risk = `latest/${props.risk}`;
+  const risk = `${props.currentTrack}/${props.risk}`;
   const devModeRisk = props.risk === "stable" || props.risk === "candidate";
   const hasDevmodeRevisions =
     Object.values(props.item.revisions).some(isInDevmode) && devModeRisk;


### PR DESCRIPTION
## Done

- replace hardcoded 'latest' with currentTrack

## How to QA
- go to
- select a snap that has  multiple tracks such as "fran-snap"
- select a different track other than "latest"
- Hover on a revision in the "Revisions available to release"
- Click on the "release" button 
- select a channel 
- Verify the revision is placed on the correct track's table (not latest's)

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
https://warthogs.atlassian.net/browse/WD-23314
