### PR TITLE
fix: use correct type conversion for None -> bool

### DIFF
--- a/webapp/publisher/snaps/settings_views.py
+++ b/webapp/publisher/snaps/settings_views.py
@@ -71,7 +71,7 @@ def get_settings_data(snap_name):
         "update_metadata_on_release": snap_details[
             "update_metadata_on_release"
         ],
-        "visibility_locked": snap_details["visibility_locked"] | False,
+        "visibility_locked": bool(snap_details["visibility_locked"]),
     }
 
     return flask.jsonify({"success": True, "data": context})


### PR DESCRIPTION
## Done
Fixed a 500 error on calls to https://snapcraft.io/< snap name >/settings caused by an incorrect type conversion:
```
TypeError: unsupported operand type(s) for |: 'NoneType' and 'bool'
```

## How to QA
1. Go to https://snapcraft-io-5226.demos.haus/< snap name >/settings
2. The snap's settings page loads correctly

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #5224

## Screenshots
