### PR TITLE
fix:escape version values in select dropdown to prevent xss

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -59,7 +59,7 @@
     <select name="version-select" id="version-select" onChange="window.location.href=this.value">
     {% for version in versions %}
       {% set active = docs_version == version['path'] %}
-      <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>{{ version['version'] }}</option>
+      <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>{{ version['version'] | e }}</option>
     {% endfor %}
     </select>
     {% endif %}


### PR DESCRIPTION
## Done
Added the | e filter to escape version['version'] in the option text to prevent potential HTML injection and improve security. It converts special characters like <, >, &, and " into their HTML entity equivalents.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://github.com/canonical/snapcraft.io/security/code-scanning
