### PR TITLE
chore: Move store endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/tests_get_store.py
+++ b/tests/endpoints/tests_get_store.py
@@ -1,0 +1,68 @@
+import json
+from json import dumps as _dumps
+from unittest.mock import MagicMock, patch
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestGetStore(TestEndpoints):
+    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store")
+    def test_get_store(self, mock_get_store):
+        def dumps_wrapper(*args, **kwargs):
+            return _dumps(
+                *args,
+                **(kwargs | {"default": lambda obj: json.dumps(test_store)})
+            )
+
+        json.dumps = MagicMock(wraps=dumps_wrapper)
+
+        test_store = {
+            "allowed-inclusion-source-stores": [],
+            "allowed-inclusion-target-stores": [],
+            "brand-id": "test-brand-id",
+            "id": "test-id",
+            "manual-review-policy": "avoid",
+            "name": "Test Store",
+            "parent": None,
+            "private": False,
+            "roles": [
+                {
+                    "description": "Admin's manage the store users",
+                    "label": "Admin",
+                    "role": "admin",
+                }
+            ],
+            "snap-name-prefixes": [],
+            "store-whitelist": [],
+        }
+
+        mock_get_store.return_value = test_store
+
+        response = self.client.get("/api/store/test-store-id")
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(
+            data["data"],
+            json.dumps(
+                {
+                    "allowed-inclusion-source-stores": [],
+                    "allowed-inclusion-target-stores": [],
+                    "brand-id": "test-brand-id",
+                    "id": "test-id",
+                    "manual-review-policy": "avoid",
+                    "name": "Test Store",
+                    "parent": None,
+                    "private": False,
+                    "roles": [
+                        {
+                            "description": "Admin's manage the store users",
+                            "label": "Admin",
+                            "role": "admin",
+                        }
+                    ],
+                    "snap-name-prefixes": [],
+                    "store-whitelist": [],
+                }
+            ),
+        )

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -45,26 +45,6 @@ def get_admin(path):
     return flask.render_template("admin/admin.html", **context)
 
 
-@admin.route("/api/store/<store_id>")
-@login_required
-@exchange_required
-def get_settings(store_id):
-    store = dashboard.get_store(flask.session, store_id)
-    store["links"] = []
-
-    if any(role["role"] == "admin" for role in store["roles"]):
-        store["links"].append(
-            {"name": "Members", "path": f'/admin/{store["id"]}/members'}
-        )
-        store["links"].append(
-            {"name": "Settings", "path": f'/admin/${store["id"]}/settings'}
-        )
-
-    res = {"success": True, "data": store}
-
-    return jsonify(res)
-
-
 @admin.route("/api/store/<store_id>/settings", methods=["PUT"])
 @login_required
 @exchange_required

--- a/webapp/endpoints/views.py
+++ b/webapp/endpoints/views.py
@@ -41,6 +41,26 @@ def get_stores():
     return jsonify(res)
 
 
+@endpoints.route("/api/store/<store_id>")
+@login_required
+@exchange_required
+def get_settings(store_id):
+    store = dashboard.get_store(flask.session, store_id)
+    store["links"] = []
+
+    if any(role["role"] == "admin" for role in store["roles"]):
+        store["links"].append(
+            {"name": "Members", "path": f'/admin/{store["id"]}/members'}
+        )
+        store["links"].append(
+            {"name": "Settings", "path": f'/admin/${store["id"]}/settings'}
+        )
+
+    res = {"success": True, "data": store}
+
+    return jsonify(res)
+
+
 @endpoints.route("/api/store/<store_id>/brand")
 @login_required
 @exchange_required


### PR DESCRIPTION
## Done
Migrates `/api/store/<store_id>` into a dedicated endpoints module

## How to QA
- Go to https://snapcraft-io-5244.demos.haus/api/store/ahnuP3quahti9vis8aiw
- Check that it is the same as https://snapcraft.io/api/store/ahnuP3quahti9vis8aiw

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24116