### PR TITLE
fix: avoid exposing internal errors

### DIFF
--- a/webapp/publisher/snaps/release_views.py
+++ b/webapp/publisher/snaps/release_views.py
@@ -88,10 +88,14 @@ def post_release(snap_name):
         if api_response_error_list.status_code == 404:
             return flask.abort(404, "No snap named {}".format(snap_name))
         else:
-            response = {
-                "errors": api_response_error_list,
-            }
-            return flask.jsonify(response), 400
+            return (
+                flask.jsonify(
+                    {
+                        "errors": api_response_error_list.errors,
+                    }
+                ),
+                400,
+            )
 
     return flask.jsonify(response)
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -10,6 +10,7 @@ from canonicalwebteam.exceptions import (
     StoreApiResourceNotFound,
 )
 from flask.json import jsonify
+from talisker import logging
 
 # Local
 from webapp import authentication
@@ -341,7 +342,11 @@ def get_snap_build_status():
     try:
         account_info = dashboard.get_account(flask.session)
     except (StoreApiError, ApiError) as api_error:
-        return flask.jsonify(api_error), 400
+        logging.getLogger("talisker.wsgi").error(
+            "Error with session: %s", api_error
+        )
+
+        return flask.jsonify({"error": "An unexpected error occurred"}), 400
 
     response = []
     user_snaps, _ = logic.get_snaps_account_info(account_info)
@@ -501,7 +506,11 @@ def get_is_user_snap(snap_name):
     try:
         snap_info = dashboard.get_snap_info(flask.session, snap_name)
     except (StoreApiError, ApiError) as api_error:
-        return flask.jsonify({"error": str(api_error)}), 400
+        logging.getLogger("talisker.wsgi").error(
+            "Error with session: %s", api_error
+        )
+
+        return flask.jsonify({"error": "An unexpected error occurred"}), 400
 
     if authentication.is_authenticated(flask.session):
         publisher_info = flask.session.get("publisher", {})


### PR DESCRIPTION
## Done
log stack traces internally, return generic error messages to avoid exposing stack traces

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24170

