### PR TITLE
chore: Move models endpoint to the endpoints section of app

### DIFF
--- a/tests/admin/tests_models.py
+++ b/tests/admin/tests_models.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from canonicalwebteam.candid import CandidClient
 from canonicalwebteam.exceptions import (
-    StoreApiResponseErrorList,
     StoreApiResourceNotFound,
 )
 from webapp.helpers import api_publisher_session
@@ -19,68 +18,6 @@ class TestModelServiceEndpoints(TestAdminEndpoints):
             "webapp.admin.views.dashboard.get_store"
         ).start()
         super().setUp()
-
-
-class TestGetModels(TestModelServiceEndpoints):
-    @patch(
-        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
-    )
-    def test_get_models(self, mock_get_store_models):
-        mock_get_store_models.return_value = {
-            "models": [{"name": "test_model"}]
-        }
-
-        response = self.client.get("/api/store/1/models")
-        data = response.json
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIsNotNone(data["data"])
-
-    @patch(
-        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
-    )
-    def test_store_has_no_models(self, mock_get_store_models):
-        mock_get_store_models.return_value = {"models": []}
-
-        response = self.client.get("/api/store/2/models")
-        data = response.json["data"]
-
-        success = response.json["success"]
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(success)
-        self.assertEqual(data["models"], [])
-
-    @patch(
-        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
-    )
-    def test_invalid_store_id(self, mock_get_store_models):
-        mock_get_store_models.side_effect = StoreApiResponseErrorList(
-            "Store not found",
-            404,
-            [{"message": "Store not found"}],
-        )
-
-        response = self.client.get("/api/store/3/models")
-        data = response.json
-
-        self.assertEqual(response.status_code, 500)
-        self.assertFalse(data["success"])
-        self.assertIn("Store not found", data["message"])
-
-    @patch(
-        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
-    )
-    def test_unauthorized_user(self, mock_get_store_models):
-        mock_get_store_models.side_effect = StoreApiResponseErrorList(
-            "unauthorized", 401, [{"message": "unauthorized"}]
-        )
-
-        response = self.client.get("/api/store/1/models")
-        data = response.json
-
-        self.assertEqual(response.status_code, 500)
-        self.assertFalse(data["success"])
-        self.assertIn("Store not found", data["message"])
 
 
 class TestCreateModel(TestModelServiceEndpoints):

--- a/tests/endpoints/tests_models.py
+++ b/tests/endpoints/tests_models.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+
+from canonicalwebteam.candid import CandidClient
+from canonicalwebteam.exceptions import (
+    StoreApiResponseErrorList,
+)
+from webapp.helpers import api_publisher_session
+from tests.endpoints.endpoint_testing import TestModelServiceEndpoints
+
+
+candid = CandidClient(api_publisher_session)
+
+
+class TestGetModels(TestModelServiceEndpoints):
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
+    )
+    def test_get_models(self, mock_get_store_models):
+        mock_get_store_models.return_value = {
+            "models": [{"name": "test_model"}]
+        }
+
+        response = self.client.get("/api/store/1/models")
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(data["data"])
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
+    )
+    def test_store_has_no_models(self, mock_get_store_models):
+        mock_get_store_models.return_value = {"models": []}
+
+        response = self.client.get("/api/store/2/models")
+        data = response.json["data"]
+
+        success = response.json["success"]
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(success)
+        self.assertEqual(data["models"], [])
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
+    )
+    def test_invalid_store_id(self, mock_get_store_models):
+        mock_get_store_models.side_effect = StoreApiResponseErrorList(
+            "Store not found",
+            404,
+            [{"message": "Store not found"}],
+        )
+
+        response = self.client.get("/api/store/3/models")
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertIn("Store not found", data["message"])
+
+    @patch(
+        "canonicalwebteam.store_api.publishergw.PublisherGW.get_store_models"
+    )
+    def test_unauthorized_user(self, mock_get_store_models):
+        mock_get_store_models.side_effect = StoreApiResponseErrorList(
+            "unauthorized", 401, [{"message": "unauthorized"}]
+        )
+
+        response = self.client.get("/api/store/1/models")
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertIn("Store not found", data["message"])

--- a/tests/endpoints/tests_signing_keys.py
+++ b/tests/endpoints/tests_signing_keys.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch, Mock
-from tests.admin.tests_models import TestModelServiceEndpoints
+from tests.endpoints.endpoint_testing import TestModelServiceEndpoints
 from canonicalwebteam.exceptions import StoreApiResponseErrorList
 
 

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -15,6 +15,7 @@ from flask.json import jsonify
 # Local
 from webapp.decorators import login_required, exchange_required
 from webapp.helpers import api_publisher_session, api_session
+from webapp.endpoints.models import get_models
 
 
 dashboard = Dashboard(api_session)
@@ -234,40 +235,6 @@ def update_invite_status(store_id):
 
 
 # ---------------------- MODELS SERVICES ----------------------
-@admin.route("/api/store/<store_id>/models")
-@login_required
-@exchange_required
-def get_models(store_id):
-    """
-    Retrieves models associated with a given store ID.
-
-    Args:
-        store_id (int): The ID of the store for which to retrieve models.
-
-    Returns:
-        dict: A dictionary containing the response message, success status,
-        and data.
-    """
-    res = {}
-    try:
-        models = publisher_gateway.get_store_models(flask.session, store_id)
-        res["success"] = True
-        res["data"] = models
-        response = make_response(res, 200)
-        response.cache_control.max_age = "3600"
-    except StoreApiResponseErrorList as error_list:
-        error_messages = [
-            f"{error.get('message', 'An error occurred')}"
-            for error in error_list.errors
-        ]
-        if "unauthorized" in error_messages:
-            res["message"] = "Store not found"
-        else:
-            res["message"] = " ".join(error_messages)
-        res["success"] = False
-        response = make_response(res, 500)
-
-    return response
 
 
 @admin.route("/api/store/<store_id>/models", methods=["POST"])

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -27,6 +27,7 @@ from webapp.tutorials.views import init_tutorials
 from webapp.packages.store_packages import store_packages
 from webapp.endpoints.views import endpoints
 from webapp.endpoints.signing_keys import signing_keys
+from webapp.endpoints.models import models
 
 
 TALISKER_WSGI_LOGGER = logging.getLogger("talisker.wsgi")
@@ -71,6 +72,7 @@ def create_app(testing=False):
     app.register_blueprint(admin)
     app.register_blueprint(endpoints)
     app.register_blueprint(signing_keys)
+    app.register_blueprint(models)
     init_docs(app, "/docs")
     init_blog(app, "/blog")
     init_tutorials(app, "/tutorials")

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -1,0 +1,55 @@
+# Packages
+import flask
+from flask import make_response
+from canonicalwebteam.exceptions import (
+    StoreApiResponseErrorList,
+)
+from canonicalwebteam.store_api.publishergw import PublisherGW
+
+# Local
+from webapp.decorators import login_required, exchange_required
+from webapp.helpers import api_publisher_session
+
+
+publisher_gateway = PublisherGW("snap", api_publisher_session)
+
+models = flask.Blueprint(
+    "models",
+    __name__,
+)
+
+
+@models.route("/api/store/<store_id>/models")
+@login_required
+@exchange_required
+def get_models(store_id):
+    """
+    Retrieves models associated with a given store ID.
+
+    Args:
+        store_id (int): The ID of the store for which to retrieve models.
+
+    Returns:
+        dict: A dictionary containing the response message, success status,
+        and data.
+    """
+    res = {}
+    try:
+        models = publisher_gateway.get_store_models(flask.session, store_id)
+        res["success"] = True
+        res["data"] = models
+        response = make_response(res, 200)
+        response.cache_control.max_age = "3600"
+    except StoreApiResponseErrorList as error_list:
+        error_messages = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in error_list.errors
+        ]
+        if "unauthorized" in error_messages:
+            res["message"] = "Store not found"
+        else:
+            res["message"] = " ".join(error_messages)
+        res["success"] = False
+        response = make_response(res, 500)
+
+    return response


### PR DESCRIPTION
## Done
Migrates `/api/store/brand-id/models` into a dedicated endpoints module

## How to QA
- Go to https://snapcraft-io-5248.demos.haus/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models
- Check that it is the same as https://snapcraft.io/api/store/njwQYXFnS7ppo7LaGxoh7aqVZc1CPi26/models

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24123