### PR TITLE
fix: reduce GITHUB_TOKEN scope for the jobs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +55,8 @@ jobs:
     name: publish-coverage-report
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
@@ -101,6 +105,8 @@ jobs:
 
   tics-report:
     runs-on: [self-hosted, reactive, amd64, tiobe, noble]
+    permissions:
+      contents: read
     needs: publish-coverage-report
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   run-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Build image
@@ -19,7 +21,8 @@ jobs:
 
   run-dotrun:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -42,7 +45,8 @@ jobs:
 
   lint-python:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -73,6 +77,8 @@ jobs:
 
   lint-scss:
     runs-on: ubuntu-latest
+      permissions:
+        contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -94,6 +100,8 @@ jobs:
 
   lint-js:
     runs-on: ubuntu-latest
+      permissions:
+        contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,6 +129,9 @@ jobs:
 
   test-python:
     runs-on: ubuntu-latest
+      permissions:
+        pull-requests: write
+        contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -162,7 +173,8 @@ jobs:
 
   test-js:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -200,6 +212,9 @@ jobs:
 
   check-inclusive-naming:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,8 +77,8 @@ jobs:
 
   lint-scss:
     runs-on: ubuntu-latest
-      permissions:
-        contents: read
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,8 +100,8 @@ jobs:
 
   lint-js:
     runs-on: ubuntu-latest
-      permissions:
-        contents: read
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -129,9 +129,9 @@ jobs:
 
   test-python:
     runs-on: ubuntu-latest
-      permissions:
-        pull-requests: write
-        contents: read
+    permissions:
+      pull-requests: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Done
The GITHUB_TOKEN in the workflows have broad write permissions across many scopes (issues, pages, deployments, packages...). Adding permissions limits the token's power and improves CI/CD security.

## QA:
- Go to https://github.com/canonical/snapcraft.io/actions/runs/16651461029
- Click on the job in the workflow run.
- Expand the “Set up job” step.
- Check the “GITHUB_TOKEN Permissions” section.
- Verify that the required permissions are present:
  - If the job only reads repository content, contents: read is enough.
  - If it modifies or comments on a pull request, it needs pull-requests: write.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24281

