### PR TITLE
chore: Move policies endpoint to the endpoint section of app

### DIFF
--- a/tests/admin/tests_policies.py
+++ b/tests/admin/tests_policies.py
@@ -4,38 +4,6 @@ from canonicalwebteam.exceptions import StoreApiResponseErrorList
 from tests.admin.tests_models import TestModelServiceEndpoints
 
 
-class TestGetPolicies(TestModelServiceEndpoints):
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.get_store_model_policies"
-    )
-    def test_get_policies(self, mock_get_store_model_policies):
-        mock_get_store_model_policies.return_value = ["policy1", "policy2"]
-
-        response = self.client.get("/api/store/1/models/Model1/policies")
-        data = response.json
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(data["success"])
-        self.assertEqual(data["data"], ["policy1", "policy2"])
-
-    @patch(
-        "canonicalwebteam.store_api.publishergw."
-        "PublisherGW.get_store_model_policies"
-    )
-    def test_failed_get_policies(self, mock_get_store_model_policies):
-        mock_get_store_model_policies.side_effect = StoreApiResponseErrorList(
-            "An error occurred", 500, [{"message": "An error occurred"}]
-        )
-
-        response = self.client.get("/api/store/1/models/Model1/policies")
-        data = response.json
-
-        self.assertEqual(response.status_code, 500)
-        self.assertFalse(data["success"])
-        self.assertEqual(data["message"], "An error occurred")
-
-
 class TestCreatePolicies(TestModelServiceEndpoints):
     @patch(
         "canonicalwebteam.store_api.publishergw."

--- a/tests/admin/tests_signing_keys.py
+++ b/tests/admin/tests_signing_keys.py
@@ -58,6 +58,10 @@ class TestCreateSigningKeys(TestModelServiceEndpoints):
 
 class TestDeleteSigningKeys(TestModelServiceEndpoints):
     @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_store",
+        Mock(return_value={"brand-id": "BrandName"}),
+    )
+    @patch(
         "canonicalwebteam.store_api.publishergw."
         "PublisherGW.delete_store_signing_key"
     )
@@ -75,6 +79,10 @@ class TestDeleteSigningKeys(TestModelServiceEndpoints):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(data["success"])
 
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_store",
+        Mock(return_value={"brand-id": "BrandName"}),
+    )
     @patch(
         "canonicalwebteam.store_api.publishergw."
         "PublisherGW.delete_store_signing_key"
@@ -113,6 +121,10 @@ class TestDeleteSigningKeys(TestModelServiceEndpoints):
             [{"name": "Model1", "policies": [{"revision": "1"}]}],
         )
 
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_store",
+        Mock(return_value={"brand-id": "BrandName"}),
+    )
     @patch(
         "canonicalwebteam.store_api.publishergw."
         "PublisherGW.delete_store_signing_key"

--- a/tests/endpoints/tests_policies.py
+++ b/tests/endpoints/tests_policies.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch, Mock
+from canonicalwebteam.exceptions import StoreApiResponseErrorList
+
+from tests.admin.tests_models import TestModelServiceEndpoints
+
+
+class TestGetPolicies(TestModelServiceEndpoints):
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_store",
+        Mock(return_value={"brand-id": "BrandName"}),
+    )
+    @patch(
+        "canonicalwebteam.store_api.publishergw."
+        "PublisherGW.get_store_model_policies"
+    )
+    def test_get_policies(self, mock_get_store_model_policies):
+        mock_get_store_model_policies.return_value = ["policy1", "policy2"]
+
+        response = self.client.get("/api/store/1/models/Model1/policies")
+        data = response.json
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"], ["policy1", "policy2"])
+
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.get_store",
+        Mock(return_value={"brand-id": "BrandName"}),
+    )
+    @patch(
+        "canonicalwebteam.store_api.publishergw."
+        "PublisherGW.get_store_model_policies"
+    )
+    def test_failed_get_policies(self, mock_get_store_model_policies):
+        mock_get_store_model_policies.side_effect = StoreApiResponseErrorList(
+            "An error occurred", 500, [{"message": "An error occurred"}]
+        )
+
+        response = self.client.get("/api/store/1/models/Model1/policies")
+        data = response.json
+
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["message"], "An error occurred")

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -15,7 +15,7 @@ from flask.json import jsonify
 # Local
 from webapp.decorators import login_required, exchange_required
 from webapp.helpers import api_publisher_session, api_session
-from webapp.endpoints.models import get_models
+from webapp.endpoints.models import get_models, get_policies
 
 
 dashboard = Dashboard(api_session)
@@ -330,47 +330,6 @@ def update_model(store_id: str, model_name: str):
         res["message"] = "Model not found"
     if res["success"]:
         return make_response(res, 200)
-    return make_response(res, 500)
-
-
-@admin.route("/api/store/<store_id>/models/<model_name>/policies")
-@login_required
-@exchange_required
-def get_policies(store_id: str, model_name: str):
-    """
-    Get the policies for a given store model.
-
-    Args:
-        store_id (str): The ID of the store.
-        model_name (str): The name of the model.
-
-    Returns:
-        dict: A dictionary containing the response message and success
-    """
-    brand_id = get_brand_id(flask.session, store_id)
-    res = {}
-
-    try:
-        policies = publisher_gateway.get_store_model_policies(
-            flask.session, brand_id, model_name
-        )
-        res["success"] = True
-        res["data"] = policies
-        response = make_response(res, 200)
-        response.cache_control.max_age = "3600"
-        return response
-    except StoreApiResponseErrorList as error_list:
-        res["success"] = False
-        res["message"] = " ".join(
-            [
-                f"{error.get('message', 'An error occurred')}"
-                for error in error_list.errors
-            ]
-        )
-    except Exception:
-        res["success"] = False
-        res["message"] = "An error occurred"
-
     return make_response(res, 500)
 
 

--- a/webapp/endpoints/models.py
+++ b/webapp/endpoints/models.py
@@ -8,7 +8,7 @@ from canonicalwebteam.store_api.publishergw import PublisherGW
 
 # Local
 from webapp.decorators import login_required, exchange_required
-from webapp.helpers import api_publisher_session
+from webapp.helpers import api_publisher_session, get_brand_id
 
 
 publisher_gateway = PublisherGW("snap", api_publisher_session)
@@ -53,3 +53,44 @@ def get_models(store_id):
         response = make_response(res, 500)
 
     return response
+
+
+@models.route("/api/store/<store_id>/models/<model_name>/policies")
+@login_required
+@exchange_required
+def get_policies(store_id: str, model_name: str):
+    """
+    Get the policies for a given store model.
+
+    Args:
+        store_id (str): The ID of the store.
+        model_name (str): The name of the model.
+
+    Returns:
+        dict: A dictionary containing the response message and success
+    """
+    brand_id = get_brand_id(flask.session, store_id)
+    res = {}
+
+    try:
+        policies = publisher_gateway.get_store_model_policies(
+            flask.session, brand_id, model_name
+        )
+        res["success"] = True
+        res["data"] = policies
+        response = make_response(res, 200)
+        response.cache_control.max_age = "3600"
+        return response
+    except StoreApiResponseErrorList as error_list:
+        res["success"] = False
+        res["message"] = " ".join(
+            [
+                f"{error.get('message', 'An error occurred')}"
+                for error in error_list.errors
+            ]
+        )
+    except Exception:
+        res["success"] = False
+        res["message"] = "An error occurred"
+
+    return make_response(res, 500)


### PR DESCRIPTION
## Done
Migrates `/api/store/<brand_id>/models/<model_id>/policies` to dedicated endpoints module

Also patches `get_store` method in signing key tests so they don't break

## How to QA
- Go to https://snapcraft-io-5251.demos.haus/api/store/ahnuP3quahti9vis8aiw/models/test-model/policies
- Check that it is the same as https://snapcraft.io/api/store/ahnuP3quahti9vis8aiw/models/test-model/policies

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24126