### PR TITLE
chore: Move verify endpoint to the endpoint section of app

### DIFF
--- a/tests/endpoints/tests_dns_verified_status.py
+++ b/tests/endpoints/tests_dns_verified_status.py
@@ -1,0 +1,26 @@
+import json
+from json import dumps as _dumps
+from unittest.mock import patch, Mock, MagicMock
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestDnsVerifiedStatus(TestEndpoints):
+    @patch("webapp.helpers.get_dns_verification_token")
+    @patch(
+        "canonicalwebteam.store_api.devicegw.DeviceGW.get_item_details",
+        Mock(return_value={"links": {}}),
+    )
+    def test_dns_verified_status(self, mock_get_dns_verification_token):
+        def dumps_wrapper(*args, **kwargs):
+            return _dumps(
+                *args,
+                **(kwargs | {"default": lambda obj: json.dumps({"links": {}})})
+            )
+
+        json.dumps = MagicMock(wraps=dumps_wrapper)
+
+        mock_get_dns_verification_token.return_value = "test-token"
+
+        response = self.client.get("/api/store/test-store-id")
+
+        self.assertEqual(response.status_code, 200)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,6 +28,7 @@ from webapp.packages.store_packages import store_packages
 from webapp.endpoints.views import endpoints
 from webapp.endpoints.signing_keys import signing_keys
 from webapp.endpoints.models import models
+from webapp.endpoints.snaps import snaps
 
 
 TALISKER_WSGI_LOGGER = logging.getLogger("talisker.wsgi")
@@ -73,6 +74,7 @@ def create_app(testing=False):
     app.register_blueprint(endpoints)
     app.register_blueprint(signing_keys)
     app.register_blueprint(models)
+    app.register_blueprint(snaps)
     init_docs(app, "/docs")
     init_blog(app, "/blog")
     init_tutorials(app, "/tutorials")

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -1,0 +1,82 @@
+import flask
+from flask import make_response
+
+import dns.resolver
+import re
+
+import webapp.helpers as helpers
+
+from canonicalwebteam.store_api.devicegw import DeviceGW
+
+device_gateway = DeviceGW("snap", helpers.api_session)
+
+FIELDS = [
+    "title",
+    "summary",
+    "description",
+    "license",
+    "contact",
+    "website",
+    "publisher",
+    "media",
+    "download",
+    "version",
+    "created-at",
+    "confinement",
+    "categories",
+    "trending",
+    "unlisted",
+    "links",
+]
+snaps = flask.Blueprint(
+    "snaps",
+    __name__,
+)
+
+
+snap_regex = "[a-z0-9-]*[a-z][a-z0-9-]*"
+
+
+def _get_snap_link_fields(snap_name):
+    details = device_gateway.get_item_details(
+        snap_name, api_version=2, fields=FIELDS
+    )
+    context = {
+        "links": details["snap"].get("links", {}),
+    }
+    return context
+
+
+@snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/verify')
+def dns_verified_status(snap_name):
+    res = {"primary_domain": False, "token": None}
+    context = _get_snap_link_fields(snap_name)
+
+    primary_domain = None
+
+    if "website" in context["links"]:
+        primary_domain = context["links"]["website"][0]
+
+    if primary_domain:
+        token = helpers.get_dns_verification_token(snap_name, primary_domain)
+
+        domain = re.compile(r"https?://")
+        domain = domain.sub("", primary_domain).strip().strip("/")
+
+        res["token"] = token
+
+        try:
+            dns_txt_records = [
+                dns_record.to_text()
+                for dns_record in dns.resolver.resolve(domain, "TXT").rrset
+            ]
+
+            if f'"SNAPCRAFT_IO_VERIFICATION={token}"' in dns_txt_records:
+                res["primary_domain"] = True
+
+        except Exception:
+            res["primary_domain"] = False
+
+    response = make_response(res, 200)
+    response.cache_control.max_age = "3600"
+    return response

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -1,9 +1,7 @@
 import flask
-from flask import make_response, Response
+from flask import Response
 
 import humanize
-import dns.resolver
-import re
 import os
 
 import webapp.helpers as helpers
@@ -45,15 +43,6 @@ FIELDS = [
 def snap_details_views(store):
     snap_regex = "[a-z0-9-]*[a-z][a-z0-9-]*"
     snap_regex_upercase = "[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*"
-
-    def _get_snap_link_fields(snap_name):
-        details = device_gateway.get_item_details(
-            snap_name, api_version=2, fields=FIELDS
-        )
-        context = {
-            "links": details["snap"].get("links", {}),
-        }
-        return context
 
     def _get_context_snap_details(snap_name):
         details = device_gateway.get_item_details(
@@ -201,42 +190,6 @@ def snap_details_views(store):
         }
 
         return context
-
-    @store.route('/api/<regex("' + snap_regex + '"):snap_name>/verify')
-    def dns_verified_status(snap_name):
-        res = {"primary_domain": False, "token": None}
-        context = _get_snap_link_fields(snap_name)
-
-        primary_domain = None
-
-        if "website" in context["links"]:
-            primary_domain = context["links"]["website"][0]
-
-        if primary_domain:
-            token = helpers.get_dns_verification_token(
-                snap_name, primary_domain
-            )
-
-            domain = re.compile(r"https?://")
-            domain = domain.sub("", primary_domain).strip().strip("/")
-
-            res["token"] = token
-
-            try:
-                dns_txt_records = [
-                    dns_record.to_text()
-                    for dns_record in dns.resolver.resolve(domain, "TXT").rrset
-                ]
-
-                if f'"SNAPCRAFT_IO_VERIFICATION={token}"' in dns_txt_records:
-                    res["primary_domain"] = True
-
-            except Exception:
-                res["primary_domain"] = False
-
-        response = make_response(res, 200)
-        response.cache_control.max_age = "3600"
-        return response
 
     @store.route('/<regex("' + snap_regex + '"):snap_name>')
     def snap_details(snap_name):


### PR DESCRIPTION
## Done
Migrate `/api/<snap_id>/verify` to endpoints section of app

## How to QA
- Go to https://snapcraft-io-5252.demos.haus/api/steve-test-snap/verify
- Check that it is the same as https://snapcraft.io/api/steve-test-snap/verify
- Go to https://snapcraft-io-5252.demos.haus/api/fran-snap/verify
- Check that it is the same as https://snapcraft.io/api/fran-snap/verify

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24105