### PR TITLE
chore: Move snap search endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/tests_snaps_search.py
+++ b/tests/endpoints/tests_snaps_search.py
@@ -1,0 +1,61 @@
+from unittest.mock import patch
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestSnapsSearch(TestEndpoints):
+    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store_snaps")
+    def test_get_snaps_search(self, mock_get_store_snaps):
+        """Test basic functionality of get_snaps_search endpoint"""
+
+        test_snaps = {
+            "snaps": [
+                {
+                    "name": "test-snap-1",
+                    "id": "snap-1-id",
+                    "title": "Test Snap 1",
+                    "summary": "A test snap for testing",
+                },
+                {
+                    "name": "test-snap-2",
+                    "id": "snap-2-id",
+                    "title": "Test Snap 2",
+                    "summary": "Another test snap",
+                },
+            ],
+            "total": 2,
+        }
+
+        mock_get_store_snaps.return_value = test_snaps
+
+        response = self.client.get("/api/test-store-id/snaps/search")
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, test_snaps)
+
+    @patch("canonicalwebteam.store_api.dashboard.Dashboard.get_store_snaps")
+    def test_get_snaps_search_with_query_params(self, mock_get_store_snaps):
+        test_snaps = {
+            "snaps": [
+                {
+                    "name": "filtered-snap",
+                    "id": "filtered-snap-id",
+                    "title": "Filtered Snap",
+                    "summary": "A filtered snap",
+                }
+            ],
+            "total": 1,
+        }
+
+        mock_get_store_snaps.return_value = test_snaps
+
+        response = self.client.get(
+            (
+                "/api/test-store-id/snaps/search"
+                "?q=test-query&allowed_for_inclusion=true"
+            )
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, test_snaps)

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -64,20 +64,6 @@ def post_settings(store_id):
     return jsonify({"success": True})
 
 
-@admin.route("/api/<store_id>/snaps/search")
-@login_required
-@exchange_required
-def get_snaps_search(store_id):
-    snaps = dashboard.get_store_snaps(
-        flask.session,
-        store_id,
-        flask.request.args.get("q"),
-        flask.request.args.get("allowed_for_inclusion"),
-    )
-
-    return jsonify(snaps)
-
-
 @admin.route("/api/store/<store_id>/snaps")
 @login_required
 @exchange_required

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -29,6 +29,7 @@ from webapp.endpoints.views import endpoints
 from webapp.endpoints.signing_keys import signing_keys
 from webapp.endpoints.models import models
 from webapp.endpoints.snaps import snaps
+from webapp.endpoints.snap_search import snap_search
 from webapp.endpoints.validation_sets import validation_sets
 
 
@@ -76,6 +77,7 @@ def create_app(testing=False):
     app.register_blueprint(signing_keys)
     app.register_blueprint(models)
     app.register_blueprint(snaps)
+    app.register_blueprint(snap_search)
     app.register_blueprint(validation_sets)
     init_docs(app, "/docs")
     init_blog(app, "/blog")

--- a/webapp/endpoints/snap_search.py
+++ b/webapp/endpoints/snap_search.py
@@ -1,0 +1,25 @@
+import flask
+from flask.json import jsonify
+from canonicalwebteam.store_api.dashboard import Dashboard
+
+# Local
+from webapp.decorators import login_required, exchange_required
+from webapp.helpers import api_session
+
+dashboard = Dashboard(api_session)
+
+snap_search = flask.Blueprint("snap_search", __name__)
+
+
+@snap_search.route("/api/<store_id>/snaps/search")
+@login_required
+@exchange_required
+def get_snaps_search(store_id):
+    snaps = dashboard.get_store_snaps(
+        flask.session,
+        store_id,
+        flask.request.args.get("q"),
+        flask.request.args.get("allowed_for_inclusion"),
+    )
+
+    return jsonify(snaps)


### PR DESCRIPTION
## Done
Moves the snaps search endpoint into the endpoints section of the app

## How to QA
- Go to https://snapcraft-io-5259.demos.haus/api/ahnuP3quahti9vis8aiw/snaps/search
- Check it is the same as https://snapcraft.io/api/ahnuP3quahti9vis8aiw/snaps/search
- Go to https://snapcraft-io-5259.demos.haus/api/ahnuP3quahti9vis8aiw/snaps/search?q=canonical
- Check it is the same as https://snapcraft.io/api/ahnuP3quahti9vis8aiw/snaps/search?q=canonical

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24113
