### PR TITLE
chore: Move update invite endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/tests_invites.py
+++ b/tests/endpoints/tests_invites.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from tests.endpoints.endpoint_testing import TestEndpoints
@@ -30,3 +31,24 @@ class TestInvites(TestEndpoints):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data, mock_invites_data)
+
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.update_store_invites"
+    )
+    def test_update_invite_status(self, mock_update_store_invites):
+        """Test successful invite status update"""
+        mock_invites_data = [
+            {"id": "invite-1", "status": "accepted"},
+            {"id": "invite-2", "status": "declined"},
+        ]
+
+        mock_update_store_invites.return_value = None
+
+        response = self.client.post(
+            "/api/store/test-store-id/invite/update",
+            data={"invites": json.dumps(mock_invites_data)},
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["msg"], "Changes saved")

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -69,31 +69,6 @@ def post_invite_members(store_id):
     return jsonify(res)
 
 
-@admin.route("/api/store/<store_id>/invite/update", methods=["POST"])
-@login_required
-@exchange_required
-def update_invite_status(store_id):
-    invites = json.loads(flask.request.form.get("invites"))
-
-    res = {}
-
-    try:
-        dashboard.update_store_invites(flask.session, store_id, invites)
-        res["msg"] = "Changes saved"
-    except StoreApiResponseErrorList as api_response_error_list:
-        msgs = [
-            f"{error.get('message', 'An error occurred')}"
-            for error in api_response_error_list.errors
-        ]
-
-        msgs = list(dict.fromkeys(msgs))
-
-        for msg in msgs:
-            flask.flash(msg, "negative")
-
-    return jsonify(res)
-
-
 # -------------------- FEATURED SNAPS AUTOMATION ------------------
 @admin.route("/admin/featured", methods=["POST"])
 @login_required

--- a/webapp/endpoints/invites.py
+++ b/webapp/endpoints/invites.py
@@ -1,5 +1,9 @@
 # Packages
+import json
 import flask
+from canonicalwebteam.exceptions import (
+    StoreApiResponseErrorList,
+)
 from canonicalwebteam.store_api.dashboard import Dashboard
 from flask.json import jsonify
 
@@ -23,3 +27,28 @@ def get_invites(store_id):
     invites = dashboard.get_store_invites(flask.session, store_id)
 
     return jsonify(invites)
+
+
+@invites.route("/api/store/<store_id>/invite/update", methods=["POST"])
+@login_required
+@exchange_required
+def update_invite_status(store_id):
+    invites = json.loads(flask.request.form.get("invites"))
+
+    res = {}
+
+    try:
+        dashboard.update_store_invites(flask.session, store_id, invites)
+        res["msg"] = "Changes saved"
+    except StoreApiResponseErrorList as api_response_error_list:
+        msgs = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in api_response_error_list.errors
+        ]
+
+        msgs = list(dict.fromkeys(msgs))
+
+        for msg in msgs:
+            flask.flash(msg, "negative")
+
+    return jsonify(res)


### PR DESCRIPTION
## Done
Moves the update invite endpoint to the endpoints section of the app

## How to QA
- Go to https://snapcraft-io-5272.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Go to the invites table and reopen an invite
- It should change the status to "Pending"

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24122
