### PR TITLE
fix: check supported archs when showing last updates

### DIFF
--- a/webapp/store/content/distros/arch.yaml
+++ b/webapp/store/content/distros/arch.yaml
@@ -3,6 +3,9 @@ color-1: "#1793D1"
 color-2: "#116F9E"
 logo: https://assets.ubuntu.com/v1/feca0fc0-Distro_Logo_ArchLinux.svg
 logo-mono: https://assets.ubuntu.com/v1/d1dabe71-Distro_Logo_ArchLinux_White.svg
+supported-archs:
+  - amd64
+  - arm64
 install:
   - action: |
       On Arch Linux, snap can be installed from the <a href="https://aur.archlinux.org/packages/snapd/" >Arch User Repository (AUR).</a>

--- a/webapp/store/content/distros/centos.yaml
+++ b/webapp/store/content/distros/centos.yaml
@@ -3,6 +3,11 @@ color-1: "#265AA3"
 color-2: "#0E223D"
 logo: https://assets.ubuntu.com/v1/acf876d9-Distro_Logo_CentOS.svg
 logo-mono: https://assets.ubuntu.com/v1/7d49bfed-Distro_Logo_CentOS_White.svg
+supported-archs:
+  - amd64
+  - arm64
+  - ppc64el
+  - s390x
 install:
   -
     action: |

--- a/webapp/store/content/distros/debian.yaml
+++ b/webapp/store/content/distros/debian.yaml
@@ -3,6 +3,14 @@ color-1: "#A80030"
 color-2: "#750022"
 logo: https://assets.ubuntu.com/v1/cfdc1144-Distro_Logo_Debian.svg
 logo-mono: https://assets.ubuntu.com/v1/dc7be4e8-Distro_Logo_Debian_White.svg
+supported-archs:
+  - amd64
+  - arm64
+  - armhf
+  - i386
+  - ppc64el
+  - s390x
+  - riscv64
 install:
   -
     action: |

--- a/webapp/store/content/distros/elementary.yaml
+++ b/webapp/store/content/distros/elementary.yaml
@@ -3,6 +3,8 @@ color-1: "#95A3AB"
 color-2: "#485A6C"
 logo: https://assets.ubuntu.com/v1/c0c09661-Distro_Logo_Elementary.svg
 logo-mono: https://assets.ubuntu.com/v1/4f36b56d-Distro_Logo_Elementary_White.svg
+supported-archs:
+  - amd64
 install:
   -
     action: |

--- a/webapp/store/content/distros/fedora.yaml
+++ b/webapp/store/content/distros/fedora.yaml
@@ -3,6 +3,11 @@ color-1: "#3C6EB4"
 color-2: "#294172"
 logo: https://assets.ubuntu.com/v1/c93d842f-fedora.png
 logo-mono: https://assets.ubuntu.com/v1/c93d842f-fedora.png
+supported-archs:
+  - amd64
+  - arm64
+  - ppc64el
+  - s390x
 install:
   -
     action: |

--- a/webapp/store/content/distros/kde-neon.yaml
+++ b/webapp/store/content/distros/kde-neon.yaml
@@ -3,6 +3,8 @@ color-1: "#20A3A8"
 color-2: "#167275"
 logo: https://assets.ubuntu.com/v1/d0593902-Distro_Logo_KDE+Neon.svg
 logo-mono: https://assets.ubuntu.com/v1/31ced116-Distro_Logo_KDE+Neon_White.svg
+supported-archs:
+  - amd64
 install:
   -
     action: |

--- a/webapp/store/content/distros/kubuntu.yaml
+++ b/webapp/store/content/distros/kubuntu.yaml
@@ -3,6 +3,9 @@ color-1: "#0079C1"
 color-2: "#005A8F"
 logo: https://assets.ubuntu.com/v1/7ab50a06-Distro_Logo_Kubuntu.svg
 logo-mono: https://assets.ubuntu.com/v1/e9f102e3-Distro_Logo_Kubuntu_White.svg
+supported-archs:
+  - amd64
+  - arm64
 install:
   -
     action: |

--- a/webapp/store/content/distros/manjaro.yaml
+++ b/webapp/store/content/distros/manjaro.yaml
@@ -3,6 +3,9 @@ color-1: "#35BF5C"
 color-2: "#278C44"
 logo: https://assets.ubuntu.com/v1/4635a0bd-Distro_Logo_Manjaro.svg
 logo-mono: https://assets.ubuntu.com/v1/e1b2fbdb-Distro_Logo_Manjaro_White.svg
+supported-archs:
+  - amd64
+  - arm64
 install:
   -
     action: |

--- a/webapp/store/content/distros/opensuse.yaml
+++ b/webapp/store/content/distros/opensuse.yaml
@@ -3,6 +3,12 @@ color-1: "#73BA25"
 color-2: "#54871B"
 logo: https://assets.ubuntu.com/v1/610301c6-Distro_Logo_OpenSUSE.svg
 logo-mono: https://assets.ubuntu.com/v1/e4e63887-Distro_Logo_OpenSUSE_White.svg
+supported-archs:
+  - amd64
+  - arm64
+  - ppc64el
+  - s390x
+  - i386
 install:
   -
     action: |

--- a/webapp/store/content/distros/pop.yaml
+++ b/webapp/store/content/distros/pop.yaml
@@ -3,6 +3,8 @@ color-1: "#48B9C7"
 color-2: "#102a4c"
 logo: https://assets.ubuntu.com/v1/c7ca0dfa-Distro_Logo_Pop.svg
 logo-mono: https://assets.ubuntu.com/v1/91e233bc-PopOS-short-white.svg
+supported-archs:
+  - amd64
 install:
   -
     action: |

--- a/webapp/store/content/distros/raspbian.yaml
+++ b/webapp/store/content/distros/raspbian.yaml
@@ -3,6 +3,9 @@ color-1: "#c05672"
 color-2: "#a22846"
 logo: https://assets.ubuntu.com/v1/193cb6ac-logo-raspberry-pi.svg
 logo-mono: https://assets.ubuntu.com/v1/a31b1451-rpi-b-w.svg
+supported-archs:
+  - armhf
+  - arm64
 install:
   - action: |
       On a <a href="https://www.raspberrypi.org/" >Raspberry Pi</a> running the latest version of <a href="https://www.raspberrypi.org/downloads/raspbian/" >Raspbian</a> snap can be installed directly from the command line:

--- a/webapp/store/content/distros/rhel.yaml
+++ b/webapp/store/content/distros/rhel.yaml
@@ -3,6 +3,11 @@ color-1: "#ee0000"
 color-2: "#820000"
 logo: https://assets.ubuntu.com/v1/be89e41a-red-hat-2019-primary-stacked.svg
 logo-mono: https://assets.ubuntu.com/v1/eb20b7c6-red-hat-mono.svg
+supported-archs:
+  - amd64
+  - arm64
+  - ppc64el
+  - s390x
 install:
   - action: |
       Snap is available for <a href="https://www.redhat.com/en/enterprise-linux-8" >Red Hat Enterprise Linux (RHEL) 8</a> and RHEL 7, from the 7.6 release onward.

--- a/webapp/store/content/distros/ubuntu.yaml
+++ b/webapp/store/content/distros/ubuntu.yaml
@@ -3,6 +3,14 @@ color-1: "#E95420"
 color-2: "#B54119"
 logo: https://assets.ubuntu.com/v1/2d850f3f-CoF%20Circle%20New.svg
 logo-mono: https://assets.ubuntu.com/v1/4aff6463-ubuntu-logo-mono.svg
+supported-archs:
+  - amd64
+  - arm64
+  - armhf
+  - i386
+  - ppc64el
+  - s390x
+  - riscv64
 install:
   -
     action: |

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -277,7 +277,9 @@ def get_snap_categories(snap_categories):
     return categories
 
 
-def get_latest_versions(channel_maps, default_track, lowest_risk):
+def get_latest_versions(
+    channel_maps, default_track, lowest_risk, supported_architectures=None
+):
     """Get the latest versions of both default/stable and the latest of
     all other channels, unless it's default/stable
 
@@ -289,16 +291,19 @@ def get_latest_versions(channel_maps, default_track, lowest_risk):
 
     default_stable = None
     other = None
-
     for channel in ordered_versions:
         if (
-            channel["track"] == default_track
-            and channel["risk"] == lowest_risk
+            not supported_architectures
+            or channel["architecture"] in supported_architectures
         ):
-            if not default_stable:
-                default_stable = channel
-        elif not other:
-            other = channel
+            if (
+                channel["track"] == default_track
+                and channel["risk"] == lowest_risk
+            ):
+                if not default_stable:
+                    default_stable = channel
+            elif not other:
+                other = channel
 
     if default_stable:
         default_stable["released-at-display"] = convert_date(

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -423,11 +423,11 @@ def snap_details_views(store):
         if not distro_data:
             flask.abort(404)
 
-        if all(arch not in context["channel_map"] for arch in supported_archs):
-            return flask.render_template("404.html"), 404
-
         supported_archs = distro_data["supported-archs"]
         context = _get_context_snap_details(snap_name, supported_archs)
+
+        if all(arch not in context["channel_map"] for arch in supported_archs):
+            return flask.render_template("404.html"), 404
 
         context.update(
             {

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -423,11 +423,11 @@ def snap_details_views(store):
         if not distro_data:
             flask.abort(404)
 
-        supported_archs = distro_data["supported-archs"]
-        context = _get_context_snap_details(snap_name, supported_archs)
-
         if all(arch not in context["channel_map"] for arch in supported_archs):
             return flask.render_template("404.html"), 404
+
+        supported_archs = distro_data["supported-archs"]
+        context = _get_context_snap_details(snap_name, supported_archs)
 
         context.update(
             {
@@ -438,7 +438,6 @@ def snap_details_views(store):
                 "distro_color_1": distro_data["color-1"],
                 "distro_color_2": distro_data["color-2"],
                 "distro_install_steps": distro_data["install"],
-                "distro_supported_archs": supported_archs,
             }
         )
 

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -44,7 +44,7 @@ def snap_details_views(store):
     snap_regex = "[a-z0-9-]*[a-z][a-z0-9-]*"
     snap_regex_upercase = "[A-Za-z0-9-]*[A-Za-z][A-Za-z0-9-]*"
 
-    def _get_context_snap_details(snap_name):
+    def _get_context_snap_details(snap_name, supported_architectures=None):
         details = device_gateway.get_item_details(
             snap_name, fields=FIELDS, api_version=2
         )
@@ -87,7 +87,10 @@ def snap_details_views(store):
 
         last_updated = latest_channel["channel"]["released-at"]
         updates = logic.get_latest_versions(
-            details.get("channel-map"), default_track, lowest_risk_available
+            details.get("channel-map"),
+            default_track,
+            lowest_risk_available,
+            supported_architectures,
         )
         binary_filesize = latest_channel["download"]["size"]
 
@@ -420,14 +423,11 @@ def snap_details_views(store):
         if not distro_data:
             flask.abort(404)
 
-        context = _get_context_snap_details(snap_name)
+        supported_archs = distro_data["supported-archs"]
+        context = _get_context_snap_details(snap_name, supported_archs)
 
-        if distro == "raspbian":
-            if (
-                "armhf" not in context["channel_map"]
-                and "arm64" not in context["channel_map"]
-            ):
-                return flask.render_template("404.html"), 404
+        if all(arch not in context["channel_map"] for arch in supported_archs):
+            return flask.render_template("404.html"), 404
 
         context.update(
             {
@@ -438,6 +438,7 @@ def snap_details_views(store):
                 "distro_color_1": distro_data["color-1"],
                 "distro_color_2": distro_data["color-2"],
                 "distro_install_steps": distro_data["install"],
+                "distro_supported_archs": supported_archs,
             }
         )
 


### PR DESCRIPTION
## Done
- added supported archs for every distro
- show 404 if the snap isnt released for the supported arch
- show the correct release date in the distro page

## How to QA
- go to https://snapcraft-io-5273.demos.haus/jami
- verify the latest date is "18 July 2025 - latest/stable
23 July 2025 - latest/edge"
- go to https://snapcraft-io-5273.demos.haus/install/jami/raspbian
- verify the latest date is "17 April 2021 - latest/edge"
- go to https://snapcraft-io-5273.demos.haus/install/jami/ubuntu
- verify the latest update date is "18 July 2025 - latest/stable
23 July 2025 - latest/edge"

(You can check the dates rom the[ releases section](https://snapcraft-io-5273.demos.haus/jami/releases))

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why):

## Issue / Card
Fixes #https://warthogs.atlassian.net/browse/WD-23619

