### PR TITLE
chore: Move send invite endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/tests_invites.py
+++ b/tests/endpoints/tests_invites.py
@@ -52,3 +52,24 @@ class TestInvites(TestEndpoints):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(data["msg"], "Changes saved")
+
+    @patch(
+        "canonicalwebteam.store_api.dashboard.Dashboard.invite_store_members"
+    )
+    def test_post_invite_members_success(self, mock_invite_store_members):
+        """Test successful invitation of store members"""
+        mock_members_data = [
+            {"email": "user1@example.com", "roles": ["admin"]},
+            {"email": "user2@example.com", "roles": ["view"]},
+        ]
+
+        mock_invite_store_members.return_value = None
+
+        response = self.client.post(
+            "/api/store/test-store-id/invite",
+            data={"members": json.dumps(mock_members_data)},
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["msg"], "Changes saved")

--- a/webapp/admin/views.py
+++ b/webapp/admin/views.py
@@ -1,15 +1,10 @@
 # Packages
 import os
-import json
 import flask
 from flask import make_response
-from canonicalwebteam.exceptions import (
-    StoreApiResponseErrorList,
-)
 from canonicalwebteam.store_api.dashboard import Dashboard
 from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.store_api.devicegw import DeviceGW
-from flask.json import jsonify
 
 # Local
 from webapp.decorators import login_required, exchange_required
@@ -42,31 +37,6 @@ def get_brand_id(session, store_id):
 @exchange_required
 def get_admin(path):
     return flask.render_template("admin/admin.html", **context)
-
-
-@admin.route("/api/store/<store_id>/invite", methods=["POST"])
-@login_required
-@exchange_required
-def post_invite_members(store_id):
-    members = json.loads(flask.request.form.get("members"))
-
-    res = {}
-
-    try:
-        dashboard.invite_store_members(flask.session, store_id, members)
-        res["msg"] = "Changes saved"
-    except StoreApiResponseErrorList as api_response_error_list:
-        msgs = [
-            f"{error.get('message', 'An error occurred')}"
-            for error in api_response_error_list.errors
-        ]
-
-        msgs = list(dict.fromkeys(msgs))
-
-        for msg in msgs:
-            flask.flash(msg, "negative")
-
-    return jsonify(res)
 
 
 # -------------------- FEATURED SNAPS AUTOMATION ------------------

--- a/webapp/endpoints/invites.py
+++ b/webapp/endpoints/invites.py
@@ -52,3 +52,28 @@ def update_invite_status(store_id):
             flask.flash(msg, "negative")
 
     return jsonify(res)
+
+
+@invites.route("/api/store/<store_id>/invite", methods=["POST"])
+@login_required
+@exchange_required
+def post_invite_members(store_id):
+    members = json.loads(flask.request.form.get("members"))
+
+    res = {}
+
+    try:
+        dashboard.invite_store_members(flask.session, store_id, members)
+        res["msg"] = "Changes saved"
+    except StoreApiResponseErrorList as api_response_error_list:
+        msgs = [
+            f"{error.get('message', 'An error occurred')}"
+            for error in api_response_error_list.errors
+        ]
+
+        msgs = list(dict.fromkeys(msgs))
+
+        for msg in msgs:
+            flask.flash(msg, "negative")
+
+    return jsonify(res)


### PR DESCRIPTION
## Done
Moves the send invite endpoint to the endpoints section of the app

## How to QA
- Go to https://snapcraft-io-5274.demos.haus/admin/ahnuP3quahti9vis8aiw/members
- Add a member with a dummy email address (your.name+whatever@canonical.com)
- Send the invite when it asks you to
- You should receive an invite
- **Note**: There is a bug where sending the invite appears to add the user to the store, although they are not there when refreshing the page. [This is an existing bug](https://warthogs.atlassian.net/browse/WD-24554)

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24121
