### PR TITLE
chore: Move get build endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestGetSnapBuildPage(TestEndpoints):
+    def setUp(self):
+        super().setUp()
+        self.snap_name = "test-snap"
+        self.build_id = "12345"
+        self.endpoint_url = f"/{self.snap_name}/builds/{self.build_id}"
+
+    @patch("webapp.endpoints.publisher.builds.dashboard")
+    def test_get_snap_build_page_success(self, mock_dashboard):
+        """Test successful rendering of snap build page"""
+        # Mock snap info response
+        mock_snap_info = {
+            "snap_name": self.snap_name,
+            "title": "Test Snap",
+            "snap_id": "test-snap-id-123",
+        }
+        mock_dashboard.get_snap_info.return_value = mock_snap_info
+
+        response = self.client.get(self.endpoint_url)
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"text/html", response.content_type.encode())
+
+        # Verify dashboard method was called with correct session and snap name
+        mock_dashboard.get_snap_info.assert_called_once()
+        call_args = mock_dashboard.get_snap_info.call_args
+        self.assertEqual(call_args[0][1], self.snap_name)
+
+    def test_get_snap_build_page_requires_login(self):
+        """Test that the endpoint requires login"""
+        # Create a new client without logging in
+        app = self.app
+        client = app.test_client()
+
+        response = client.get(self.endpoint_url)
+
+        # Should redirect to login or return unauthorized
+        # The exact behavior depends on the login_required decorator
+        self.assertIn(response.status_code, [302, 401, 403])

--- a/webapp/endpoints/publisher/builds.py
+++ b/webapp/endpoints/publisher/builds.py
@@ -1,0 +1,18 @@
+# Packages
+import flask
+from canonicalwebteam.store_api.dashboard import Dashboard
+
+# Local
+from webapp.helpers import api_publisher_session
+from webapp.decorators import login_required
+
+dashboard = Dashboard(api_publisher_session)
+
+
+@login_required
+def get_snap_build_page(snap_name, build_id):
+    # If this fails, the page will 404
+    dashboard.get_snap_info(flask.session, snap_name)
+    return flask.render_template(
+        "store/publisher.html", snap_name=snap_name, build_id=build_id
+    )

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -73,15 +73,6 @@ def get_snap_builds_page(snap_name):
 
 
 @login_required
-def get_snap_build_page(snap_name, build_id):
-    # If this fails, the page will 404
-    dashboard.get_snap_info(flask.session, snap_name)
-    return flask.render_template(
-        "store/publisher.html", snap_name=snap_name, build_id=build_id
-    )
-
-
-@login_required
 def get_snap_builds(snap_name):
     res = {"message": "", "success": True}
     data = {"snap_builds": [], "total_builds": 0}

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -28,6 +28,7 @@ from webapp.publisher.snaps import (
     settings_views,
     collaboration_views,
 )
+from webapp.endpoints.publisher.builds import get_snap_build_page
 from webapp.endpoints.publisher.settings import get_settings_data
 from webapp.endpoints import releases, builds
 from webapp.publisher.snaps.builds import map_snap_build_status
@@ -93,7 +94,7 @@ publisher_snaps.add_url_rule(
 
 publisher_snaps.add_url_rule(
     "/<snap_name>/builds/<build_id>",
-    view_func=build_views.get_snap_build_page,
+    view_func=get_snap_build_page,
     methods=["GET"],
 ),
 


### PR DESCRIPTION
## Done
Moves the build endpoint to the endpoints section of the app

## How to QA
- Run locally (doesn't work on demos) - you need to [set up your GH tokens locally](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds)
- Go to /<snap_name>/builds
- Click on a build
- Check that it loads the build data

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24589
