### PR TITLE
chore: Move snap metadata endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/publisher/tests_packages.py
+++ b/tests/endpoints/publisher/tests_packages.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+from canonicalwebteam.exceptions import StoreApiResourceNotFound
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestGetPackageMetadata(TestEndpoints):
+    @patch("webapp.endpoints.publisher.packages.publisher_gateway")
+    def test_get_package_metadata_success(self, mock_publisher_gateway):
+        # Mock successful response from publisher gateway
+        mock_package_metadata = {
+            "snap_name": "test-snap",
+            "title": "Test Snap",
+            "snap_id": "test-snap-id-123",
+            "publisher": {"display-name": "Test Publisher"},
+            "license": "MIT",
+            "private": False,
+            "status": "Published",
+            "version": "1.0.0",
+        }
+        mock_publisher_gateway.get_package_metadata.return_value = (
+            mock_package_metadata
+        )
+
+        # Make the request
+        response = self.client.get("/api/packages/test-snap")
+        data = response.json
+
+        # Assert response structure
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertIn("data", data)
+        self.assertEqual(data["data"], mock_package_metadata)
+
+        # Verify the gateway was called with correct parameters
+        mock_publisher_gateway.get_package_metadata.assert_called_once()
+
+    @patch("webapp.endpoints.publisher.packages.publisher_gateway")
+    def test_get_package_metadata_not_found(self, mock_publisher_gateway):
+        # Mock StoreApiResourceNotFound exception
+        mock_publisher_gateway.get_package_metadata.side_effect = (
+            StoreApiResourceNotFound()
+        )
+
+        # Make the request
+        response = self.client.get("/api/packages/test-snap")
+        data = response.json
+
+        # Assert 404 response
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["error"], "Package not found")

--- a/webapp/endpoints/publisher/packages.py
+++ b/webapp/endpoints/publisher/packages.py
@@ -1,0 +1,61 @@
+# Packages
+import flask
+from canonicalwebteam.store_api.publishergw import PublisherGW
+from canonicalwebteam.exceptions import (
+    StoreApiError,
+    StoreApiResponseErrorList,
+    StoreApiResponseError,
+    StoreApiResourceNotFound,
+)
+from flask.json import jsonify
+
+# Local
+from webapp.helpers import api_publisher_session
+from webapp.decorators import exchange_required, login_required
+
+publisher_gateway = PublisherGW("snap", api_publisher_session)
+
+
+@login_required
+@exchange_required
+def get_package_metadata(snap_name):
+    try:
+        package_metadata = publisher_gateway.get_package_metadata(
+            flask.session, snap_name
+        )
+        return jsonify({"data": package_metadata, "success": True})
+    except StoreApiResourceNotFound:
+        return (jsonify({"error": "Package not found", "success": False}), 404)
+    except StoreApiResponseErrorList as error:
+        return (
+            jsonify(
+                {
+                    "error": "Error occurred while fetching snap metadata.",
+                    "errors": error.errors,
+                    "success": False,
+                }
+            ),
+            error.status_code,
+        )
+    except StoreApiResponseError as error:
+        return (
+            jsonify(
+                {
+                    "error": "Error occurred while fetching snap metadata.",
+                    "success": False,
+                }
+            ),
+            error.status_code,
+        )
+    except StoreApiError:
+        return (
+            jsonify(
+                {
+                    "error": "Error occurred while fetching snap metadata.",
+                    "success": False,
+                }
+            ),
+            500,
+        )
+    except Exception:
+        return (jsonify({"error": "Unexpected error", "success": False}), 500)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -6,8 +6,6 @@ from canonicalwebteam.store_api.publishergw import PublisherGW
 from canonicalwebteam.exceptions import (
     StoreApiError,
     StoreApiResponseErrorList,
-    StoreApiResponseError,
-    StoreApiResourceNotFound,
 )
 from flask.json import jsonify
 from talisker import logging
@@ -34,6 +32,7 @@ from webapp.endpoints.publisher.settings import (
     post_settings_data,
 )
 from webapp.endpoints.publisher.publicise import get_publicise_data
+from webapp.endpoints.publisher.packages import get_package_metadata
 from webapp.endpoints import releases, builds
 from webapp.publisher.snaps.builds import map_snap_build_status
 
@@ -444,50 +443,11 @@ def post_register_name():
     return jsonify({"success": True})
 
 
-@publisher_snaps.route("/api/packages/<snap_name>", methods=["GET"])
-@login_required
-@exchange_required
-def get_package_metadata(snap_name):
-    try:
-        package_metadata = publisher_gateway.get_package_metadata(
-            flask.session, snap_name
-        )
-        return jsonify({"data": package_metadata, "success": True})
-    except StoreApiResourceNotFound:
-        return (jsonify({"error": "Package not found", "success": False}), 404)
-    except StoreApiResponseErrorList as error:
-        return (
-            jsonify(
-                {
-                    "error": "Error occurred while fetching snap metadata.",
-                    "errors": error.errors,
-                    "success": False,
-                }
-            ),
-            error.status_code,
-        )
-    except StoreApiResponseError as error:
-        return (
-            jsonify(
-                {
-                    "error": "Error occurred while fetching snap metadata.",
-                    "success": False,
-                }
-            ),
-            error.status_code,
-        )
-    except StoreApiError:
-        return (
-            jsonify(
-                {
-                    "error": "Error occurred while fetching snap metadata.",
-                    "success": False,
-                }
-            ),
-            500,
-        )
-    except Exception:
-        return (jsonify({"error": "Unexpected error", "success": False}), 500)
+publisher_snaps.add_url_rule(
+    "/api/packages/<snap_name>",
+    view_func=get_package_metadata,
+    methods=["GET"],
+)
 
 
 @publisher_snaps.route("/packages/<package_name>", methods=["DELETE"])


### PR DESCRIPTION
## Done
Moves the snap package metadata endpoint to the endpoints section of the app

## How to QA
- Go to https://snapcraft-io-5286.demos.haus/api/packages/<snap_name>
- Check that it is the same as https://staging.snapcraft.io/api/packages/<snap_name>

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24602
