### PR TITLE
chore: Move validate repo endpoint to endpoints section of app

### DIFF
--- a/webapp/endpoints/publisher/builds.py
+++ b/webapp/endpoints/publisher/builds.py
@@ -4,6 +4,7 @@ from canonicalwebteam.store_api.dashboard import Dashboard
 
 # Local
 from webapp.helpers import api_publisher_session
+from webapp.api.github import GitHub, InvalidYAML
 from webapp.decorators import login_required
 
 dashboard = Dashboard(api_publisher_session)
@@ -15,4 +16,69 @@ def get_snap_build_page(snap_name, build_id):
     dashboard.get_snap_info(flask.session, snap_name)
     return flask.render_template(
         "store/publisher.html", snap_name=snap_name, build_id=build_id
+    )
+
+
+def validate_repo(github_token, snap_name, gh_owner, gh_repo):
+    github = GitHub(github_token)
+    result = {"success": True}
+    yaml_location = github.get_snapcraft_yaml_location(gh_owner, gh_repo)
+
+    # The snapcraft.yaml is not present
+    if not yaml_location:
+        result["success"] = False
+        result["error"] = {
+            "type": "MISSING_YAML_FILE",
+            "message": (
+                "Missing snapcraft.yaml: this repo needs a snapcraft.yaml "
+                "file, so that Snapcraft can make it buildable, installable "
+                "and runnable."
+            ),
+        }
+    # The property name inside the yaml file doesn't match the snap
+    else:
+        try:
+            gh_snap_name = github.get_snapcraft_yaml_data(
+                gh_owner, gh_repo
+            ).get("name")
+
+            if gh_snap_name != snap_name:
+                result["success"] = False
+                result["error"] = {
+                    "type": "SNAP_NAME_DOES_NOT_MATCH",
+                    "message": (
+                        "Name mismatch: the snapcraft.yaml uses the snap "
+                        f'name "{gh_snap_name}", but you\'ve registered'
+                        f' the name "{snap_name}". Update your '
+                        "snapcraft.yaml to continue."
+                    ),
+                    "yaml_location": yaml_location,
+                    "gh_snap_name": gh_snap_name,
+                }
+        except InvalidYAML:
+            result["success"] = False
+            result["error"] = {
+                "type": "INVALID_YAML_FILE",
+                "message": (
+                    "Invalid snapcraft.yaml: there was an issue parsing the "
+                    f"snapcraft.yaml for {snap_name}."
+                ),
+            }
+
+    return result
+
+
+@login_required
+def get_validate_repo(snap_name):
+    details = dashboard.get_snap_info(flask.session, snap_name)
+
+    owner, repo = flask.request.args.get("repo").split("/")
+
+    return flask.jsonify(
+        validate_repo(
+            flask.session.get("github_auth_secret"),
+            details["snap_name"],
+            owner,
+            repo,
+        )
     )

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -180,22 +180,6 @@ def validate_repo(github_token, snap_name, gh_owner, gh_repo):
 
 
 @login_required
-def get_validate_repo(snap_name):
-    details = dashboard.get_snap_info(flask.session, snap_name)
-
-    owner, repo = flask.request.args.get("repo").split("/")
-
-    return flask.jsonify(
-        validate_repo(
-            flask.session.get("github_auth_secret"),
-            details["snap_name"],
-            owner,
-            repo,
-        )
-    )
-
-
-@login_required
 def post_snap_builds(snap_name):
     details = dashboard.get_snap_info(flask.session, snap_name)
 

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -27,7 +27,10 @@ from webapp.publisher.snaps import (
     settings_views,
     collaboration_views,
 )
-from webapp.endpoints.publisher.builds import get_snap_build_page
+from webapp.endpoints.publisher.builds import (
+    get_snap_build_page,
+    get_validate_repo,
+)
 from webapp.endpoints.publisher.settings import (
     get_settings_data,
     post_settings_data,
@@ -125,7 +128,7 @@ publisher_snaps.add_url_rule(
 )
 publisher_snaps.add_url_rule(
     "/api/<snap_name>/builds/validate-repo",
-    view_func=build_views.get_validate_repo,
+    view_func=get_validate_repo,
     methods=["GET"],
 )
 publisher_snaps.add_url_rule(


### PR DESCRIPTION
## Done
Moves the validate repo endpoint to the endpoints section of the app. There are intentionally no changes to the logic to minimise the risk of potential issues.

## How to QA
- Run locally (doesn't work on demos) - you need to [set up your GH tokens locally](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds)
- Go to the builds page of a snap you own e.g. /<snap_name>/builds
- Make sure you can connect to the github repo

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Existing tests

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24590
