### PR TITLE
chore: Move trigger build endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from requests.exceptions import HTTPError
 from tests.endpoints.endpoint_testing import TestEndpoints
 
 
@@ -38,6 +39,132 @@ class TestGetSnapBuildPage(TestEndpoints):
         client = app.test_client()
 
         response = client.get(self.endpoint_url)
+
+        # Should redirect to login or return unauthorized
+        # The exact behavior depends on the login_required decorator
+        self.assertIn(response.status_code, [302, 401, 403])
+
+
+class TestPostBuild(TestEndpoints):
+    def setUp(self):
+        super().setUp()
+        self.snap_name = "test-snap"
+        self.endpoint_url = f"/api/{self.snap_name}/builds/trigger-build"
+
+    @patch("webapp.endpoints.publisher.builds.launchpad")
+    @patch("webapp.endpoints.publisher.builds.dashboard")
+    def test_post_build_success(self, mock_dashboard, mock_launchpad):
+        """Test successful build trigger"""
+        # Mock account snaps to include our test snap
+        mock_dashboard.get_account_snaps.return_value = {
+            self.snap_name: {"snap_name": self.snap_name}
+        }
+
+        # Mock launchpad methods
+        mock_launchpad.is_snap_building.return_value = False
+        mock_launchpad.build_snap.return_value = "build-12345"
+
+        response = self.client.post(self.endpoint_url)
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        response_data = response.get_json()
+        self.assertTrue(response_data["success"])
+        self.assertEqual(response_data["build_id"], "build-12345")
+
+        # Verify method calls
+        mock_dashboard.get_account_snaps.assert_called_once()
+        mock_launchpad.is_snap_building.assert_called_once_with(self.snap_name)
+        mock_launchpad.build_snap.assert_called_once_with(self.snap_name)
+
+    @patch("webapp.endpoints.publisher.builds.launchpad")
+    @patch("webapp.endpoints.publisher.builds.dashboard")
+    def test_post_build_cancels_existing_build(
+        self, mock_dashboard, mock_launchpad
+    ):
+        """Test that existing builds are cancelled before starting new one"""
+        # Mock account snaps to include our test snap
+        mock_dashboard.get_account_snaps.return_value = {
+            self.snap_name: {"snap_name": self.snap_name}
+        }
+
+        # Mock launchpad methods - existing build is running
+        mock_launchpad.is_snap_building.return_value = True
+        mock_launchpad.build_snap.return_value = "build-12345"
+
+        response = self.client.post(self.endpoint_url)
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        response_data = response.get_json()
+        self.assertTrue(response_data["success"])
+        self.assertEqual(response_data["build_id"], "build-12345")
+
+        # Verify existing build was cancelled
+        mock_launchpad.is_snap_building.assert_called_once_with(self.snap_name)
+        mock_launchpad.cancel_snap_builds.assert_called_once_with(
+            self.snap_name
+        )
+        mock_launchpad.build_snap.assert_called_once_with(self.snap_name)
+
+    @patch("webapp.endpoints.publisher.builds.dashboard")
+    def test_post_build_forbidden_non_contributor(self, mock_dashboard):
+        """Test that non-contributors cannot trigger builds"""
+        # Mock account snaps to NOT include our test snap
+        mock_dashboard.get_account_snaps.return_value = {}
+
+        response = self.client.post(self.endpoint_url)
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertEqual(response_data["error"]["type"], "FORBIDDEN")
+        self.assertIn(
+            "not allowed to request builds", response_data["error"]["message"]
+        )
+
+    @patch("webapp.endpoints.publisher.builds.launchpad")
+    @patch("webapp.endpoints.publisher.builds.dashboard")
+    def test_post_build_http_error(self, mock_dashboard, mock_launchpad):
+        """Test handling of HTTP errors from Launchpad"""
+        from unittest.mock import Mock
+
+        # Mock account snaps to include our test snap
+        mock_dashboard.get_account_snaps.return_value = {
+            self.snap_name: {"snap_name": self.snap_name}
+        }
+
+        # Mock launchpad methods
+        mock_launchpad.is_snap_building.return_value = False
+
+        # Create mock HTTP error
+        mock_response = Mock()
+        mock_response.text = "Launchpad error message"
+        mock_response.status_code = 500
+        http_error = HTTPError()
+        http_error.response = mock_response
+        mock_launchpad.build_snap.side_effect = http_error
+
+        response = self.client.post(self.endpoint_url)
+
+        # Assert response
+        self.assertEqual(response.status_code, 200)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertIn(
+            "error happened building", response_data["error"]["message"]
+        )
+        self.assertEqual(response_data["details"], "Launchpad error message")
+        self.assertEqual(response_data["status_code"], 500)
+
+    def test_post_build_requires_login(self):
+        """Test that the endpoint requires login"""
+        # Create a new client without logging in
+        app = self.app
+        client = app.test_client()
+
+        response = client.post(self.endpoint_url)
 
         # Should redirect to login or return unauthorized
         # The exact behavior depends on the login_required decorator

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -315,45 +315,6 @@ def post_snap_builds(snap_name):
 
 
 @login_required
-def post_build(snap_name):
-    # Don't allow builds from no contributors
-    account_snaps = dashboard.get_account_snaps(flask.session)
-
-    if snap_name not in account_snaps:
-        return flask.jsonify(
-            {
-                "success": False,
-                "error": {
-                    "type": "FORBIDDEN",
-                    "message": "You are not allowed to request "
-                    "builds for this snap",
-                },
-            }
-        )
-
-    try:
-        if launchpad.is_snap_building(snap_name):
-            launchpad.cancel_snap_builds(snap_name)
-
-        build_id = launchpad.build_snap(snap_name)
-
-    except HTTPError as e:
-        return flask.jsonify(
-            {
-                "success": False,
-                "error": {
-                    "message": "An error happened building "
-                    "this snap, please try again."
-                },
-                "details": e.response.text,
-                "status_code": e.response.status_code,
-            }
-        )
-
-    return flask.jsonify({"success": True, "build_id": build_id})
-
-
-@login_required
 def check_build_request(snap_name, build_id):
     # Don't allow builds from no contributors
     account_snaps = dashboard.get_account_snaps(flask.session)

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -30,6 +30,7 @@ from webapp.publisher.snaps import (
 from webapp.endpoints.publisher.builds import (
     get_snap_build_page,
     get_validate_repo,
+    post_build,
 )
 from webapp.endpoints.publisher.settings import (
     get_settings_data,
@@ -133,7 +134,7 @@ publisher_snaps.add_url_rule(
 )
 publisher_snaps.add_url_rule(
     "/api/<snap_name>/builds/trigger-build",
-    view_func=build_views.post_build,
+    view_func=post_build,
     methods=["POST"],
 )
 publisher_snaps.add_url_rule(


### PR DESCRIPTION
## Done
Moves the trigger build endpoint to the endpoints section of the app. There are intentionally no changes to the logic to minimise the risk of potential issues.

## How to QA
- Run locally (doesn't work on demos) - you need to [set up your GH tokens locally](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds)
- Go to the builds page of a snap you own e.g. /<snap_name>/builds
- Trigger a build
- It should work

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24591
