### PR TITLE
chore: Move register name dispute endpoint to endpoints section of app

### DIFF
--- a/webapp/endpoints/publisher/register.py
+++ b/webapp/endpoints/publisher/register.py
@@ -1,4 +1,5 @@
 # Packages
+import bleach
 import flask
 from canonicalwebteam.store_api.dashboard import Dashboard
 from canonicalwebteam.exceptions import StoreApiResponseErrorList
@@ -68,4 +69,27 @@ def post_register_name():
 
         return jsonify(res)
 
+    return jsonify({"success": True})
+
+
+@login_required
+def post_register_name_dispute():
+    try:
+        claim = flask.json.loads(flask.request.data)
+        snap_name = claim["snap-name"]
+        claim_comment = claim["claim-comment"]
+        dashboard.post_register_name_dispute(
+            flask.session,
+            bleach.clean(snap_name),
+            bleach.clean(claim_comment),
+        )
+    except StoreApiResponseErrorList as api_response_error_list:
+        if api_response_error_list.status_code in [400, 409]:
+            return jsonify(
+                {
+                    "success": False,
+                    "data": api_response_error_list.errors,
+                    "message": api_response_error_list.errors[0]["message"],
+                }
+            )
     return jsonify({"success": True})

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -1,5 +1,4 @@
 # Packages
-import bleach
 import flask
 from canonicalwebteam.store_api.dashboard import Dashboard
 from canonicalwebteam.store_api.publishergw import PublisherGW
@@ -38,7 +37,10 @@ from webapp.endpoints.publisher.settings import (
 )
 from webapp.endpoints.publisher.publicise import get_publicise_data
 from webapp.endpoints.publisher.packages import get_package_metadata
-from webapp.endpoints.publisher.register import post_register_name
+from webapp.endpoints.publisher.register import (
+    post_register_name,
+    post_register_name_dispute,
+)
 from webapp.endpoints import releases, builds
 from webapp.publisher.snaps.builds import map_snap_build_status
 
@@ -400,6 +402,12 @@ publisher_snaps.add_url_rule(
     methods=["POST"],
 )
 
+publisher_snaps.add_url_rule(
+    "/api/register-name-dispute",
+    view_func=post_register_name_dispute,
+    methods=["POST"],
+)
+
 
 @publisher_snaps.route("/packages/<package_name>", methods=["DELETE"])
 @login_required
@@ -485,30 +493,6 @@ def get_register_name_dispute():
     return flask.render_template(
         "store/publisher.html",
     )
-
-
-@publisher_snaps.route("/api/register-name-dispute", methods=["POST"])
-@login_required
-def post_register_name_dispute():
-    try:
-        claim = flask.json.loads(flask.request.data)
-        snap_name = claim["snap-name"]
-        claim_comment = claim["claim-comment"]
-        dashboard.post_register_name_dispute(
-            flask.session,
-            bleach.clean(snap_name),
-            bleach.clean(claim_comment),
-        )
-    except StoreApiResponseErrorList as api_response_error_list:
-        if api_response_error_list.status_code in [400, 409]:
-            return jsonify(
-                {
-                    "success": False,
-                    "data": api_response_error_list.errors,
-                    "message": api_response_error_list.errors[0]["message"],
-                }
-            )
-    return jsonify({"success": True})
 
 
 @publisher_snaps.route("/request-reserved-name")


### PR DESCRIPTION
## Done
Moves the register name dispute endpoint to the endpoints section of the app. No logic is changed intentionally to avoid potential issues.

## How to QA
- Go to https://snapcraft-io-5297.demos.haus/register-name-dispute?snap-name=lukewh
- In the comment write "This is a test from the web team. Please do not action this."
- Submit the form
- It should work

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24106
