### PR TITLE
chore: Move disconnect repo endpoint to endpoints section of app

### DIFF
--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -169,3 +169,22 @@ class TestPostBuild(TestEndpoints):
         # Should redirect to login or return unauthorized
         # The exact behavior depends on the login_required decorator
         self.assertIn(response.status_code, [302, 401, 403])
+
+
+class TestPostDisconnectRepo(TestEndpoints):
+    def setUp(self):
+        super().setUp()
+        self.snap_name = "test-snap"
+        self.endpoint_url = f"/api/{self.snap_name}/builds/disconnect/"
+
+    def test_post_disconnect_repo_requires_login(self):
+        """Test that the endpoint requires login"""
+        # Create a new client without logging in
+        app = self.app
+        client = app.test_client()
+
+        response = client.post(self.endpoint_url)
+
+        # Should redirect to login or return unauthorized
+        # The exact behavior depends on the login_required decorator
+        self.assertIn(response.status_code, [302, 401, 403])

--- a/webapp/endpoints/publisher/builds.py
+++ b/webapp/endpoints/publisher/builds.py
@@ -1,3 +1,6 @@
+# Standard library
+import os
+
 # Packages
 import flask
 from canonicalwebteam.store_api.dashboard import Dashboard
@@ -8,6 +11,8 @@ from requests.exceptions import HTTPError
 from webapp.helpers import api_publisher_session, launchpad
 from webapp.api.github import GitHub, InvalidYAML
 from webapp.decorators import login_required
+
+GITHUB_WEBHOOK_HOST_URL = os.getenv("GITHUB_WEBHOOK_HOST_URL")
 
 dashboard = Dashboard(api_publisher_session)
 
@@ -123,3 +128,37 @@ def post_build(snap_name):
         )
 
     return flask.jsonify({"success": True, "build_id": build_id})
+
+
+@login_required
+def post_disconnect_repo(snap_name):
+    details = dashboard.get_snap_info(flask.session, snap_name)
+
+    lp_snap = launchpad.get_snap_by_store_name(snap_name)
+    launchpad.delete_snap(details["snap_name"])
+
+    # Try to remove the GitHub webhook if possible
+    if flask.session.get("github_auth_secret"):
+        github = GitHub(flask.session.get("github_auth_secret"))
+
+        try:
+            gh_owner, gh_repo = lp_snap["git_repository_url"][19:].split("/")
+
+            old_hook = github.get_hook_by_url(
+                gh_owner,
+                gh_repo,
+                f"{GITHUB_WEBHOOK_HOST_URL}api/{snap_name}/webhook/notify",
+            )
+
+            if old_hook:
+                github.remove_hook(
+                    gh_owner,
+                    gh_repo,
+                    old_hook["id"],
+                )
+        except HTTPError:
+            pass
+
+    return flask.redirect(
+        flask.url_for(".get_snap_builds", snap_name=snap_name)
+    )

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -360,40 +360,6 @@ def check_build_request(snap_name, build_id):
     )
 
 
-@login_required
-def post_disconnect_repo(snap_name):
-    details = dashboard.get_snap_info(flask.session, snap_name)
-
-    lp_snap = launchpad.get_snap_by_store_name(snap_name)
-    launchpad.delete_snap(details["snap_name"])
-
-    # Try to remove the GitHub webhook if possible
-    if flask.session.get("github_auth_secret"):
-        github = GitHub(flask.session.get("github_auth_secret"))
-
-        try:
-            gh_owner, gh_repo = lp_snap["git_repository_url"][19:].split("/")
-
-            old_hook = github.get_hook_by_url(
-                gh_owner,
-                gh_repo,
-                f"{GITHUB_WEBHOOK_HOST_URL}api/{snap_name}/webhook/notify",
-            )
-
-            if old_hook:
-                github.remove_hook(
-                    gh_owner,
-                    gh_repo,
-                    old_hook["id"],
-                )
-        except HTTPError:
-            pass
-
-    return flask.redirect(
-        flask.url_for(".get_snap_builds", snap_name=snap_name)
-    )
-
-
 @csrf.exempt
 def post_github_webhook(snap_name=None, github_owner=None, github_repo=None):
     payload = flask.request.json

--- a/webapp/publisher/snaps/views.py
+++ b/webapp/publisher/snaps/views.py
@@ -30,6 +30,7 @@ from webapp.endpoints.publisher.builds import (
     get_snap_build_page,
     get_validate_repo,
     post_build,
+    post_disconnect_repo,
 )
 from webapp.endpoints.publisher.settings import (
     get_settings_data,
@@ -162,7 +163,7 @@ publisher_snaps.add_url_rule(
 )
 publisher_snaps.add_url_rule(
     "/api/<snap_name>/builds/disconnect/",
-    view_func=build_views.post_disconnect_repo,
+    view_func=post_disconnect_repo,
     methods=["POST"],
 )
 


### PR DESCRIPTION
## Done
Moves the disconnect repo endpoint into the endpoints section of the app. There are deliberately no logic changes to prevent potential issues.

## How to QA
- Run locally (doesn't work on demos) - you need to [set up your GH tokens locally](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds)
- Go to the builds page of a snap you own e.g. /<snap_name>/builds
- Disconnect the repo
- It should work

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-24595
