### PR TITLE
fix: Fix internal server error when missing CVE key

### DIFF
--- a/tests/publisher/cve/test_cve_get_by_revision.py
+++ b/tests/publisher/cve/test_cve_get_by_revision.py
@@ -65,7 +65,6 @@ class CveHGetByRevisionTest(unittest.TestCase):
                                             "version": "2.27-3ubuntu1.4",
                                         },
                                     ],
-                                    "channels_with_fix": [],
                                     "usns": ["3009-1"],
                                 },
                                 "CVE-2023-31486": {

--- a/webapp/publisher/cve/cve_helper.py
+++ b/webapp/publisher/cve/cve_helper.py
@@ -58,6 +58,11 @@ class CveHelper:
                             }
                         )
 
+            channels_with_fix = None
+
+            if "channels_with_fix" in cve:
+                channels_with_fix = cve["channels_with_fix"]
+
             cves.append(
                 {
                     "id": cve_id,
@@ -67,7 +72,7 @@ class CveHelper:
                     "description": cve_detail["description"],
                     "ubuntu_priority": cve_detail["ubuntu_priority"],
                     "affected_binaries": cve["affected_binaries"],
-                    "channels_with_fix": cve["channels_with_fix"],
+                    "channels_with_fix": channels_with_fix,
                     "usns": cve_usns,
                 }
             )


### PR DESCRIPTION
## Done
Fixes Internal Server Error when response is missing `channels_with_fix` key

## How to QA
- Go to https://snapcraft-io-5301.demos.haus/api/docker/3220/cves
- Check that there is data

## Testing
- [x] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-25533
