### PR TITLE
Remove expose-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "d3-time-format": "4.1.0",
     "date-fns": "4.1.0",
     "downshift": "9.0.8",
-    "expose-loader": "5.0.0",
     "fast-average-color": "9.4.0",
     "jotai": "2.12.5",
     "markdown-it": "14.1.0",

--- a/static/js/libs/declare.ts
+++ b/static/js/libs/declare.ts
@@ -1,0 +1,102 @@
+type Mergeable = Record<string, unknown>;
+
+/**
+ * Build an object that contains `value` at `path`, where `path` is a
+ * period-separated string.
+ */
+function buildObjectFromPath(path: string, value: unknown): Mergeable {
+  const segments = path.split(".");
+  const obj = {} as Mergeable;
+  let curr = obj;
+  for (const [i, s] of segments.entries()) {
+    curr[s] = i < segments.length - 1 ? {} : value;
+    curr = curr[s] as Mergeable;
+  }
+
+  return obj;
+}
+
+function deepMerge(target: Mergeable, source: Mergeable, override: boolean) {
+  for (const key of Object.keys(source)) {
+    if (typeof target[key] === "object" && typeof source[key] === "object") {
+      target[key] = deepMerge(
+        target[key] as Mergeable,
+        source[key] as Mergeable,
+        override,
+      );
+    } else if (typeof target[key] === "undefined") {
+      target[key] = source[key];
+    } else if (override) {
+      console.warn(
+        `Overwriting "${key}" of type "${typeof target[key]} with value of type ${typeof source[key]}"`,
+      );
+      target[key] = source[key];
+    } else {
+      throw new Error(`"${key}" is already defined, but "override" is false`);
+    }
+  }
+  return target;
+}
+
+/**
+ * @param {string} path A period-separated string representing the path for the
+ * global variable.
+ * @param {*} value The value to expose globally.
+ * @param {boolean} [override=false] If true, forces the value to be assigned,
+ * even if it conflicts with an existing non-object variable at the specified
+ * path. Defaults to false.
+ * @returns {void}
+ * @throws {Error} Throws an error if `override` is false and a non-object
+ * value already exists at a nested path.
+ * @description
+ * This function exposes `value` into the global scope under the name given by
+ * `path`.
+ * The `path` parameter can be a period-separated string (e.g., 'myApp.data'),
+ * which will nest the `value` within a series of objects.
+ *
+ * If you call this function multiple times with overlapping paths, it will
+ * merge the values if both the new `value` and the existing variable at that
+ * path are objects.
+ * For example, if 'myApp.data' already exists as an object, calling
+ * `declareGlobal('myApp.config', { theme: 'dark' })` will add a `config`
+ * property to the `globalThis.myApp` object.
+ *
+ * An error will be thrown if a conflict occurs, such as trying to merge an
+ * object with an existing non-object value at the same path, unless the
+ * `override` parameter is set to true.
+ *
+ * @example
+ * // Declaring a simple global variable
+ * declareGlobal('myGlobalVar', 123);
+ * console.log(globalThis.myGlobalVar); // 123
+ *
+ * @example
+ * // Declaring a nested global object
+ * declareGlobal('myApp.user', { name: 'John Doe' });
+ * console.log(globalThis.myApp.user.name); // John Doe
+ *
+ * @example
+ * // Merging with an existing object
+ * declareGlobal('myApp-settings', { theme: 'light' });
+ * declareGlobal('myApp.settings', { language: 'en' });
+ * console.log(globalThis.myApp.settings); // { theme: 'light', language: 'en' }
+ *
+ * @example
+ * // Using override to force assignment and prevent an error
+ * declareGlobal('config', { api: 'v1' });
+ * declareGlobal('config', 'api/v2', true); // Overwrites the 'config' object
+ * console.log(globalThis.config); // 'api/v2'
+ */
+export default function declareGlobal(
+  path: string,
+  value: unknown,
+  override: boolean = false,
+): void {
+  deepMerge(globalThis, buildObjectFromPath(path, value), override);
+}
+
+// TODO: this approach is due to how we handled bundles in Webpack, using
+// expose-loader to declare exports as an object in the global scope. A better
+// approach would be to explicitly import the modules that use the function
+// above inside the <script> tags that make use their exports (making sure to
+// use modulepreload hints to not delay loading)

--- a/static/js/public/about/index.ts
+++ b/static/js/public/about/index.ts
@@ -1,4 +1,5 @@
 import { initFSFLanguageSelect } from "../fsf-language-select";
 import initExpandableArea from "../expandable-area";
+import declareGlobal from "../../libs/declare";
 
-export { initFSFLanguageSelect, initExpandableArea };
+declareGlobal("snapcraft.about", { initFSFLanguageSelect, initExpandableArea });

--- a/static/js/public/blog.ts
+++ b/static/js/public/blog.ts
@@ -1,3 +1,4 @@
+import declareGlobal from "../libs/declare";
 import { newsletter } from "./newsletter";
 
-export { newsletter };
+declareGlobal("snapcraft.public.blog", { newsletter });

--- a/static/js/public/distro-install.ts
+++ b/static/js/public/distro-install.ts
@@ -2,5 +2,11 @@ import screenshots from "./snap-details/screenshots";
 import videos from "./snap-details/videos";
 import initExpandableArea from "./expandable-area";
 import triggerEventWhenVisible from "./ga-scroll-event";
+import declareGlobal from "../libs/declare";
 
-export { screenshots, initExpandableArea, triggerEventWhenVisible, videos };
+declareGlobal("snapcraft.public.distroInstall", {
+  screenshots,
+  initExpandableArea,
+  triggerEventWhenVisible,
+  videos,
+});

--- a/static/js/public/featured-snaps.ts
+++ b/static/js/public/featured-snaps.ts
@@ -1,3 +1,5 @@
+import declareGlobal from "../libs/declare";
+
 type PackageData = {
   apps: Array<string>;
   architecture: Array<string>;
@@ -168,4 +170,4 @@ async function init(featuredCategories: Array<string>): Promise<void> {
   await buildCards(featuredCategories[0].toLowerCase());
 }
 
-export { init };
+declareGlobal("snapcraft.public.featuredSnaps", { init });

--- a/static/js/public/fsf.ts
+++ b/static/js/public/fsf.ts
@@ -2,10 +2,11 @@ import initAccordion from "./accordion";
 import { initFSFLanguageSelect } from "./fsf-language-select";
 import firstSnapFlow from "./first-snap-flow";
 import initExpandableArea from "./expandable-area";
+import declareGlobal from "../libs/declare";
 
-export {
+declareGlobal("snapcraft.public.fsf", {
   initAccordion,
   initExpandableArea,
   initFSFLanguageSelect,
   firstSnapFlow,
-};
+});

--- a/static/js/public/homepage.ts
+++ b/static/js/public/homepage.ts
@@ -1,5 +1,10 @@
 import { initFSFLanguageSelect } from "./fsf-language-select";
 import nps from "./nps";
 import initExpandableArea from "./expandable-area";
+import declareGlobal from "../libs/declare";
 
-export { initExpandableArea, initFSFLanguageSelect, nps };
+declareGlobal("snapcraft.public.homepage", {
+  initExpandableArea,
+  initFSFLanguageSelect,
+  nps,
+});

--- a/static/js/public/modal.ts
+++ b/static/js/public/modal.ts
@@ -1,3 +1,5 @@
+import declareGlobal from "../libs/declare";
+
 function toggleModal(modal: HTMLElement) {
   if (modal && modal.classList.contains("p-modal")) {
     if (modal.style.display === "none") {
@@ -26,4 +28,4 @@ function init(): void {
   });
 }
 
-export { init };
+declareGlobal("snapcraft.public.modal", { init });

--- a/static/js/public/publisher-details.ts
+++ b/static/js/public/publisher-details.ts
@@ -1,3 +1,4 @@
+import declareGlobal from "../libs/declare";
 import { snapDetailsPosts } from "./snap-details/blog-posts";
 
-export { snapDetailsPosts };
+declareGlobal("snapcraft.public.publisherDetails", { snapDetailsPosts });

--- a/static/js/public/store-details.ts
+++ b/static/js/public/store-details.ts
@@ -6,8 +6,9 @@ import initReportSnap from "./snap-details/reportSnap";
 import initEmbeddedCardModal from "./snap-details/embeddedCard";
 import { snapDetailsPosts } from "./snap-details/blog-posts";
 import initExpandableArea from "./expandable-area";
+import declareGlobal from "../libs/declare";
 
-export {
+declareGlobal("snapcraft.public.storeDetails", {
   map,
   screenshots,
   channelMap,
@@ -16,4 +17,4 @@ export {
   initExpandableArea,
   initReportSnap,
   videos,
-};
+});

--- a/webpack.config.rules.js
+++ b/webpack.config.rules.js
@@ -27,66 +27,47 @@ module.exports = [
       },
     ],
   },
-  // TODO:
-  // we should get rid of using globals making expose-loader unnecessary
-  // https://github.com/canonical-web-and-design/snapcraft.io/issues/1245
-
   // loaders are evaluated from bottom to top (right to left)
   // so first transpile via babel, then expose as global
   {
     test: require.resolve(__dirname + "/static/js/base/base.ts"),
-    use: ["expose-loader?exposes=snapcraft.base", "babel-loader"],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/featured-snaps.ts"),
-    use: [
-      "expose-loader?exposes=snapcraft.public.featuredSnaps",
-      "babel-loader",
-    ],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/modal.ts"),
-    use: ["expose-loader?exposes=snapcraft.public.modal", "babel-loader"],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/homepage.ts"),
-    use: ["expose-loader?exposes=snapcraft.public.homepage", "babel-loader"],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/blog.ts"),
-    use: ["expose-loader?exposes=snapcraft.public.blog", "babel-loader"],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/store-details.ts"),
-    use: [
-      "expose-loader?exposes=snapcraft.public.storeDetails",
-      "babel-loader",
-    ],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/fsf.ts"),
-    use: ["expose-loader?exposes=snapcraft.public.fsf", "babel-loader"],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/distro-install.ts"),
-    use: [
-      "expose-loader?exposes=snapcraft.public.distroInstall",
-      "babel-loader",
-    ],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/publisher-details.ts"),
-    use: [
-      "expose-loader?exposes=snapcraft.public.publisherDetails",
-      "babel-loader",
-    ],
+    use: ["babel-loader"],
   },
   {
     test: require.resolve(__dirname + "/static/js/public/about/index.ts"),
-    use: [
-      "expose-loader?exposes=snapcraft.about",
-      "babel-loader",
-    ],
+    use: ["babel-loader"],
   },
   {
     test: /\.tsx?/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,11 +5234,6 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-expose-loader@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/expose-loader/-/expose-loader-5.0.0.tgz#41368903eb1246b7c09fecf32c5cb3f67d0260e6"
-  integrity sha512-BtUqYRmvx1bEY5HN6eK2I9URUZgNmN0x5UANuocaNjXSgfoDlkXt+wyEMe7i5DzDNh2BKJHPc5F4rBwEdSQX6w==
-
 extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"


### PR DESCRIPTION
## Done
Replaced Webpack's *expose-loader* with explicit declarations for exposing functions in the global scope.

- added a `declareGlobal` function that merges a variable into the `globalThis` object at a path specified by a period-separated string
- replaced `export` declarations in bundle entry points with explicit calls to `declareGlobal`
- removed *expose-loader* rules from webpack.config.rules.js
- removed *expose-loader* dependency from package.json

## How to QA
If the "run-cypress" test action is green most things should be good, but some manual QA is always welcome. Try to visit the demo site and click around on the interactive stuff (cookie popup, header dropdown, first snap flow, /store page, /about/listing page, etc.)

One route that needs manual testing is /blog, automated tests for it have been disabled because they fail if the machine is not connected to the VPN. Check that the newsletter form works correctly on /blog and on blog article pages

## Testing
- [x] This PR has tests -> "run-cypress" GitHub action checks that the new bundles export the same objects as the previous ones
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-25565](https://warthogs.atlassian.net/browse/WD-25565)

## Screenshots


[WD-25565]: https://warthogs.atlassian.net/browse/WD-25565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ