### PR TITLE
chore: use Vite bundle for homepage.js

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -161,7 +161,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-<script src="{{ static_url('js/dist/homepage.js') }}" defer></script>
+<script type="module" src="{{ static_url('js/dist/vite/homepage.js') }}" defer></script>
 <script src="{{ static_url('js/dist/featured-snaps.js') }}" defer></script>
 {% if nps %}
 <script src="//app-sjg.marketo.com/js/forms2/js/forms2.min.js" defer></script>


### PR DESCRIPTION
## Done
Changed homepage.js bundle to the one build by Vite

## How to QA
- open https://snapcraft-io-5314.demos.haus/#language
- change language
- click the "Show more" button
- these features should work

## Testing
- [x] This PR has tests -> run-cypress tests homepage.js exports are available in `window.snapcraft.public.homepage`
- [ ] No testing required (explain why):

## Issue / Card
Fixes [WD-24764](https://warthogs.atlassian.net/browse/WD-24764)

## Screenshots


[WD-24764]: https://warthogs.atlassian.net/browse/WD-24764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ