### PR TITLE
chore: use Vite bundle for base.js

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -37,7 +37,7 @@
       });
     </script>
 
-    <script src="{{ static_url('js/dist/base.js') }}" defer></script>
+    <script type="module" src="{{ static_url('js/dist/vite/base.js') }}" defer></script>
     {% block scripts_includes %}{% endblock %}
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 


### PR DESCRIPTION
## Done
Changed base.js bundle to the one built by Vite

## How to QA
- open https://snapcraft-io-5315.demos.haus/
- click the "Contact us" anchor in the footer
- the contact form should appear
- log in with your account
- go back to the home page
- your account name should have appeared in the top right

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24760

## Screenshots
