### PR TITLE
chore: use Vite bundle for about-listing.js

### DIFF
--- a/templates/about/listing.html
+++ b/templates/about/listing.html
@@ -185,5 +185,5 @@
   </div>
 </section>
 
-<script src="{{ static_url('js/dist/about-listing.js') }}" defer></script>
+<script type="module" src="{{ static_url('js/dist/vite/about-listing.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Done
Changed about-listing.js bundle to the one built by Vite

## How to QA
- visit https://snapcraft-io-5317.demos.haus/about/listing#icon
- change tabs to "Title", "Category", etc. by either
  - clicking the anchors on the left
  - clicking the "next"/"previous" buttons
  - using the dropdown (mobile layout)

## Testing
- [x] This PR has tests -> run-cypress checks event listeners set up by about-listing.js on the /about/listing page
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24770

## Screenshots
