### PR TITLE
chore: use Vite bundle for fsf.js

### DIFF
--- a/templates/first-snap/_layout_fsf.html
+++ b/templates/first-snap/_layout_fsf.html
@@ -17,5 +17,5 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/fsf.js') }}" defer></script>
+  <script type="module" src="{{ static_url('js/dist/vite/fsf.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Done
Changed fsf.js bundle to the one built by Vite

## How to QA
- visit https://snapcraft-io-5321.demos.haus/first-snap
- check that changing to another language works
- click the "show more" button

## Testing
- [x] This PR has tests -> run-cypress checks that the bundle exports the window.snapcraft.public.fsf object
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24767

## Screenshots
