### PR TITLE
chore: use Vite bundle for store-details.js

### DIFF
--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -306,7 +306,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/store-details.js') }}" defer></script>
+  <script type="module" src="{{ static_url('js/dist/vite/store-details.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Done
Changed store-details.js bundle to the one built by Vite

## How to QA
- open the details page for a snap (e.g. .../pinta)
- check the release channels dropdown works
- check that the images carousel works
- click on one of the images and check that the fullscreen carousel works as well
- click the "report this snap" button, the report form modal should open
- click the "share embeddable card" button, a modal should open
- the map section at the bottom of the page should be populated
- click the "show more" anchor near the map, the detailed stats should appear

## Testing
- [x] This PR has tests -> run-cypress checks that the bundle exports the window.snapcraft.public.storeDetails object
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24766

## Screenshots
