### PR TITLE
chore: use Vite bundle for distro-install.js

### DIFF
--- a/templates/store/snap-distro-install.html
+++ b/templates/store/snap-distro-install.html
@@ -263,7 +263,7 @@
 {% endblock %}
 
 {% block scripts_includes %}
-  <script src="{{ static_url('js/dist/distro-install.js') }}" defer></script>
+  <script type="module" src="{{ static_url('js/dist/vite/distro-install.js') }}" defer></script>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Done
Changed distro-install.js bundle to the one built by Vite

## How to QA
- open a distro install page (e.g. https://snapcraft-io-5323.demos.haus/install/pinta/arch)
- check that the images carousel works
- click on one of the images and check that the fullscreen carousel works as well

## Testing
- [x] This PR has tests -> run-cypress checks for window.snapcraft.public.distroInstall in the global scope
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24768

## Screenshots
