### PR TITLE
chore: use Vite bundle for brand-store.js

### DIFF
--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -10,5 +10,5 @@
   window.SENTRY_DSN = "{{ SENTRY_DSN }}";
   window.API_URL = "{{ api_url }}";
 </script>
-<script src="{{ static_url('js/dist/brand-store.js') }}"></script>
+<script type="module" src="{{ static_url('js/dist/vite/brand-store.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done
Changed brand-store.js bundle to the one built by Vite

## How to QA
- visit https://snapcraft-io-5328.demos.haus/admin/nah4ahShap8aefie6pha/snaps
- the page should render correctly

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24773

## Screenshots
