### PR TITLE
chore: use Vite bundle for publisher.js

### DIFF
--- a/templates/store/publisher.html
+++ b/templates/store/publisher.html
@@ -6,5 +6,5 @@
 <script>
   window.CSRF_TOKEN = "{{ csrf_token() }}";
 </script>
-<script src="{{ static_url('js/dist/publisher.js') }}"></script>
+<script type="module" src="{{ static_url('js/dist/vite/publisher.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done
Changed publisher.js bundle to the one built by Vite

## How to QA
- visit https://snapcraft-io-5329.demos.haus/snaps
- the page should render correctly

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes WD-24772

## Screenshots
