### PR TITLE
Fix theme colors in release UI

### DIFF
--- a/static/sass/_snapcraft_p-release-details-row.scss
+++ b/static/sass/_snapcraft_p-release-details-row.scss
@@ -16,12 +16,12 @@
     }
 
     &__notes {
-      color: $color-dark;
+      color: $colors--theme--text-default;
     }
   }
 
   .p-release-details-group + .p-release-details-row {
-    border-top: 1px dashed $color-mid-light;
+    border-top: 1px dashed $colors--theme--border-default;
     margin-top: 0.5rem;
     padding-top: 0.5rem;
   }


### PR DESCRIPTION
## Done

Fixes the text color in release UI in the dark theme.

## How to QA

- Sign in
- Change theme to dark in account settings
- Go to release view of any snap
- Promote some revisions
- Open confirmation
- Check if % text is visible

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): visual changes only

## Issue / Card
Fixes WD-26022
Fixes #5332 

## Screenshots

<img width="1047" height="175" alt="image" src="https://github.com/user-attachments/assets/3c0c61ba-1ea1-403c-9c48-54e180ce1516" />
