### PR TITLE
fix: load unprefixed env vars explicitly

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,8 +9,11 @@ import webapp.api
 
 from talisker import logging
 
-from canonicalwebteam.flask_base.app import FlaskBase
+# We import the config module before anything else to make sure env vars are
+# loaded properly and the FLASK_* prefix is stripped before they are parsed
 import webapp.config
+
+from canonicalwebteam.flask_base.app import FlaskBase
 from webapp.blog.views import init_blog
 from webapp.docs.views import init_docs
 from webapp.extensions import csrf

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -10,6 +10,7 @@ import webapp.api
 from talisker import logging
 
 from canonicalwebteam.flask_base.app import FlaskBase
+import webapp.config
 from webapp.blog.views import init_blog
 from webapp.docs.views import init_docs
 from webapp.extensions import csrf

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -1,9 +1,16 @@
 import os
+from canonicalwebteam.flask_base.env import load_plain_env_variables
 
 
 class ConfigurationError(Exception):
     pass
 
+
+# Load the prefixed FLASK_* env vars into env vars without the prefix. We have
+# to do this explicitly here because otherwise the config module is imported
+# by other files before the FlaskBase app gets initialized and does this by
+# itself, meaning that the variables below are not set correctly
+load_plain_env_variables()
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 LOGIN_URL = os.getenv("LOGIN_URL", "https://login.ubuntu.com")


### PR DESCRIPTION
Fix an issue where the `webapp.config` module's variables do not reflect those available in the Flask `app.config` object created by flask_base

## Done
call `load_plain_env_variables` explicitly in the `webapp.config` module

## How to QA
This can only be tested locally
- checkout this branch
- in the .env.local file, add an env variable prefixed by FLASK_
  - a good candidate for this is FLASK_SENTRY_DSN as it is copied in a `<script>` tag on each page
- `dotrun` it
- visit http://localhost:8004
- in the inspector, look for a script that contains `Raven.config`
- the first argument of the function call should be the string that you set as FLASK_SENTRY_DSN

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
