### PR TITLE
fix Cypress test timeouts in GH action

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,5 +6,12 @@ export default defineConfig({
       // implement node event listeners here
     },
     supportFile: false,
+    blockHosts: [
+      "www.googletagmanager.com",
+      "analytics.google.com",
+      "*.analytics.google.com",
+      "www.google-analytics.com",
+      "assets.ubuntu.com"
+    ],
   },
 });


### PR DESCRIPTION
Fix an issue with Cypress tests failing due to timeout during page loads. Third party scripts would occasionally block the page from launching the "load" event, leading to Cypress hanging. The "blockHosts" Cypress config option automatically returns a 503 response on requests matching any of the hosts in the list, fixing the issue.

## Done
- blocked Google tag manager, Google analytics and assets.ubuntu.com hostnames

## How to QA
This PR must be QA'd locally
- check out this branch
- `dotrun` it
- wait for the server to be up
- run `docker run --network="host" -v .:/app -w /app cypress/base:22.18.0 bash "-c" "npx cypress install && yarn run te
st-e2e"`

## Testing
- [ ] This PR has tests
- [ ] No testing required (explain why):

## Issue / Card
Fixes #

## Screenshots
