### PR TITLE
WD-26424 - Fix error when global-nav is included but there's no header

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -80,10 +80,10 @@
     {% block header %}
     <!-- JS that is needed right away -->
     <script type="module" src="{{ static_url('js/dist/vite/cookie-policy.js') }}"></script>
-    <script type="module" src="{{ static_url('js/dist/vite/global-nav.js') }}"></script>
 
     {% from "_header_macros.html" import header %}
       {% if show_header != False %}
+        <script type="module" src="{{ static_url('js/dist/vite/global-nav.js') }}"></script>
         {% from "_header_macros.html" import header %}
         {{ header() }}
       {% endif %}


### PR DESCRIPTION
## Done

Remove script of global-nav if header is not shown to avoid errors in the JS console.

## How to QA

-

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): This error is caught by Cypress tests and it's a fix for those.

## Issue / Card

Fixes #5336 / [WD-26242](https://warthogs.atlassian.net/browse/WD-26242)
