### PR TITLE
fix: add DASHBOARD_API_URL env var for auth on staging-api env

### DIFF
--- a/konf/staging-api.snapcraft.io.yaml
+++ b/konf/staging-api.snapcraft.io.yaml
@@ -6,6 +6,9 @@ env:
   - name: SNAPSTORE_DASHBOARD_API_URL
     value: https://dashboard.staging.snapcraft.io/
 
+  - name: DASHBOARD_API_URL
+    value: https://dashboard.staging.snapcraft.io/
+
   - name: LOGIN_URL
     value: https://login.staging.ubuntu.com
 


### PR DESCRIPTION
The canonicalwebteam.store_api package uses the DASHBOARD_API_URL env var rather than SNAPSTORE_DASHBOARD_API_URL, which broke the auth flow on staging-api.snapcraft.io

This is just a quick dirty fix for this bug, but there's probably a larger issue we should track and discuss with regard to how we handle env vars

## Done

## How to QA
- visit https://staging-api.snapcraft.io/snaps
- you should get redirected
- log in (you need a staging account on https://login.staging.ubuntu.com)
- you should land on the /snaps page

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): just an env var change (I already did it manually via kubectl, I'm just adding it here to keep track of it)

## Issue / Card
Fixes #

## Screenshots
