### PR TITLE
fix: Fix template link on builds page

### DIFF
--- a/webapp/endpoints/publisher/builds.py
+++ b/webapp/endpoints/publisher/builds.py
@@ -28,11 +28,13 @@ def get_snap_build_page(snap_name, build_id):
 
 def validate_repo(github_token, snap_name, gh_owner, gh_repo):
     github = GitHub(github_token)
-    result = {"success": True}
+    result = {"success": True, "data": None, "error": None}
     yaml_location = github.get_snapcraft_yaml_location(gh_owner, gh_repo)
+    default_branch = github.get_default_branch(gh_owner, gh_repo)
 
     # The snapcraft.yaml is not present
     if not yaml_location:
+        result["data"] = {"default_branch": default_branch}
         result["success"] = False
         result["error"] = {
             "type": "MISSING_YAML_FILE",


### PR DESCRIPTION
## Done
Fixes the "get started with a template" link when connecting a repo without a `snapcraft.yaml` file

## How to QA
- Must run locally (will need [tokens](https://github.com/canonical/snapcraft.io/blob/main/HACKING.md#snap-automated-builds))
- Go to http://localhost:8004/<SNAP_NAME>/builds (must be a snap without a `snapcraft.yaml` file)
- Connect the repo
- Click the "get started with a template" link
- Check that it opens a page on GitHub where you can create a new `snapcraft.yaml` file

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): No behavioural changes

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-27231
