### PR TITLE
fix: Fix footer position on docs page

### DIFF
--- a/static/sass/_snapcraft_p-docs.scss
+++ b/static/sass/_snapcraft_p-docs.scss
@@ -9,4 +9,8 @@
   .emoji {
     height: 1rem;
   }
+
+  .l-docs {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
## Done
Fixes issue where the footer isn't fixed to the bottom of the screen

## How to QA
- Run locally (`dotrun` or `dotrun -p 5004:5004` on MacOS)
- Go to http://localhost:8004/docs/network-bind-interface
- Check that the footer is fixed to the bottom of the screen

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Visual change

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-27344
Fixes https://github.com/canonical/snapcraft.io/issues/5378

## Screenshots

### Before
<img width="1080" height="977" alt="before" src="https://github.com/user-attachments/assets/11facc7c-44b7-47e6-b96e-b61726456c94" />

### After
<img width="1080" height="977" alt="after" src="https://github.com/user-attachments/assets/a798da91-121a-40a6-ad75-48819672e676" />
