### PR TITLE
WD-27333 - Fix bug in docs global navigation

### DIFF
--- a/templates/_base-layout.html
+++ b/templates/_base-layout.html
@@ -71,12 +71,10 @@
     <!-- JS that is needed right away -->
     {{ vite_import('static/js/base/cookie-policy.ts') }}
 
-    {% from "_header_macros.html" import header %}
-      {% if show_header != False %}
-        {{ vite_import('static/js/base/global-nav.ts') }}
-        {% from "_header_macros.html" import header %}
-        {{ header() }}
-      {% endif %}
+    {% if show_header != False %}
+      {% from "_header_macros.html" import header %}
+      {{ header(vite_import) }}
+    {% endif %}
     {% endblock %}
 
     {% block content %}{% endblock %}

--- a/templates/_docs_layout.html
+++ b/templates/_docs_layout.html
@@ -1,7 +1,8 @@
 {% extends "_base-layout.html" %}
 
 {% block header %}
-{% from "_header_docs_macros.html" import header %}{{ header() }}
+{% from "_header_macros.html" import header %}
+  {{ header(vite_import, docs=True) }}
 {% endblock %}
 
 {% block content %}{% endblock %}

--- a/templates/_header_docs_macros.html
+++ b/templates/_header_docs_macros.html
@@ -1,3 +1,0 @@
-{% macro header(docs=True) %}
-  {% include "_header.html" %}
-{% endmacro %}

--- a/templates/_header_macros.html
+++ b/templates/_header_macros.html
@@ -1,3 +1,4 @@
-{% macro header(docs=False) %}
+{% macro header(vite_import, docs=False) %}
+  {{ vite_import('static/js/base/global-nav.ts') }}
   {% include "_header.html" %}
 {% endmacro %}


### PR DESCRIPTION
## Done

Move the `vite_import` of the global-nav to the header macro. This way we are sure that everywhere the header is used, the necessary global-nav JS lib will be there.

## How to QA

Can't be checked on Demos because of an error with Discourse unrelated to this PR:
```
2025-09-26 12:22:31.946Z ERROR flask.app "Exception on /docs [GET]" service=snapcraft.io pid=11 request_id=db090d0c73e42876f66f235e482798cb
Traceback (most recent call last):
  File "/root/.local/lib/python3.10/site-packages/flask/app.py", line 2190, in wsgi_app
    response = self.full_dispatch_request()
  File "/root/.local/lib/python3.10/site-packages/flask/app.py", line 1486, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/root/.local/lib/python3.10/site-packages/flask/app.py", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File "/root/.local/lib/python3.10/site-packages/flask/app.py", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/root/.local/lib/python3.10/site-packages/canonicalwebteam/discourse/app.py", line 163, in document_view
    self.parser.parse()
  File "/root/.local/lib/python3.10/site-packages/canonicalwebteam/discourse/parsers/docs.py", line 54, in parse
    self.index_topic = self.api.get_topic(self.index_topic_id)
  File "/root/.local/lib/python3.10/site-packages/canonicalwebteam/discourse/models.py", line 46, in get_topic
    response.raise_for_status()
  File "/root/.local/lib/python3.10/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
```

- Get this branch locally and run the project with `dotrun`.
- Open the `/docs` page.
- Check that the navigation works in both desktop and mobile views.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): Just Jinja template modifications

## Issue / Card
Fixes [WD-27333](https://warthogs.atlassian.net/browse/WD-27333)


[WD-27333]: https://warthogs.atlassian.net/browse/WD-27333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ