### PR TITLE
fix: use correct dashboard env var name

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -7,7 +7,7 @@ To use staging APIs locally you can add the following lines to an `.env.local` f
 
 ```bash
 DEVICE_GATEWAY_API_URL=https://api.staging.snapcraft.io/
-DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
+SNAPSTORE_DASHBOARD_API_URL=https://dashboard.staging.snapcraft.io/
 LOGIN_URL=https://login.staging.ubuntu.com
 CANDID_API_URL=https://api.staging.jujucharms.com/identity/
 ```

--- a/konf/staging-api.snapcraft.io.yaml
+++ b/konf/staging-api.snapcraft.io.yaml
@@ -6,9 +6,6 @@ env:
   - name: SNAPSTORE_DASHBOARD_API_URL
     value: https://dashboard.staging.snapcraft.io/
 
-  - name: DASHBOARD_API_URL
-    value: https://dashboard.staging.snapcraft.io/
-
   - name: LOGIN_URL
     value: https://login.staging.ubuntu.com
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ canonicalwebteam.discourse==7.0.0
 canonicalwebteam.blog==6.5.0
 canonicalwebteam.search==2.1.2
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.store-api==7.3.1
+canonicalwebteam.store-api==7.3.3
 canonicalwebteam.launchpad==0.9.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.0


### PR DESCRIPTION
## Done
Related to [this PR](https://github.com/canonical/canonicalwebteam.store-api/pull/169), effectively remove the dirty fix added [here](https://github.com/canonical/snapcraft.io/pull/5345)

- updated store-api package
- changed env var name in docs
- removed unused env var from staging-api site config

## How to QA

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): no behavior changes

## Issue / Card
Fixes #

## Screenshots
