### PR TITLE
refactor(code): update validateRepo function name

### DIFF
--- a/static/js/publisher/pages/Builds/RepoSelector.tsx
+++ b/static/js/publisher/pages/Builds/RepoSelector.tsx
@@ -91,7 +91,7 @@ function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {
   // Track autofill attempts to avoid unnecessary re-runs
   const autofillAttemptedRef = useRef<string | null>(null);
 
-  const validateRepoInternal = async (repo: Repo | undefined) => {
+  const validateRepo = async (repo: Repo | undefined) => {
     if (!repo) {
       return;
     }
@@ -148,7 +148,7 @@ function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {
       if (matchingRepo) {
         setRepoInputValue(matchingRepo.name);
         setSelectedRepo(matchingRepo);
-        validateRepoInternal(matchingRepo);
+        validateRepo(matchingRepo);
       }
       // Mark autofill as attempted for this org/snap combination
       autofillAttemptedRef.current = currentOrgKey;
@@ -253,7 +253,7 @@ function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {
     setSelectedRepo(selectedRepo);
 
     if (selectedRepo) {
-      validateRepoInternal(selectedRepo);
+      validateRepo(selectedRepo);
     }
   };
 
@@ -359,7 +359,7 @@ function RepoSelector({ githubData, setAutoTriggerBuild }: Props) {
                 className="p-tooltip--btm-center"
                 aria-describedby="recheck-tooltip"
                 onClick={() => {
-                  validateRepoInternal(selectedRepo);
+                  validateRepo(selectedRepo);
                 }}
               >
                 <i className="p-icon--restart"></i>


### PR DESCRIPTION
## Done
Rename the `validateRepoInternal` function back to `validateRepoInternal` for readability. Based on unaddressed PR comment from a recently merged PR https://github.com/canonical/snapcraft.io/pull/5347

## How to QA
1. Execute the `dotrun test` command locally to make sure all the tests pass.

## Testing
- [ ] This PR has tests
- [x] No testing required (explain why): function renaming based on a PR comment https://github.com/canonical/snapcraft.io/pull/5347#discussion_r2386915660

## Issue / Card
Fixes #3319 and pending comment https://github.com/canonical/snapcraft.io/pull/5347#discussion_r2386915660

## Screenshots
Not Applicable
