### PR TITLE
Open Desktop button fixes

### DIFF
--- a/static/js/public/snap-details/__tests__/openDesktop.test.ts
+++ b/static/js/public/snap-details/__tests__/openDesktop.test.ts
@@ -73,9 +73,10 @@ describe("isDesktopStoreSupported", () => {
       setUserAgent(MAC_UA);
       expect(isDesktopStoreSupported()).toBe(true);
     } finally {
-      delete (navigator as any).userAgentData;
+      delete (navigator as { userAgentData?: unknown }).userAgentData;
     }
   });
+});
 
 describe("applyDesktopStoreSupport", () => {
   beforeEach(() => {

--- a/static/js/public/snap-details/__tests__/openDesktop.test.ts
+++ b/static/js/public/snap-details/__tests__/openDesktop.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import "@testing-library/jest-dom";
+
+import openDesktop, {
+  applyDesktopStoreSupport,
+  isDesktopStoreSupported,
+} from "../openDesktop";
+
+const { trackEvent } = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+
+vi.mock("@canonical/analytics-events", () => ({ trackEvent }));
+
+const LINUX_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const MAC_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const WINDOWS_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const ANDROID_UA =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+const CROS_UA =
+  "Mozilla/5.0 (X11; CrOS x86_64 14541.0.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+const BLOCK_HTML = `
+  <div data-js="open-desktop-block" class="u-hide">
+    <p>Ubuntu 16.04 or later?</p>
+    <button
+      data-snap="test-snap?channel=latest/beta"
+      class="p-button p-view-store-button"
+      data-js="open-desktop"
+      data-analytics-click
+      data-analytics-target="details_view_in_desktop_store"
+      data-shown-event="open_desktop_shown"
+      data-analytics-channel="latest/beta">View in Desktop store</button>
+    <p class="p-form-help-text" data-js="open-desktop-help">Make sure snap support is enabled.</p>
+    <div data-js="open-desktop-error"></div>
+  </div>`;
+
+function setUserAgent(ua: string) {
+  vi.spyOn(navigator, "userAgent", "get").mockReturnValue(ua);
+}
+
+const block = () => document.querySelector('[data-js="open-desktop-block"]')!;
+const button = () =>
+  document.querySelector<HTMLButtonElement>('[data-js="open-desktop"]')!;
+const helpText = () => document.querySelector('[data-js="open-desktop-help"]')!;
+const errorHolder = () =>
+  document.querySelector('[data-js="open-desktop-error"]')!;
+
+describe("isDesktopStoreSupported", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test.each([
+    ["Linux", LINUX_UA, true],
+    ["macOS", MAC_UA, false],
+    ["Windows", WINDOWS_UA, false],
+    ["Android", ANDROID_UA, false],
+    ["ChromeOS", CROS_UA, false],
+  ])("%s is %s", (_name, ua, expected) => {
+    setUserAgent(ua);
+    expect(isDesktopStoreSupported()).toBe(expected);
+  });
+});
+
+describe("applyDesktopStoreSupport", () => {
+  beforeEach(() => {
+    document.body.innerHTML = BLOCK_HTML;
+    trackEvent.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  test("reveals the block on Linux", () => {
+    setUserAgent(LINUX_UA);
+    applyDesktopStoreSupport();
+    expect(block()).not.toHaveClass("u-hide");
+  });
+
+  test("leaves the block hidden on unsupported platforms", () => {
+    setUserAgent(MAC_UA);
+    applyDesktopStoreSupport();
+    expect(block()).toHaveClass("u-hide");
+  });
+
+  test("reports an impression when the block is revealed", () => {
+    setUserAgent(LINUX_UA);
+    applyDesktopStoreSupport();
+    expect(trackEvent).toHaveBeenCalledWith("open_desktop_shown", {
+      channel: "latest/beta",
+    });
+  });
+
+  test("does not report an impression on unsupported platforms", () => {
+    setUserAgent(MAC_UA);
+    applyDesktopStoreSupport();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  test("does not report a second impression for an already-visible block", () => {
+    setUserAgent(LINUX_UA);
+    applyDesktopStoreSupport();
+    applyDesktopStoreSupport();
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("openDesktop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = BLOCK_HTML;
+    setUserAgent(LINUX_UA);
+    applyDesktopStoreSupport();
+    trackEvent.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("fires the snap:// URL with whitespace stripped", () => {
+    openDesktop(button());
+
+    const iframe = document.querySelector<HTMLIFrameElement>(
+      ".js-snap-open-frame",
+    )!;
+    expect(iframe.getAttribute("src")).toEqual(
+      "snap://test-snap?channel=latest/beta",
+    );
+  });
+
+  test("enters the loading state on click", () => {
+    openDesktop(button());
+
+    expect(button()).toBeDisabled();
+    expect(button()).toHaveClass("is-processing");
+    expect(button().querySelector(".p-icon--spinner")).not.toBeNull();
+  });
+
+  test("returns to idle and reports success when the window blurs", () => {
+    openDesktop(button());
+    window.dispatchEvent(new Event("blur"));
+
+    expect(button()).not.toBeDisabled();
+    expect(button()).not.toHaveClass("is-processing");
+    expect(button()).toHaveTextContent("View in Desktop store");
+    expect(errorHolder()).toBeEmptyDOMElement();
+    expect(trackEvent).toHaveBeenCalledWith(
+      "details_view_in_desktop_store_success",
+      { channel: "latest/beta" },
+    );
+  });
+
+  test("reports success when the document becomes hidden", () => {
+    openDesktop(button());
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "details_view_in_desktop_store_success",
+      { channel: "latest/beta" },
+    );
+  });
+
+  test("shows an error and reports it when nothing happens in time", () => {
+    openDesktop(button());
+    vi.advanceTimersByTime(1500);
+
+    expect(button()).not.toBeDisabled();
+    expect(
+      errorHolder().querySelector(".p-notification--caution"),
+    ).not.toBeNull();
+    expect(errorHolder()).toHaveTextContent(/Couldn't open the Desktop Store/);
+    expect(helpText()).toHaveClass("u-hide");
+    expect(trackEvent).toHaveBeenCalledWith(
+      "details_view_in_desktop_store_error",
+      { channel: "latest/beta" },
+    );
+  });
+
+  test("does not report twice when the timeout follows a success", () => {
+    openDesktop(button());
+    window.dispatchEvent(new Event("blur"));
+    vi.advanceTimersByTime(1500);
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(errorHolder()).toBeEmptyDOMElement();
+  });
+
+  test("clears a previous error on the next click", () => {
+    openDesktop(button());
+    vi.advanceTimersByTime(1500);
+    expect(errorHolder()).not.toBeEmptyDOMElement();
+
+    openDesktop(button());
+    expect(errorHolder()).toBeEmptyDOMElement();
+    expect(helpText()).not.toHaveClass("u-hide");
+  });
+
+  test("ignores clicks while already loading", () => {
+    openDesktop(button());
+    openDesktop(button());
+    vi.advanceTimersByTime(1500);
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/js/public/snap-details/__tests__/openDesktop.test.ts
+++ b/static/js/public/snap-details/__tests__/openDesktop.test.ts
@@ -62,7 +62,20 @@ describe("isDesktopStoreSupported", () => {
     setUserAgent(ua);
     expect(isDesktopStoreSupported()).toBe(expected);
   });
-});
+
+  test("prefers userAgentData.platform when available", () => {
+    Object.defineProperty(navigator, "userAgentData", {
+      value: { platform: "Linux" },
+      configurable: true,
+    });
+
+    try {
+      setUserAgent(MAC_UA);
+      expect(isDesktopStoreSupported()).toBe(true);
+    } finally {
+      delete (navigator as any).userAgentData;
+    }
+  });
 
 describe("applyDesktopStoreSupport", () => {
   beforeEach(() => {

--- a/static/js/public/snap-details/channelMap.ts
+++ b/static/js/public/snap-details/channelMap.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import SnapEvents from "../../libs/events";
+import openDesktop, { applyDesktopStoreSupport } from "./openDesktop";
 
 interface SnapElement extends HTMLElement {
   dataset: {
@@ -376,22 +377,7 @@ class ChannelMap {
   }
 
   openDesktop(clickEl: HTMLElement) {
-    const name = clickEl.dataset.snap?.trim() || "";
-    let iframe = document.querySelector(
-      ".js-snap-open-frame",
-    ) as HTMLIFrameElement | null;
-
-    if (iframe && iframe.parentNode) {
-      iframe.parentNode.removeChild(iframe);
-    }
-
-    iframe = document.createElement("iframe");
-    iframe.className = "js-snap-open-frame";
-    iframe.style.position = "absolute";
-    iframe.style.top = "-9999px";
-    iframe.style.left = "-9999px";
-    iframe.src = `snap://${name}`;
-    document.body.appendChild(iframe);
+    openDesktop(clickEl as HTMLButtonElement);
   }
 
   selectScreen(screenEl: HTMLElement) {
@@ -499,6 +485,8 @@ class ChannelMap {
     ) as HTMLElement;
 
     holder.innerHTML = newDiv.innerHTML;
+
+    applyDesktopStoreSupport(holder);
   }
 
   writeTable(el: HTMLElement, data: string[][], tableType?: string): void {

--- a/static/js/public/snap-details/openDesktop.ts
+++ b/static/js/public/snap-details/openDesktop.ts
@@ -1,0 +1,173 @@
+import { trackEvent } from "@canonical/analytics-events";
+
+// How long to wait for the OS to hand off to the Desktop Store before we
+// assume no `snap://` handler is registered.
+const LAUNCH_TIMEOUT_MS = 1500;
+
+const BLOCK_SELECTOR = '[data-js="open-desktop-block"]';
+const HELP_SELECTOR = '[data-js="open-desktop-help"]';
+const ERROR_SELECTOR = '[data-js="open-desktop-error"]';
+
+const ERROR_MESSAGE =
+  `Couldn't open the Desktop Store. Make sure ` +
+  `<a href="/docs/installing-snapd">snap support</a> is enabled, or install ` +
+  `this snap using the command below.`;
+
+interface UserAgentData {
+  platform?: string;
+}
+
+export function isDesktopStoreSupported(): boolean {
+  const uaData = (navigator as Navigator & { userAgentData?: UserAgentData })
+    .userAgentData;
+
+  if (uaData && uaData.platform) {
+    return uaData.platform === "Linux";
+  }
+
+  const ua = navigator.userAgent;
+
+  // Android and ChromeOS both report a Linux kernel but have no snapd.
+  return /Linux/.test(ua) && !/Android|CrOS/.test(ua);
+}
+
+export function applyDesktopStoreSupport(root: ParentNode = document): void {
+  if (!isDesktopStoreSupported()) {
+    return;
+  }
+
+  root.querySelectorAll(BLOCK_SELECTOR).forEach((block) => {
+    if (!block.classList.contains("u-hide")) {
+      return;
+    }
+
+    block.classList.remove("u-hide");
+
+    const button = block.querySelector<HTMLElement>('[data-js="open-desktop"]');
+    const shownEvent = button?.dataset.shownEvent;
+    const channel = button?.dataset.analyticsChannel;
+
+    if (shownEvent) {
+      trackEvent(shownEvent, channel ? { channel } : {});
+    }
+  });
+}
+
+function clearError(block: Element | null): void {
+  if (!block) {
+    return;
+  }
+
+  const errorEl = block.querySelector(ERROR_SELECTOR);
+  if (errorEl) {
+    errorEl.innerHTML = "";
+  }
+
+  block.querySelector(HELP_SELECTOR)?.classList.remove("u-hide");
+}
+
+function showError(block: Element | null): void {
+  if (!block) {
+    return;
+  }
+
+  const errorEl = block.querySelector(ERROR_SELECTOR);
+  if (!errorEl) {
+    return;
+  }
+
+  // The help text below the button repeats the snapd advice, so hide it while
+  // the notification is on screen.
+  block.querySelector(HELP_SELECTOR)?.classList.add("u-hide");
+
+  errorEl.innerHTML = `
+    <div class="p-notification--caution is-inline u-no-margin--bottom" role="alert">
+      <div class="p-notification__content">
+        <p class="p-notification__message">${ERROR_MESSAGE}</p>
+      </div>
+    </div>`;
+}
+
+function setLoading(button: HTMLButtonElement): void {
+  button.dataset.idleLabel = button.innerHTML;
+  button.classList.add("is-processing", "has-icon");
+  button.disabled = true;
+  button.setAttribute("aria-busy", "true");
+  button.innerHTML = `<i class="p-icon--spinner u-animation--spin"></i>&nbsp;<span>Opening&hellip;</span>`;
+}
+
+function setIdle(button: HTMLButtonElement): void {
+  if (button.dataset.idleLabel !== undefined) {
+    button.innerHTML = button.dataset.idleLabel;
+    delete button.dataset.idleLabel;
+  }
+  button.classList.remove("is-processing", "has-icon");
+  button.disabled = false;
+  button.removeAttribute("aria-busy");
+}
+
+function launch(name: string): void {
+  const existing = document.querySelector(".js-snap-open-frame");
+  existing?.parentNode?.removeChild(existing);
+
+  const iframe = document.createElement("iframe");
+  iframe.className = "js-snap-open-frame";
+  iframe.style.position = "absolute";
+  iframe.style.top = "-9999px";
+  iframe.style.left = "-9999px";
+  iframe.src = `snap://${name}`;
+  document.body.appendChild(iframe);
+}
+
+export default function openDesktop(button: HTMLButtonElement): void {
+  if (button.disabled) {
+    return;
+  }
+
+  const block = button.closest(BLOCK_SELECTOR);
+  const target = button.dataset.analyticsTarget;
+  const channel = button.dataset.analyticsChannel;
+
+  clearError(block);
+  setLoading(button);
+
+  let settled = false;
+  let timer = 0;
+
+  const finish = (success: boolean) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+
+    window.clearTimeout(timer);
+    window.removeEventListener("blur", onBlur);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+
+    setIdle(button);
+
+    if (!success) {
+      showError(block);
+    }
+
+    if (target) {
+      trackEvent(
+        `${target}_${success ? "success" : "error"}`,
+        channel ? { channel } : {},
+      );
+    }
+  };
+
+  const onBlur = () => finish(true);
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      finish(true);
+    }
+  };
+
+  timer = window.setTimeout(() => finish(false), LAUNCH_TIMEOUT_MS);
+  window.addEventListener("blur", onBlur);
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  launch((button.dataset.snap || "").replace(/\s+/g, ""));
+}

--- a/static/js/public/store-details.ts
+++ b/static/js/public/store-details.ts
@@ -7,9 +7,11 @@ import initEmbeddedCardModal from "./snap-details/embeddedCard";
 import { snapDetailsPosts } from "./snap-details/blog-posts";
 import initExpandableArea from "./expandable-area";
 import initCopyCommand from "./snap-details/copyCommand";
+import { applyDesktopStoreSupport } from "./snap-details/openDesktop";
 import declareGlobal from "../libs/declare";
 
 initCopyCommand();
+applyDesktopStoreSupport();
 
 declareGlobal("snapcraft.public.storeDetails", {
   map,

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -1,3 +1,21 @@
+{% macro open_desktop_block(snap, target, shown_event, channel) %}
+  <div data-js="open-desktop-block" class="u-hide">
+    <p>Ubuntu 16.04 or later?</p>
+    <button
+      data-snap="{{ snap }}"
+      class="p-button p-view-store-button"
+      data-js="open-desktop"
+      data-analytics-click
+      data-analytics-target="{{ target }}"
+      data-shown-event="{{ shown_event }}"
+      data-analytics-channel="{{ channel }}">
+        View in Desktop store
+    </button>
+    <p class="p-form-help-text" data-js="open-desktop-help">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>
+    <div data-js="open-desktop-error"></div>
+  </div>
+{% endmacro %}
+
 <div id="js-channel-map" class="p-channel-map is-closed">
   <div id="channel-map-install" class="p-channel-map__tab">
     <div class="p-strip--light is-shallow">
@@ -13,20 +31,8 @@
           </div>
         {% endif %}
 
-        <p>Ubuntu 16.04 or later?</p>
-        <button
-          data-snap="{{ package_name }}
-            {% if lowest_risk_available != 'stable' %}
-              ?channel={{ default_track }}/{{ lowest_risk_available }}
-            {% endif %}"
-          class="p-view-store-button"
-          data-js="open-desktop"
-          data-analytics-click
-          data-analytics-target="details_view_in_desktop_store"
-          data-analytics-channel="{{ default_track }}/{{ lowest_risk_available }}">
-            View in Desktop store
-        </button>
-        <p class="p-form-help-text">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>
+        {% set desktop_snap = package_name if lowest_risk_available == 'stable' else package_name ~ '?channel=' ~ default_track ~ '/' ~ lowest_risk_available %}
+        {{ open_desktop_block(desktop_snap, 'details_view_in_desktop_store', 'open_desktop_shown', default_track ~ '/' ~ lowest_risk_available) }}
       </div>
       <div class="u-fixed-width">
         <hr />
@@ -170,9 +176,8 @@
         <p class="p-notification__message" data-js="warning"></p>
       </div>
     </div>
-    <p>Ubuntu 16.04 or later?</p>
-    <button data-snap="{{ package_name }}?channel=${channel}" class="p-view-store-button" data-js="open-desktop" data-analytics-click data-analytics-target="details_channel_view_in_desktop_store" data-analytics-channel="${channel}">View in Desktop store</button>
-    <p class="p-form-help-text">Make sure <a href="/docs/installing-snapd">snap support</a> is enabled in your Desktop store.</p>
+
+    {{ open_desktop_block(package_name ~ '?channel=${channel}', 'details_channel_view_in_desktop_store', 'open_desktop_channel_shown', '${channel}') }}
   </div>
   <div class="u-fixed-width">
     <hr />


### PR DESCRIPTION
## Done
Adds a "View in Desktop store" button on the snap details / channel map that launches the snap in the user's desktop store via a snap:// handoff.

- Platform-gated: the button is hidden by default and only revealed on platforms that can register a snap:// handler (Linux desktop; excludes Android/ChromeOS), so it never shows where it would silently fail.
- Feedback states: shows a loading spinner while launching, and a caution notification with the CLI install fallback if no handler responds within 1.5s.
- Launch detection: treats the window losing focus/visibility as a successful handoff, and the timeout as "no handler registered".
- Shared button markup extracted into a Jinja macro; adds analytics for impressions and launch outcomes; unit tests for platform detection, reveal, and launch flow.

Scenarios

  - Non-Linux (macOS/Windows) or Android/ChromeOS -> button stays hidden, nothing tracked.
  - Linux desktop, page load -> button revealed, *_shown impression fired.
  - Click with snapd installed-> spinner, window blurs/tab hides, returns to idle, *_success fired.
  - Click with no snap:// handler -> spinner, 1.5s timeout, caution notification + CLI fallback shown, *_error fired.
  - Click on a specific channel (channel map) -> same flow with the channel's snap://…?channel= and details_channel_* events.
  - Re-click after an error → previous error cleared, launch retried.
  - Rapid double-click / click while loading -> ignored, single launch and single event.
  - Channel install screen re-rendered -> newly injected block re-checked and revealed on supported platforms.

## How to QA
- go to https://snapcraft-io-5806.demos.haus/microcloud
- Click on the install button
    - if your computer is Linux verify the "view in desktop store" is visible
    - if you are using non-Luinux verify the 'view in desktop store" is hidden
- click  "view in desktop store" if visible
    - if your Os is Ubuntu it should open the store
    - if not an error message should be shown 
- Click on the channel button near the install button
- hover on a channel
- click on the install button:
    - if your computer is Linux verify the "view in desktop store" is visible
    - if you are using non-Luinux verify the 'view in desktop store" is hidden
- click  "view in desktop store" if visible
    - if your Os is Ubuntu it should open the store
    - if not an error message should be shown 

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36645