### PR TITLE
fix: Builds return 404 if they aren't accessible by the user

### DIFF
--- a/static/js/publisher/pages/Build/Build.tsx
+++ b/static/js/publisher/pages/Build/Build.tsx
@@ -1,6 +1,12 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "react-query";
-import { Strip, Row, Col, MainTable } from "@canonical/react-components";
+import {
+  Strip,
+  Row,
+  Col,
+  MainTable,
+  Notification,
+} from "@canonical/react-components";
 import { formatDistanceToNow } from "date-fns";
 
 import {
@@ -11,21 +17,42 @@ import {
 import { GitCommitLink } from "../../utils/formatGitCommit";
 import Loader from "../../components/Loader";
 
+const genericBuildError = "There was a problem trying to fetch build data";
+
+type BuildErrorResponse = {
+  error?: {
+    message?: string;
+  };
+  message?: string;
+};
+
+async function getBuildErrorMessage(response: Response): Promise<string> {
+  try {
+    const responseData = (await response.json()) as BuildErrorResponse;
+
+    return (
+      responseData.error?.message || responseData.message || genericBuildError
+    );
+  } catch {
+    return genericBuildError;
+  }
+}
+
 function Build(): React.JSX.Element {
   const { buildId, snapId } = useParams();
-  const { data, isFetched, isLoading, isFetching } = useQuery({
+  const { data, error, isFetched, isLoading, isFetching, status } = useQuery({
     queryKey: ["build", snapId, buildId],
     queryFn: async () => {
       const response = await fetch(`/api/${snapId}/builds/${buildId}`);
 
       if (!response.ok) {
-        throw new Error("There was a problem trying to fetch build data");
+        throw new Error(await getBuildErrorMessage(response));
       }
 
       const responseData = await response.json();
 
       if (!responseData.success) {
-        throw new Error("There was a problem trying to fetch build data");
+        throw new Error(responseData.error?.message || genericBuildError);
       }
 
       return responseData.data;
@@ -34,17 +61,29 @@ function Build(): React.JSX.Element {
   });
 
   const build = data?.snap_build;
+  const hasError = status === "error";
+  const errorMessage =
+    error instanceof Error ? error.message : genericBuildError;
   const isDataLoading =
-    isLoading ||
-    isFetching ||
-    !data ||
-    (build && build.id.toString() !== buildId);
+    !hasError &&
+    (isLoading ||
+      isFetching ||
+      !data ||
+      (build && build.id.toString() !== buildId));
 
   setPageTitle(`Build ${buildId} for ${snapId}`);
 
   return (
     <>
       {isDataLoading && <Loader text={`Loading ${snapId} build data`} />}
+
+      {hasError && (
+        <Strip shallow>
+          <Notification severity="negative" title="Build data unavailable">
+            {errorMessage}
+          </Notification>
+        </Strip>
+      )}
 
       {!isDataLoading && isFetched && data && (
         <Strip shallow>

--- a/static/js/publisher/pages/Build/__tests__/Build.test.tsx
+++ b/static/js/publisher/pages/Build/__tests__/Build.test.tsx
@@ -139,4 +139,23 @@ describe("Build", () => {
 
     expect(screen.getByText(/Test build logs/)).toBeInTheDocument();
   });
+
+  test("shows error message when build data cannot be loaded", () => {
+    // @ts-expect-error - Mocking useQuery response
+    useQuery.mockReturnValue({
+      data: undefined,
+      error: new Error("The requested build could not be found."),
+      isLoading: false,
+      isFetched: true,
+      isFetching: false,
+      status: "error",
+    });
+
+    renderComponent();
+
+    expect(screen.getByText("Build data unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText("The requested build could not be found."),
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -45,6 +45,92 @@ class TestGetSnapBuildPage(TestEndpoints):
         self.assertIn(response.status_code, [302, 401, 403])
 
 
+class TestGetSnapBuild(TestEndpoints):
+    def setUp(self):
+        super().setUp()
+        self.snap_name = "test-snap"
+        self.build_id = "12345"
+        self.endpoint_url = f"/api/{self.snap_name}/builds/{self.build_id}"
+        self.snap_info = {
+            "snap_name": self.snap_name,
+            "title": "Test Snap",
+            "snap_id": "test-snap-id-123",
+        }
+
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_success(self, mock_dashboard, mock_launchpad):
+        mock_dashboard.get_snap_info.return_value = self.snap_info
+        mock_launchpad.get_snap_by_store_name.return_value = {
+            "store_name": self.snap_name,
+            "git_repository_url": "https://github.com/owner/repo",
+        }
+        mock_launchpad.get_snap_build.return_value = {
+            "self_link": (
+                "https://api.launchpad.net/devel/~owner/"
+                "+snap/test-snap/+build/12345"
+            ),
+            "arch_tag": "amd64",
+            "datebuilt": "2023-01-01T12:00:00Z",
+            "duration": "00:05:30",
+            "build_log_url": "https://launchpad.net/buildlog.txt",
+            "revision_id": "abcdef1234567890abcdef1234567890abcdef12",
+            "buildstate": "Successfully built",
+            "store_upload_status": "Uploaded",
+            "title": "Test build",
+        }
+        mock_launchpad.get_snap_build_log.return_value = "Build log"
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 200)
+        response_data = response.get_json()
+        self.assertTrue(response_data["success"])
+        self.assertEqual(response_data["data"]["raw_logs"], "Build log")
+        snap_build = response_data["data"]["snap_build"]
+        self.assertEqual(snap_build["id"], self.build_id)
+        self.assertEqual(snap_build["github_repository"], "owner/repo")
+
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_returns_404_when_snap_not_in_launchpad(
+        self, mock_dashboard, mock_launchpad
+    ):
+        mock_dashboard.get_snap_info.return_value = self.snap_info
+        mock_launchpad.get_snap_by_store_name.return_value = None
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 404)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertEqual(
+            response_data["error"]["type"], "SNAP_BUILD_NOT_FOUND"
+        )
+        mock_launchpad.get_snap_build.assert_not_called()
+
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_returns_404_when_build_not_found(
+        self, mock_dashboard, mock_launchpad
+    ):
+        mock_dashboard.get_snap_info.return_value = self.snap_info
+        mock_launchpad.get_snap_by_store_name.return_value = {
+            "store_name": self.snap_name,
+            "git_repository_url": "https://github.com/owner/repo",
+        }
+        mock_launchpad.get_snap_build.return_value = None
+
+        response = self.client.get(self.endpoint_url)
+
+        self.assertEqual(response.status_code, 404)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertEqual(
+            response_data["error"]["type"], "SNAP_BUILD_NOT_FOUND"
+        )
+
+
 class TestPostBuild(TestEndpoints):
     def setUp(self):
         super().setUp()

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -135,37 +135,68 @@ def get_snap_build(snap_name, build_id):
         "snap_build": {},
     }
 
-    # Get build by snap name and build_id
-    lp_build = launchpad.get_snap_build(details["snap_name"], build_id)
+    lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
 
-    if lp_build:
-        # Get snap info to extract GitHub repository
-        lp_snap = launchpad.get_snap_by_store_name(details["snap_name"])
-        github_repository = None
-        if lp_snap:
-            github_repository = extract_github_repository(
-                lp_snap.get("git_repository_url")
-            )
-
-        status = map_build_and_upload_states(
-            lp_build["buildstate"], lp_build["store_upload_status"]
+    if not lp_snap:
+        return (
+            flask.jsonify(
+                {
+                    "error": {
+                        "type": "SNAP_BUILD_NOT_FOUND",
+                        "message": "The requested build could not be found.",
+                    },
+                    "success": False,
+                }
+            ),
+            404,
         )
-        context["snap_build"] = {
-            "id": lp_build["self_link"].split("/")[-1],
-            "arch_tag": lp_build["arch_tag"],
-            "datebuilt": lp_build["datebuilt"],
-            "duration": lp_build["duration"],
-            "logs": lp_build["build_log_url"],
-            "revision_id": lp_build["revision_id"],
-            "status": status,
-            "title": lp_build["title"],
-            "github_repository": github_repository,
-        }
 
-        if context["snap_build"]["logs"]:
-            context["raw_logs"] = launchpad.get_snap_build_log(
-                details["snap_name"], build_id
-            )
+    # Get build by snap name and build_id
+    try:
+        lp_build = launchpad.get_snap_build(details["snap_name"], build_id)
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            lp_build = None
+        else:
+            raise e
+
+    if not lp_build:
+        return (
+            flask.jsonify(
+                {
+                    "error": {
+                        "type": "SNAP_BUILD_NOT_FOUND",
+                        "message": "The requested build could not be found.",
+                    },
+                    "success": False,
+                }
+            ),
+            404,
+        )
+
+    github_repository = extract_github_repository(
+        lp_snap.get("git_repository_url")
+    )
+
+    status = map_build_and_upload_states(
+        lp_build["buildstate"], lp_build["store_upload_status"]
+    )
+    context["snap_build"] = {
+        "id": lp_build["self_link"].split("/")[-1],
+        "arch_tag": lp_build["arch_tag"],
+        "datebuilt": lp_build["datebuilt"],
+        "duration": lp_build["duration"],
+        "logs": lp_build["build_log_url"],
+        "revision_id": lp_build["revision_id"],
+        "status": status,
+        "title": lp_build["title"],
+        "github_repository": github_repository,
+    }
+
+    if context["snap_build"]["logs"]:
+        context["raw_logs"] = launchpad.get_snap_build_log(
+            details["snap_name"], build_id
+        )
 
     return flask.jsonify({"data": context, "success": True})
 


### PR DESCRIPTION
## Done
Fixes issue where a build that isn't accessible returns a 404

## How to QA

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Just changes error visibility for user

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38163

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
