### PR TITLE
fix: Fix for build logs timing out

### DIFF
--- a/static/js/publisher/pages/Build/Build.tsx
+++ b/static/js/publisher/pages/Build/Build.tsx
@@ -60,13 +60,7 @@ function Build(): React.JSX.Element {
         throw new Error("There was a problem trying to fetch build logs");
       }
 
-      const responseData = await response.json();
-
-      if (!responseData.success) {
-        throw new Error("There was a problem trying to fetch build logs");
-      }
-
-      return responseData.data;
+      return { raw_logs: await response.text() };
     },
     enabled: Boolean(snapId && buildId && !isDataLoading && build?.logs),
     refetchOnWindowFocus: false,

--- a/static/js/publisher/pages/Build/__tests__/Build.test.tsx
+++ b/static/js/publisher/pages/Build/__tests__/Build.test.tsx
@@ -149,6 +149,23 @@ describe("Build", () => {
     ).toBeInTheDocument();
   });
 
+  test("links to raw build log", () => {
+    mockUseQueryResponses({
+      data: mockBuildData,
+      isLoading: false,
+      isFetched: true,
+      isFetching: false,
+      isError: false,
+    });
+
+    renderComponent();
+
+    expect(screen.getByRole("link", { name: "View raw" })).toHaveAttribute(
+      "href",
+      "https://launchpad.net",
+    );
+  });
+
   test("shows build log", () => {
     mockUseQueryResponses({
       data: mockBuildData,

--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from requests.exceptions import HTTPError
 from tests.endpoints.endpoint_testing import TestEndpoints
 
@@ -98,22 +98,34 @@ class TestGetSnapBuild(TestEndpoints):
         )
         mock_launchpad.get_snap_build_log.assert_not_called()
 
+    @patch("webapp.publisher.snaps.build_views.api_publisher_session")
     @patch("webapp.publisher.snaps.build_views.launchpad")
     @patch("webapp.publisher.snaps.build_views.dashboard")
-    def test_get_snap_build_logs_success(self, mock_dashboard, mock_launchpad):
+    def test_get_snap_build_logs_streams_from_launchpad(
+        self, mock_dashboard, mock_launchpad, mock_api_publisher_session
+    ):
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = ["Test ", "build logs"]
         mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
         mock_launchpad.get_snap_build.return_value = self._mock_build()
-        mock_launchpad.get_snap_build_log.return_value = "Test build logs"
+        mock_api_publisher_session.get.return_value = mock_response
 
         response = self.client.get(f"{self.endpoint_url}/logs")
 
         self.assertEqual(response.status_code, 200)
-        response_data = response.get_json()
-        self.assertTrue(response_data["success"])
-        self.assertEqual(response_data["data"]["raw_logs"], "Test build logs")
-        mock_launchpad.get_snap_build_log.assert_called_once_with(
-            self.snap_name, self.build_id
+        self.assertEqual(response.content_type, "text/plain; charset=utf-8")
+        self.assertEqual(response.get_data(as_text=True), "Test build logs")
+        mock_api_publisher_session.get.assert_called_once_with(
+            "https://launchpad.net/buildlog.txt",
+            headers={"Accept": "text/plain"},
+            stream=True,
+            timeout=(5, 30),
         )
+        mock_response.iter_content.assert_called_once_with(
+            chunk_size=8192, decode_unicode=True
+        )
+        mock_response.close.assert_called_once()
+        mock_launchpad.get_snap_build_log.assert_not_called()
 
     @patch("webapp.publisher.snaps.build_views.launchpad")
     @patch("webapp.publisher.snaps.build_views.dashboard")

--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -105,7 +105,9 @@ class TestGetSnapBuild(TestEndpoints):
         self, mock_dashboard, mock_launchpad, mock_api_publisher_session
     ):
         mock_response = MagicMock()
+        mock_response.status_code = 200
         mock_response.iter_content.return_value = ["Test ", "build logs"]
+        mock_response.raise_for_status.return_value = None
         mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
         mock_launchpad.get_snap_build.return_value = self._mock_build()
         mock_api_publisher_session.get.return_value = mock_response
@@ -124,7 +126,37 @@ class TestGetSnapBuild(TestEndpoints):
         mock_response.iter_content.assert_called_once_with(
             chunk_size=8192, decode_unicode=True
         )
+        mock_response.raise_for_status.assert_called_once_with()
         mock_response.close.assert_called_once()
+        mock_launchpad.get_snap_build_log.assert_not_called()
+
+    @patch("webapp.publisher.snaps.build_views.api_publisher_session")
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_logs_returns_error_when_launchpad_fails(
+        self, mock_dashboard, mock_launchpad, mock_api_publisher_session
+    ):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status.side_effect = HTTPError(
+            response=mock_response
+        )
+        mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
+        mock_launchpad.get_snap_build.return_value = self._mock_build()
+        mock_api_publisher_session.get.return_value = mock_response
+
+        response = self.client.get(f"{self.endpoint_url}/logs")
+
+        self.assertEqual(response.status_code, 502)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertEqual(
+            response_data["error"]["message"],
+            "The requested build log could not be fetched.",
+        )
+        mock_response.raise_for_status.assert_called_once_with()
+        mock_response.close.assert_called_once_with()
+        mock_response.iter_content.assert_not_called()
         mock_launchpad.get_snap_build_log.assert_not_called()
 
     @patch("webapp.publisher.snaps.build_views.launchpad")

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -194,9 +194,28 @@ def get_snap_build_logs(snap_name, build_id):
             404,
         )
 
-    raw_logs = launchpad.get_snap_build_log(details["snap_name"], build_id)
+    response = api_publisher_session.get(
+        lp_build["build_log_url"],
+        headers={"Accept": "text/plain"},
+        stream=True,
+        timeout=(5, 30),
+    )
+    response.raise_for_status()
 
-    return flask.jsonify({"data": {"raw_logs": raw_logs}, "success": True})
+    def generate_log_chunks():
+        try:
+            for chunk in response.iter_content(
+                chunk_size=8192, decode_unicode=True
+            ):
+                if chunk:
+                    yield chunk
+        finally:
+            response.close()
+
+    return flask.Response(
+        flask.stream_with_context(generate_log_chunks()),
+        mimetype="text/plain",
+    )
 
 
 def validate_repo(github_token, snap_name, gh_owner, gh_repo):

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -200,7 +200,22 @@ def get_snap_build_logs(snap_name, build_id):
         stream=True,
         timeout=(5, 30),
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except HTTPError:
+        response.close()
+        return (
+            flask.jsonify(
+                {
+                    "error": {
+                        "message": "The requested build log could not be "
+                        "fetched."
+                    },
+                    "success": False,
+                }
+            ),
+            502,
+        )
 
     def generate_log_chunks():
         try:


### PR DESCRIPTION
## Done

Addresses issue where the build log times out by streaming the response.

## How to QA
This issue can't be reproduced locally so the only QA is to ensure that the logs display on a single build page, e.g. /<snap_name>/builds/<build_id>

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
