### PR TITLE
Python deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # App dependencies
 canonicalwebteam.flask-base==3.1.2
-canonicalwebteam.flask-vite==0.5.1
+canonicalwebteam.flask-vite==0.6.0
 canonicalwebteam.candid==0.9.0
 canonicalwebteam.discourse==7.2.0
 canonicalwebteam.blog==7.1.0
@@ -11,12 +11,12 @@ canonicalwebteam.launchpad==0.10.0
 django-openid-auth==0.17
 Flask-OpenID==1.3.1
 Flask-WTF==1.3.0
-Flask==2.3.3
-bleach==6.3.0
+Flask==3.1.3
+bleach==6.4.0
 emoji==2.15.0
 feedgen==1.0.0
 humanize==4.9.0
-mistune==3.2.1
+mistune==3.3.0
 pybadges==3.0.1
 pycountry==24.6.1
 pymacaroons==0.13.0

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -221,3 +221,21 @@ class TestMarkdownParser(unittest.TestCase):
             "</strong></p>\n"
         )
         self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_markdown_link_with_bold_label_does_not_crash(self):
+        markdown = "[**bold**](https://example.com)"
+        expected = (
+            "<p>"
+            '[<strong>bold</strong>](<a href="https://example.com">'
+            "https://example.com</a>)"
+            "</p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_markdown_image_with_bold_alt_does_not_crash(self):
+        markdown = "![**image**](link.png)"
+        expected = (
+            '<p>![<strong>image</strong>](<a href="link.png">'
+            "link.png</a>)</p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -172,7 +172,7 @@ class TestMarkdownParser(unittest.TestCase):
         """Image link is converted into a simple link"""
         markdown = "![image](link.png)"
         result = parse_markdown_description(markdown)
-        expected_result = "<p>" + markdown + "</p>\n"
+        expected_result = '<p>![image](<a href="link.png">link.png</a>)</p>\n'
 
         self.assertEqual(result, expected_result)
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -60,6 +60,13 @@ class SnapcraftBlockParser(BlockParser):
 
 
 class SnapcraftInlineParser(InlineParser):
+    # Override some of InlineParser's functionality to defend against
+    # malicious markdown
+    #
+    # Supported Mistune v3 customization point:
+    # - Inline parser methods can be overridden (see InlineParser API).
+    #   https://mistune.lepture.com/en/latest/api.html#mistune.InlineParser
+
     SPECIFICATION = {
         **InlineParser.SPECIFICATION,
         # Only match a single backtick so triple-backtick fences stay literal
@@ -87,15 +94,38 @@ class SnapcraftInlineParser(InlineParser):
             self.rules.remove("softbreak")
 
     def parse_link(self, m, state):
-        # Keep markdown link syntax as literal text instead of creating links.
+        # Keep markdown link syntax as literal text instead of creating links;
+        # only create anchor tags for the URLs themselves.
         #
         # Supported Mistune v3 customization point:
         # - Inline parser methods can be overridden (see InlineParser API).
         #   https://mistune.lepture.com/en/latest/api.html#mistune.InlineParser
-        # - Default link behavior lives in InlineParser.parse_link.
-        #   https://raw.githubusercontent.com/lepture/mistune/v3.2.1/src/mistune/inline_parser.py
-        state.append_token({"type": "text", "raw": m.group(0)})
-        return m.end()
+        #
+        # What we do:
+        # - call the parent's parse_link -> it appends a link token to state
+        # - pop the link token and replace it with:
+        #      1. a raw token for the "[<label>](" part of the link
+        #      2. the link token, but using the actual URL for the label
+        #      3. another raw token for ")"
+        # This method is also used for parsing images, so we add some logic for
+        # that too.
+
+        pos = super().parse_link(m, state)
+
+        if state.tokens[-1]["type"] in {"link", "image"}:
+            link = state.tokens.pop()
+
+            link["type"] = "link"
+            link_label = link["children"][0]["raw"]
+
+            marker = m.group(0) # "[" for links, "![" for images
+            start_token = f"{marker}{link_label}]("
+            state.append_token({"type": "text", "raw": start_token})
+            link["children"][0]["raw"] = link["attrs"]["url"]
+            state.append_token(link)
+            state.append_token({"type": "text", "raw": ")"})
+
+        return pos
 
 
 renderer = HTMLRenderer()

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -112,18 +112,28 @@ class SnapcraftInlineParser(InlineParser):
 
         pos = super().parse_link(m, state)
 
-        if state.tokens[-1]["type"] in {"link", "image"}:
-            link = state.tokens.pop()
+        if not state.tokens:
+            return pos
 
-            link["type"] = "link"
-            link_label = link["children"][0]["raw"]
+        link = state.tokens[-1]
+        if link.get("type") not in {"link", "image"}:
+            return pos
 
-            marker = m.group(0)  # "[" for links, "![" for images
-            start_token = f"{marker}{link_label}]("
-            state.append_token({"type": "text", "raw": start_token})
-            link["children"][0]["raw"] = link["attrs"]["url"]
+        link = state.tokens.pop()
+        url = link.get("attrs", {}).get("url")
+        if not url:
             state.append_token(link)
-            state.append_token({"type": "text", "raw": ")"})
+            return pos
+
+        label_children = link.get("children", [])
+        state.append_token({"type": "text", "raw": m.group(0)})
+        for child in label_children:
+            state.append_token(child)
+        state.append_token({"type": "text", "raw": "]("})
+        link["type"] = "link"
+        link["children"] = [{"type": "text", "raw": url}]
+        state.append_token(link)
+        state.append_token({"type": "text", "raw": ")"})
 
         return pos
 

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -118,7 +118,7 @@ class SnapcraftInlineParser(InlineParser):
             link["type"] = "link"
             link_label = link["children"][0]["raw"]
 
-            marker = m.group(0) # "[" for links, "![" for images
+            marker = m.group(0)  # "[" for links, "![" for images
             start_token = f"{marker}{link_label}]("
             state.append_token({"type": "text", "raw": start_token})
             link["children"][0]["raw"] = link["attrs"]["url"]


### PR DESCRIPTION
## Done
- updated python dependencies (versions suggested by dependabot)
- fixed an issue introduced by the update to mistune@3.3.0 (the `**` that closed the bold text would end up in the link's `src` attribute)
- fixed the markdown image parsing test to match the behavior described in its comment (and align it to the behavior of links)

## How to QA
- check that actions pass and demo works

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
