### PR TITLE
fix: Change way build logs are fetched to resolve 502 issue

### DIFF
--- a/tests/endpoints/publisher/tests_builds.py
+++ b/tests/endpoints/publisher/tests_builds.py
@@ -1,6 +1,8 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from requests.exceptions import HTTPError
 from tests.endpoints.endpoint_testing import TestEndpoints
+from webapp.api.exceptions import ApiConnectionError, ApiTimeoutError
+from webapp.publisher.snaps.build_views import BUILD_LOG_REQUEST_TIMEOUT
 
 
 class TestGetSnapBuildPage(TestEndpoints):
@@ -106,6 +108,7 @@ class TestGetSnapBuild(TestEndpoints):
     ):
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.iter_content.return_value = ["Test ", "build logs"]
         mock_response.raise_for_status.return_value = None
         mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
@@ -121,7 +124,8 @@ class TestGetSnapBuild(TestEndpoints):
             "https://launchpad.net/buildlog.txt",
             headers={"Accept": "text/plain"},
             stream=True,
-            timeout=(5, 30),
+            timeout=BUILD_LOG_REQUEST_TIMEOUT,
+            allow_redirects=False,
         )
         mock_response.iter_content.assert_called_once_with(
             chunk_size=8192, decode_unicode=True
@@ -133,11 +137,62 @@ class TestGetSnapBuild(TestEndpoints):
     @patch("webapp.publisher.snaps.build_views.api_publisher_session")
     @patch("webapp.publisher.snaps.build_views.launchpad")
     @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_logs_streams_from_launchpadlibrarian(
+        self, mock_dashboard, mock_launchpad, mock_api_publisher_session
+    ):
+        mock_redirect_response = MagicMock()
+        mock_redirect_response.status_code = 303
+        mock_redirect_response.is_redirect = True
+        mock_redirect_response.headers = {
+            "Location": "https://launchpadlibrarian.net/buildlog.txt"
+        }
+        mock_redirect_response.raise_for_status.return_value = None
+        mock_log_response = MagicMock()
+        mock_log_response.status_code = 200
+        mock_log_response.is_redirect = False
+        mock_log_response.iter_content.return_value = ["Test build logs"]
+        mock_log_response.raise_for_status.return_value = None
+        mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
+        mock_launchpad.get_snap_build.return_value = self._mock_build()
+        mock_api_publisher_session.get.side_effect = [
+            mock_redirect_response,
+            mock_log_response,
+        ]
+
+        response = self.client.get(f"{self.endpoint_url}/logs")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_data(as_text=True), "Test build logs")
+        mock_api_publisher_session.get.assert_has_calls(
+            [
+                call(
+                    "https://launchpad.net/buildlog.txt",
+                    headers={"Accept": "text/plain"},
+                    stream=True,
+                    timeout=BUILD_LOG_REQUEST_TIMEOUT,
+                    allow_redirects=False,
+                ),
+                call(
+                    "https://launchpadlibrarian.net/buildlog.txt",
+                    headers={"Accept": "text/plain"},
+                    stream=True,
+                    timeout=BUILD_LOG_REQUEST_TIMEOUT,
+                ),
+            ]
+        )
+        mock_redirect_response.close.assert_called_once_with()
+        mock_log_response.close.assert_called_once_with()
+        mock_launchpad.get_snap_build_log.assert_not_called()
+
+    @patch("webapp.publisher.snaps.build_views.api_publisher_session")
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
     def test_get_snap_build_logs_returns_error_when_launchpad_fails(
         self, mock_dashboard, mock_launchpad, mock_api_publisher_session
     ):
         mock_response = MagicMock()
         mock_response.status_code = 404
+        mock_response.is_redirect = False
         mock_response.raise_for_status.side_effect = HTTPError(
             response=mock_response
         )
@@ -157,6 +212,71 @@ class TestGetSnapBuild(TestEndpoints):
         mock_response.raise_for_status.assert_called_once_with()
         mock_response.close.assert_called_once_with()
         mock_response.iter_content.assert_not_called()
+        mock_api_publisher_session.get.assert_called_once_with(
+            "https://launchpad.net/buildlog.txt",
+            headers={"Accept": "text/plain"},
+            stream=True,
+            timeout=BUILD_LOG_REQUEST_TIMEOUT,
+            allow_redirects=False,
+        )
+        mock_launchpad.get_snap_build_log.assert_not_called()
+
+    @patch("webapp.publisher.snaps.build_views.api_publisher_session")
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_logs_returns_error_when_launchpad_times_out(
+        self, mock_dashboard, mock_launchpad, mock_api_publisher_session
+    ):
+        mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
+        mock_launchpad.get_snap_build.return_value = self._mock_build()
+        mock_api_publisher_session.get.side_effect = ApiTimeoutError("timeout")
+
+        response = self.client.get(f"{self.endpoint_url}/logs")
+
+        self.assertEqual(response.status_code, 502)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertEqual(
+            response_data["error"]["message"],
+            "The requested build log could not be fetched.",
+        )
+        mock_api_publisher_session.get.assert_called_once_with(
+            "https://launchpad.net/buildlog.txt",
+            headers={"Accept": "text/plain"},
+            stream=True,
+            timeout=BUILD_LOG_REQUEST_TIMEOUT,
+            allow_redirects=False,
+        )
+        mock_launchpad.get_snap_build_log.assert_not_called()
+
+    @patch("webapp.publisher.snaps.build_views.api_publisher_session")
+    @patch("webapp.publisher.snaps.build_views.launchpad")
+    @patch("webapp.publisher.snaps.build_views.dashboard")
+    def test_get_snap_build_logs_returns_error_when_launchpad_unreachable(
+        self, mock_dashboard, mock_launchpad, mock_api_publisher_session
+    ):
+        mock_dashboard.get_snap_info.return_value = self._mock_snap_info()
+        mock_launchpad.get_snap_build.return_value = self._mock_build()
+        mock_api_publisher_session.get.side_effect = ApiConnectionError(
+            "connection error"
+        )
+
+        response = self.client.get(f"{self.endpoint_url}/logs")
+
+        self.assertEqual(response.status_code, 502)
+        response_data = response.get_json()
+        self.assertFalse(response_data["success"])
+        self.assertEqual(
+            response_data["error"]["message"],
+            "The requested build log could not be fetched.",
+        )
+        mock_api_publisher_session.get.assert_called_once_with(
+            "https://launchpad.net/buildlog.txt",
+            headers={"Accept": "text/plain"},
+            stream=True,
+            timeout=BUILD_LOG_REQUEST_TIMEOUT,
+            allow_redirects=False,
+        )
         mock_launchpad.get_snap_build_log.assert_not_called()
 
     @patch("webapp.publisher.snaps.build_views.launchpad")

--- a/webapp/publisher/snaps/build_views.py
+++ b/webapp/publisher/snaps/build_views.py
@@ -2,6 +2,7 @@
 import os
 import re
 from hashlib import md5
+from urllib.parse import urljoin
 
 # Packages
 import flask
@@ -10,6 +11,7 @@ from canonicalwebteam.store_api.dashboard import Dashboard
 from requests.exceptions import HTTPError
 
 # Local
+from webapp.api.exceptions import ApiConnectionError, ApiTimeoutError
 from webapp.helpers import api_publisher_session, launchpad
 from webapp.api.github import GitHub, InvalidYAML
 from webapp.decorators import login_required
@@ -44,6 +46,7 @@ def extract_github_repository(git_repository_url):
 
 
 BUILDS_PER_PAGE = 15
+BUILD_LOG_REQUEST_TIMEOUT = (30, 60)
 dashboard = Dashboard(api_publisher_session)
 
 
@@ -194,16 +197,37 @@ def get_snap_build_logs(snap_name, build_id):
             404,
         )
 
-    response = api_publisher_session.get(
-        lp_build["build_log_url"],
-        headers={"Accept": "text/plain"},
-        stream=True,
-        timeout=(5, 30),
-    )
+    log_url = lp_build["build_log_url"]
+    response = None
+
     try:
+        response = api_publisher_session.get(
+            log_url,
+            headers={"Accept": "text/plain"},
+            stream=True,
+            timeout=BUILD_LOG_REQUEST_TIMEOUT,
+            allow_redirects=False,
+        )
         response.raise_for_status()
-    except HTTPError:
-        response.close()
+
+        if response.is_redirect:
+            redirect_url = response.headers.get("Location")
+            response.close()
+
+            if not redirect_url:
+                raise HTTPError(response=response)
+
+            response = api_publisher_session.get(
+                urljoin(log_url, redirect_url),
+                headers={"Accept": "text/plain"},
+                stream=True,
+                timeout=BUILD_LOG_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+    except (ApiConnectionError, ApiTimeoutError, HTTPError):
+        if response:
+            response.close()
+
         return (
             flask.jsonify(
                 {


### PR DESCRIPTION
## Done

In production the endpoint that is supposed to return a single build log is returning a `502`. Direct calls to launchpad are resolving so we can rule that out as a cause. With the help of Copilot, a possible cause for this is that the logs endpoint is taking too long proxying the LP redirect so the production gateway is timing out.

## How to QA

As this is a production only issue this isn't possible to QA in demos or locally, but it's a good idea to run this branch locally and verify that a single build page, e.g. `/<snap_name>/builds/<build_id>` is still working as it should and showing logs.

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

n/a

## Screenshots

n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
