### PR TITLE
fix: handle html in markdown explicitly

### DIFF
--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -242,9 +242,7 @@ class TestMarkdownParser(unittest.TestCase):
 
     def test_markdown_xml_escape(self):
         markdown = '& < > "'
-        expected = (
-            "<p>&amp; &lt; &gt; &quot;</p>\n"
-        )
+        expected = "<p>&amp; &lt; &gt; &quot;</p>\n"
         self.assertEqual(parse_markdown_description(markdown), expected)
 
     def test_markdown_html_is_escaped(self):

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -239,3 +239,17 @@ class TestMarkdownParser(unittest.TestCase):
             "link.png</a>)</p>\n"
         )
         self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_markdown_xml_escape(self):
+        markdown = '& < > "'
+        expected = (
+            "<p>&amp; &lt; &gt; &quot;</p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
+    def test_markdown_html_is_escaped(self):
+        markdown = '<script>alert("hi!")</script>'
+        expected = (
+            "<p>&lt;script&gt;alert(&quot;hi!&quot;)&lt;/script&gt;</p>\n"
+        )
+        self.assertEqual(parse_markdown_description(markdown), expected)

--- a/tests/tests_markdown_parser.py
+++ b/tests/tests_markdown_parser.py
@@ -245,6 +245,11 @@ class TestMarkdownParser(unittest.TestCase):
         expected = "<p>&amp; &lt; &gt; &quot;</p>\n"
         self.assertEqual(parse_markdown_description(markdown), expected)
 
+    def test_markdown_xml_doesnt_escape_twice(self):
+        markdown = "&amp; &lt; &gt; &quot;"
+        expected = "<p>&amp; &lt; &gt; &quot;</p>\n"
+        self.assertEqual(parse_markdown_description(markdown), expected)
+
     def test_markdown_html_is_escaped(self):
         markdown = '<script>alert("hi!")</script>'
         expected = (

--- a/webapp/markdown.py
+++ b/webapp/markdown.py
@@ -81,6 +81,7 @@ class SnapcraftInlineParser(InlineParser):
         "emphasis",
         "codespan",
         "linebreak",
+        "inline_html",
         # Keep rule enabled for mistune precedence compatibility;
         # parse_link below turns markdown [text](url) syntax into literal text.
         "link",


### PR DESCRIPTION
## Done
- fix an issue introduced by recent `mistune` dependency update where XML-like tags (`<something>`) sometime causes a crash during parsing
- add tests to guard against this issue

## How to QA
- visit https://snapcraft-io-5828.demos.haus/edisile-pyfiglet
- page should render correctly
- there should be a properly escaped `<h3>` in the description
- visit https://snapcraft-io-5828.demos.haus/lxd
- look for `snap set lxd [<key>=<value>...]`

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [x] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [x] Input: explicitly defend against attempted HTML injections in markdown descriptions
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
