### PR TITLE
fix: show all of a publisher's snaps

### DIFF
--- a/webapp/store/views.py
+++ b/webapp/store/views.py
@@ -336,26 +336,27 @@ def store_blueprint(store_query=None):
         snaps_count = 0
         publisher_details = {"display-name": publisher, "username": publisher}
 
-        snaps_results = device_gateway.find(
-            publisher=publisher,
-            fields=[
-                "title",
-                "summary",
-                "media",
-                "publisher",
-            ],
-        )["results"]
+        publisher_snaps = (
+            device_gateway.get_publisher_items(publisher)
+            .get("_embedded", {})
+            .get("clickindex:package", [])
+        )
 
-        for snap in snaps_results:
-            item = snap["snap"]
-            item["package_name"] = snap["name"]
-            item["icon_url"] = helpers.get_icon(item["media"])
-            snaps.append(item)
+        for snap in publisher_snaps:
+            snap["icon_url"] = helpers.get_icon(snap["media"])
+            snaps.append(snap)
+        snaps.sort(key=lambda s: s["title"].lower())
 
         snaps_count = len(snaps)
 
         if snaps_count > 0:
-            publisher_details = snaps[0]["publisher"]
+            snap = snaps[0]
+            publisher_details = {
+                "display-name": snap["developer_name"],
+                "id": snap["developer_id"],
+                "username": snap["developer_id"],
+                "validation": snap["developer_validation"],
+            }
 
         context = {
             "snaps": snaps,


### PR DESCRIPTION
## Done
refactored logic for community publisher page to display all snaps
- replaced `device_gateway.find` call with `device_gateway.get_publisher_items`
- sorted snaps by title

## How to QA
- go to https://snapcraft-io-5830.demos.haus/publisher/canonical
- there should be more than 100 snaps

## Testing

- [ ] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [ ] This PR has no security considerations (explain why):

## Issue / Card

Fixes #5366

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
