### PR TITLE
feat: Add endpoint for user brand permissions

### DIFF
--- a/tests/endpoints/tests_macaroon_info.py
+++ b/tests/endpoints/tests_macaroon_info.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestMacaroonInfo(TestEndpoints):
+    @patch("canonicalwebteam.store_api.publishergw.PublisherGW.macaroon_info")
+    def test_get_macaroon_info(self, mock_macaroon_info):
+        mock_macaroon_info.return_value = {
+            "account-id": "test-account-id",
+            "permissions": ["package_access"],
+        }
+
+        response = self.client.get("/api/whoami")
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(
+            data["data"],
+            {
+                "account-id": "test-account-id",
+                "permissions": ["package_access"],
+            },
+        )
+        mock_macaroon_info.assert_called_once_with("test_macaroon")

--- a/webapp/endpoints/views.py
+++ b/webapp/endpoints/views.py
@@ -35,6 +35,19 @@ def get_stores():
     return jsonify(res)
 
 
+@endpoints.route("/api/whoami")
+@login_required
+@exchange_required
+def get_macaroon_info():
+    macaroon_info = publisher_gateway.macaroon_info(
+        flask.session["developer_token"]
+    )
+
+    res = {"success": True, "data": macaroon_info}
+
+    return jsonify(res)
+
+
 @endpoints.route("/api/store/<store_id>")
 @login_required
 @exchange_required


### PR DESCRIPTION
## Done

Adds an endpoint which includes a users permissions in relation to the brand stores they have access to.

## How to QA
- Go to https://snapcraft-io-5832.demos.haus/api/whoami
- Check that there is data with your brand store permissions
- Also check that you are authenticated

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [x] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38237

## Screenshots

n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
