### PR TITLE
WD-38167 snap.yaml permissions API

### DIFF
--- a/static/js/publisher/hooks/__tests__/useUserPrivileges.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useUserPrivileges.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from "react-query";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import useUserPrivileges from "../useUserPrivileges";
+
+import type { ReactNode } from "react";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const createWrapper = () => {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const userPrivilegesResponse = {
+  "account-id": "test-account-id",
+  permissions: ["package_access"],
+};
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("useUserPrivileges", () => {
+  test("returns user privileges if request successful", async () => {
+    server.use(
+      http.get("/api/whoami", () => {
+        return HttpResponse.json({
+          data: userPrivilegesResponse,
+          success: true,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserPrivileges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(userPrivilegesResponse);
+    });
+  });
+
+  test("returns no data if the request fails", async () => {
+    server.use(
+      http.get("/api/whoami", () => {
+        return HttpResponse.json({
+          data: {},
+          message: "Unable to fetch user information",
+          success: false,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserPrivileges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  test("returns no data if the request is an error", async () => {
+    server.use(
+      http.get("/api/whoami", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserPrivileges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/static/js/publisher/hooks/index.ts
+++ b/static/js/publisher/hooks/index.ts
@@ -19,6 +19,7 @@ import useRemodels from "./useRemodels";
 import useSerialLogs from "./useSerialLogs";
 import useEndpointAvailability from "./useEndpointAvailability";
 import useSnapReleaseStatus from "./useSnapReleaseStatus";
+import useUserPrivileges from "./useUserPrivileges";
 
 export {
   useValidationSets,
@@ -42,4 +43,5 @@ export {
   useSerialLogs,
   useEndpointAvailability,
   useSnapReleaseStatus,
+  useUserPrivileges,
 };

--- a/static/js/publisher/hooks/useSideNavigationData.ts
+++ b/static/js/publisher/hooks/useSideNavigationData.ts
@@ -8,11 +8,13 @@ import {
   useBrandStores,
   usePublisher,
   useValidationSets,
+  useUserPrivileges,
 } from "./";
 import { brandIdState, brandStoresState } from "../state/brandStoreState";
 import { publisherState } from "../state/publisherState";
 import { validationSetsState } from "../state/validationSetsState";
 import { accountKeysState } from "../state/accountKeysState";
+import { userPrivilegesState } from "../state/userPrivilegesState";
 
 /**
  * Load all the data that is needed for side navigation, more specifically:
@@ -30,12 +32,14 @@ function useSideNavigationData() {
   const { data: brandStoresData } = useBrandStores();
   const { data: brandData } = useBrand(storeId);
   const { data: accountKeysData } = useAccountKeys();
+  const { data: userPrivilegesData } = useUserPrivileges();
 
   const setBrandStores = useSetAtom(brandStoresState);
   const setPublisher = useSetAtom(publisherState);
   const setBrandId = useSetAtom(brandIdState);
   const setValidationSets = useSetAtom(validationSetsState);
   const setAccountKeys = useSetAtom(accountKeysState);
+  const setUserPrivileges = useSetAtom(userPrivilegesState);
 
   useEffect(() => {
     setBrandId(brandData?.["account-id"] || brandIdState.init);
@@ -56,6 +60,10 @@ function useSideNavigationData() {
   useEffect(() => {
     setAccountKeys(accountKeysData || accountKeysState.init);
   }, [accountKeysData]);
+
+  useEffect(() => {
+    setUserPrivileges(userPrivilegesData || userPrivilegesState.init);
+  }, [userPrivilegesData]);
 }
 
 export default useSideNavigationData;

--- a/static/js/publisher/hooks/useUserPrivileges.ts
+++ b/static/js/publisher/hooks/useUserPrivileges.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "react-query";
+
+import type { ApiResponse, UserPrivileges } from "../types/shared";
+
+function useUserPrivileges() {
+  return useQuery({
+    queryKey: ["userPrivileges"],
+    queryFn: async () => {
+      const response = await fetch("/api/whoami");
+
+      if (!response.ok) {
+        throw new Error("Unable to fetch user information");
+      }
+
+      const responseData: ApiResponse<UserPrivileges> = await response.json();
+
+      if (!responseData.success || responseData.data == null) {
+        throw new Error(
+          responseData.message ?? "Unable to fetch user information",
+        );
+      }
+
+      return responseData.data;
+    },
+  });
+}
+
+export default useUserPrivileges;

--- a/static/js/publisher/state/userPrivilegesState.ts
+++ b/static/js/publisher/state/userPrivilegesState.ts
@@ -1,0 +1,7 @@
+import { atom } from "jotai";
+
+import type { UserPrivileges } from "../types/shared";
+
+const userPrivilegesState = atom(null as UserPrivileges);
+
+export { userPrivilegesState };

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -146,6 +146,17 @@ export type Publisher = {
   } | null;
 } | null;
 
+export type UserPrivileges = {
+  account: {
+    "display-name": string;
+    email: string;
+    id: string;
+    username: string;
+  };
+  "brand-permissions": Record<string, string[]>;
+  permissions: string[];
+} | null;
+
 export type UsePoliciesResponse = {
   isLoading: boolean;
   isError: boolean;

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -1,3 +1,4 @@
+from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiResponseErrorList
 import flask
 from flask import make_response
 from flask.json import jsonify
@@ -292,35 +293,56 @@ def permissions(snap_name):
     If a query parameter is missing, this endpoint returns HTTP 400.
     If lookup or parsing fails, the response contains an ``errors`` list.
     """
-    channel = flask.request.args.get("channel")
-    if channel is None:
-        return make_response(
-            {"success": False, "errors": ['"channel" parameter is required']},
-            400,
-        )
+    missing_params = [
+        p for p in ("channel", "architecture") if not flask.request.args.get(p)
+    ]
 
-    architecture = flask.request.args.get("architecture")
-    if architecture is None:
+    if missing_params:
         return make_response(
             {
                 "success": False,
-                "errors": ['"architecture" parameter is required'],
+                "errors": [
+                    f'"{param}" parameter is required'
+                    for param in missing_params
+                ],
             },
             400,
         )
 
-    details = None
+    channel = flask.request.args.get("channel")
+    architecture = flask.request.args.get("architecture")
 
     try:
         details = device_gateway.get_item_details(
             snap_name, api_version=2, fields=["snap-yaml"]
         )
+    except StoreApiResourceNotFound:
+        return make_response(
+            {
+                "success": False,
+                "errors": [f'"{snap_name}" does not exist'],
+            },
+            404,
+        )
+    except StoreApiResponseErrorList as e:
+        return make_response(
+            {
+                "success": False,
+                "errors": [
+                    f"{error.get('message', 'An error occurred')}"
+                    for error in e.errors
+                ],
+            },
+            e.status_code,
+        )
 
-        def predicate(_channel):
-            name: str = _channel.get("channel", {}).get("name", "")
-            arch: str = _channel.get("channel", {}).get("architecture", "")
-            return name == channel and arch == architecture
+    def predicate(_channel):
+        channel_entry = _channel.get("channel", {})
+        name: str = channel_entry.get("name", "")
+        arch: str = channel_entry.get("architecture", "")
+        return name == channel and arch == architecture
 
+    try:
         channel_map = details.get("channel-map", [])
         match = next((c for c in channel_map if predicate(c)), None)
 
@@ -331,7 +353,6 @@ def permissions(snap_name):
             )
 
         raw_snap_yaml = match.get("snap-yaml")
-        print(raw_snap_yaml)
         snap_yaml = get_yaml_loader().load(raw_snap_yaml)
 
         res = {
@@ -354,12 +375,9 @@ def permissions(snap_name):
         }
     except Exception as e:
         res = {"success": True if details else False, "errors": [str(e)]}
-        pass
 
     response = make_response(res, 200)
-    response.cache_control.max_age = (
-        0 if res.get("status") == "error" else 3600
-    )
+    response.cache_control.max_age = 0 if not res.get("success") else 3600
     return response
 
 

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -14,6 +14,7 @@ from webapp.api.github import repository_is_public
 from webapp.api.launchpad_provenance import LaunchpadProvenance
 from webapp.endpoints.utils import get_auditable_map_cache_key
 from cache.cache_utility import redis_cache
+from webapp.helpers import get_yaml_loader
 
 from canonicalwebteam.store_api.devicegw import DeviceGW
 from canonicalwebteam.store_api.dashboard import Dashboard
@@ -273,6 +274,77 @@ def auditable_revisions(snap_name):
 
     response = make_response(res, 200)
     response.cache_control.max_age = 0 if res.get("error") else 3600
+    return response
+
+
+@snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
+def permissions(snap_name):
+    channel = flask.request.args.get("channel")
+    if channel is None:
+        return make_response(
+            {"success": False, "errors": ['"channel" parameter is required']},
+            400,
+        )
+
+    architecture = flask.request.args.get("architecture")
+    if architecture is None:
+        return make_response(
+            {
+                "success": False,
+                "errors": ['"architecture" parameter is required'],
+            },
+            400,
+        )
+
+    details = None
+
+    try:
+        details = device_gateway.get_item_details(
+            snap_name, api_version=2, fields=["snap-yaml"]
+        )
+
+        def predicate(_channel):
+            name: str = _channel.get("channel", {}).get("name", "")
+            arch: str = _channel.get("channel", {}).get("architecture", "")
+            return name == channel and arch == architecture
+
+        channel_map = details.get("channel-map", [])
+        match = next(c for c in channel_map if predicate(c))
+
+        if match is None:
+            raise Exception(
+                f'channel "{channel}" does not exist for architecture "{architecture}"'
+            )
+
+        raw_snap_yaml = match.get("snap-yaml")
+        snap_yaml = get_yaml_loader().load(raw_snap_yaml)
+
+        res = {
+            "success": True,
+            "data": {
+                "confinement": snap_yaml["confinement"],
+                "interfaces": [
+                    {
+                        "name": name,
+                        "interface": plug["interface"],
+                        # "description": "TODO",
+                        # "raw_yaml": "TODO",
+                        # "categories": ["TODO"],
+                        # "auto_connect": False,
+                        # "details": ["TODO"]
+                    }
+                    for name, plug in snap_yaml["plugs"].items()
+                ],
+            },
+        }
+    except Exception as e:
+        res = {"success": True if details else False, "errors": [str(e)]}
+        pass
+
+    response = make_response(res, 200)
+    response.cache_control.max_age = (
+        0 if res.get("status") == "error" else 3600
+    )
     return response
 
 

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -322,12 +322,12 @@ def permissions(snap_name):
             return name == channel and arch == architecture
 
         channel_map = details.get("channel-map", [])
-        match = next(c for c in channel_map if predicate(c))
+        match = next((c for c in channel_map if predicate(c)), None)
 
         if match is None:
             raise Exception(
                 f'channel "{channel}" does not exist for architecture '
-                '"{architecture}"'
+                f'"{architecture}"'
             )
 
         raw_snap_yaml = match.get("snap-yaml")

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -285,8 +285,9 @@ def permissions(snap_name):
     It gets the channel map, finds the matching channel and architecture, and
     parses the ``snap-yaml`` field.
 
-    The response contains ``confinement`` from ``snap.yaml``. It also contains
-    ``interfaces`` as ``[{"name": <plug name>, "interface": <interface name>}]``.
+    The response contains:
+    - ``confinement`` from ``snap-yaml``
+    - ``interfaces`` as ``[{"name": <plug name>, "interface": <interface>}]``
 
     If a query parameter is missing, this endpoint returns HTTP 400.
     If lookup or parsing fails, the response contains an ``errors`` list.
@@ -325,7 +326,8 @@ def permissions(snap_name):
 
         if match is None:
             raise Exception(
-                f'channel "{channel}" does not exist for architecture "{architecture}"'
+                f'channel "{channel}" does not exist for architecture '
+                '"{architecture}"'
             )
 
         raw_snap_yaml = match.get("snap-yaml")

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -1,4 +1,7 @@
-from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiResponseErrorList
+from canonicalwebteam.exceptions import (
+    StoreApiResourceNotFound,
+    StoreApiResponseErrorList,
+)
 import flask
 from flask import make_response
 from flask.json import jsonify

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -279,6 +279,18 @@ def auditable_revisions(snap_name):
 
 @snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
 def permissions(snap_name):
+    """Return the interfaces that a snap requests for one channel build.
+
+    This endpoint needs the ``channel`` and ``architecture`` query parameters.
+    It gets the channel map, finds the matching channel and architecture, and
+    parses the ``snap-yaml`` field.
+
+    The response contains ``confinement`` from ``snap.yaml``. It also contains
+    ``interfaces`` as ``[{"name": <plug name>, "interface": <interface name>}]``.
+
+    If a query parameter is missing, this endpoint returns HTTP 400.
+    If lookup or parsing fails, the response contains an ``errors`` list.
+    """
     channel = flask.request.args.get("channel")
     if channel is None:
         return make_response(

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -331,6 +331,7 @@ def permissions(snap_name):
             )
 
         raw_snap_yaml = match.get("snap-yaml")
+        print(raw_snap_yaml)
         snap_yaml = get_yaml_loader().load(raw_snap_yaml)
 
         res = {
@@ -340,14 +341,14 @@ def permissions(snap_name):
                 "interfaces": [
                     {
                         "name": name,
-                        "interface": plug["interface"],
+                        "interface": plug.get("interface", name),
                         # "description": "TODO",
                         # "raw_yaml": "TODO",
                         # "categories": ["TODO"],
                         # "auto_connect": False,
                         # "details": ["TODO"]
                     }
-                    for name, plug in snap_yaml["plugs"].items()
+                    for name, plug in snap_yaml.get("plugs", {}).items()
                 ],
             },
         }

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -283,7 +283,8 @@ def auditable_revisions(snap_name):
 
 @snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
 def permissions(snap_name):
-    """Return the interfaces that a snap requests for one channel build.
+    """Return the permissions that a snap requests for one specific channel
+    and architecture.
 
     This endpoint needs the ``channel`` and ``architecture`` query parameters.
     It gets the channel map, finds the matching channel and architecture, and


### PR DESCRIPTION
This is a stacked PR, it should only be merged with the rest of the stack

## Done 
- created new API endpoint for extracting permissions based on snap.yaml manifest

## How to QA
- visit https://snapcraft-io-5833.demos.haus/api/lxd/permissions?channel=6%2Fstable&architecture=amd64
- the response data shows the snap is under strict containment and has a bunch of plugs with `content` interface
- check https://snapcraft-io-5833.demos.haus/api/workshop/permissions?channel=stable&architecture=amd64
- this time containment is classic and there are no interfaces
- remove the channel/architecture parameter from the URL and you should get an error response with HTTP code 400
- https://snapcraft-io-5833.demos.haus/api/snap-that-doesnt-exist/permissions?channel=stable&architecture=amd64
- should return an error message and the response should have a 404 code

## Testing

- [x] This PR has tests (in the other PR in this stack)
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): this API only exposes public data

## Issue / Card

Fixes WD-38167, WD-38168

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>