### PR TITLE
feat: tests for new permissions API

### DIFF
--- a/tests/endpoints/tests_snaps_permissions.py
+++ b/tests/endpoints/tests_snaps_permissions.py
@@ -22,7 +22,9 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(data["success"], False)
-        self.assertEqual(data["errors"], ['"architecture" parameter is required'])
+        self.assertEqual(
+            data["errors"], ['"architecture" parameter is required']
+        )
 
     @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
     def test_returns_confinement_and_interfaces(self, mock_get_item_details):

--- a/tests/endpoints/tests_snaps_permissions.py
+++ b/tests/endpoints/tests_snaps_permissions.py
@@ -1,0 +1,108 @@
+from unittest.mock import patch
+
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestSnapPermissionsEndpoint(TestEndpoints):
+    def _url(self, query=""):
+        base_url = "/api/mumble/permissions"
+        return f"{base_url}?{query}" if query else base_url
+
+    def test_missing_channel_parameter_returns_400(self):
+        response = self.client.get(self._url("architecture=amd64"))
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(data["success"], False)
+        self.assertEqual(data["errors"], ['"channel" parameter is required'])
+
+    def test_missing_architecture_parameter_returns_400(self):
+        response = self.client.get(self._url("channel=latest/stable"))
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(data["success"], False)
+        self.assertEqual(data["errors"], ['"architecture" parameter is required'])
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_confinement_and_interfaces(self, mock_get_item_details):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": (
+                        "confinement: strict\n"
+                        "plugs:\n"
+                        "  network:\n"
+                        "    interface: network\n"
+                        "  home:\n"
+                        "    interface: home\n"
+                    ),
+                }
+            ]
+        }
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"]["confinement"], "strict")
+        self.assertEqual(
+            data["data"]["interfaces"],
+            [
+                {"name": "network", "interface": "network"},
+                {"name": "home", "interface": "home"},
+            ],
+        )
+
+        mock_get_item_details.assert_called_once_with(
+            "mumble", api_version=2, fields=["snap-yaml"]
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_errors_when_snap_yaml_parsing_fails(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": "plugs: [",
+                }
+            ]
+        }
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertIn("errors", data)
+        self.assertEqual(len(data["errors"]), 1)
+        self.assertIsInstance(data["errors"][0], str)
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_unsuccessful_response_when_details_fetch_fails(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.side_effect = Exception("store API error")
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["errors"], ["store API error"])

--- a/tests/endpoints/tests_snaps_permissions.py
+++ b/tests/endpoints/tests_snaps_permissions.py
@@ -1,5 +1,10 @@
 from unittest.mock import patch
 
+from canonicalwebteam.exceptions import (
+    StoreApiResourceNotFound,
+    StoreApiResponseErrorList,
+)
+
 from tests.endpoints.endpoint_testing import TestEndpoints
 
 
@@ -13,7 +18,7 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
         data = response.get_json()
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(data["success"], False)
+        self.assertFalse(data["success"])
         self.assertEqual(data["errors"], ['"channel" parameter is required'])
 
     def test_missing_architecture_parameter_returns_400(self):
@@ -21,9 +26,23 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
         data = response.get_json()
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(data["success"], False)
+        self.assertFalse(data["success"])
         self.assertEqual(
             data["errors"], ['"architecture" parameter is required']
+        )
+
+    def test_missing_both_parameters_returns_400(self):
+        response = self.client.get(self._url())
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(
+            data["errors"],
+            [
+                '"channel" parameter is required',
+                '"architecture" parameter is required',
+            ],
         )
 
     @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
@@ -62,9 +81,88 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
                 {"name": "home", "interface": "home"},
             ],
         )
-
         mock_get_item_details.assert_called_once_with(
             "mumble", api_version=2, fields=["snap-yaml"]
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_defaults_interface_name_when_missing(self, mock_get_item_details):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": (
+                        "confinement: strict\n"
+                        "plugs:\n"
+                        "  desktop: {}\n"
+                    ),
+                }
+            ]
+        }
+
+        data = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        ).get_json()
+
+        self.assertTrue(data["success"])
+        self.assertEqual(
+            data["data"]["interfaces"],
+            [{"name": "desktop", "interface": "desktop"}],
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_empty_interfaces_when_no_plugs(self, mock_get_item_details):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": "confinement: strict\n",
+                }
+            ]
+        }
+
+        data = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        ).get_json()
+
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"]["interfaces"], [])
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_error_when_channel_or_arch_does_not_match(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "arm64",
+                    },
+                    "snap-yaml": "confinement: strict\n",
+                }
+            ]
+        }
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(
+            data["errors"],
+            [
+                'channel "latest/stable" does not exist for architecture '
+                '"amd64"'
+            ],
         )
 
     @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
@@ -95,16 +193,35 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
         self.assertIsInstance(data["errors"][0], str)
 
     @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
-    def test_returns_unsuccessful_response_when_details_fetch_fails(
-        self, mock_get_item_details
-    ):
-        mock_get_item_details.side_effect = Exception("store API error")
+    def test_returns_404_when_snap_does_not_exist(self, mock_get_item_details):
+        mock_get_item_details.side_effect = StoreApiResourceNotFound()
 
         response = self.client.get(
             self._url("channel=latest/stable&architecture=amd64")
         )
         data = response.get_json()
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 404)
         self.assertFalse(data["success"])
-        self.assertEqual(data["errors"], ["store API error"])
+        self.assertEqual(data["errors"], ['"mumble" does not exist'])
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_store_api_errors_with_upstream_status(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.side_effect = StoreApiResponseErrorList(
+            "upstream error",
+            503,
+            [{"message": "upstream unavailable"}, {"code": "oops"}],
+        )
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 503)
+        self.assertFalse(data["success"])
+        self.assertEqual(
+            data["errors"], ["upstream unavailable", "An error occurred"]
+        )

--- a/tests/endpoints/tests_snaps_permissions.py
+++ b/tests/endpoints/tests_snaps_permissions.py
@@ -95,9 +95,7 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
                         "architecture": "amd64",
                     },
                     "snap-yaml": (
-                        "confinement: strict\n"
-                        "plugs:\n"
-                        "  desktop: {}\n"
+                        "confinement: strict\n" "plugs:\n" "  desktop: {}\n"
                     ),
                 }
             ]
@@ -114,7 +112,9 @@ class TestSnapPermissionsEndpoint(TestEndpoints):
         )
 
     @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
-    def test_returns_empty_interfaces_when_no_plugs(self, mock_get_item_details):
+    def test_returns_empty_interfaces_when_no_plugs(
+        self, mock_get_item_details
+    ):
         mock_get_item_details.return_value = {
             "channel-map": [
                 {


### PR DESCRIPTION
This is a stacked PR, it should only be merged with the rest of the stack

## Done
- added tests for new permissions API endpoint

## How to QA
- check that the `test-python` action passes

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): just tests

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>