### PR TITLE
Add user privileges atom

### DIFF
--- a/static/js/publisher/hooks/__tests__/useUserPrivileges.test.tsx
+++ b/static/js/publisher/hooks/__tests__/useUserPrivileges.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from "react-query";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import useUserPrivileges from "../useUserPrivileges";
+
+import type { ReactNode } from "react";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const createWrapper = () => {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const userPrivilegesResponse = {
+  "account-id": "test-account-id",
+  permissions: ["package_access"],
+};
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("useUserPrivileges", () => {
+  test("returns user privileges if request successful", async () => {
+    server.use(
+      http.get("/api/whoami", () => {
+        return HttpResponse.json({
+          data: userPrivilegesResponse,
+          success: true,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserPrivileges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(userPrivilegesResponse);
+    });
+  });
+
+  test("returns no data if the request fails", async () => {
+    server.use(
+      http.get("/api/whoami", () => {
+        return HttpResponse.json({
+          data: {},
+          message: "Unable to fetch user information",
+          success: false,
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserPrivileges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+
+  test("returns no data if the request is an error", async () => {
+    server.use(
+      http.get("/api/whoami", () => {
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() => useUserPrivileges(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/static/js/publisher/hooks/index.ts
+++ b/static/js/publisher/hooks/index.ts
@@ -19,6 +19,7 @@ import useRemodels from "./useRemodels";
 import useSerialLogs from "./useSerialLogs";
 import useEndpointAvailability from "./useEndpointAvailability";
 import useSnapReleaseStatus from "./useSnapReleaseStatus";
+import useUserPrivileges from "./useUserPrivileges";
 
 export {
   useValidationSets,
@@ -42,4 +43,5 @@ export {
   useSerialLogs,
   useEndpointAvailability,
   useSnapReleaseStatus,
+  useUserPrivileges,
 };

--- a/static/js/publisher/hooks/useSideNavigationData.ts
+++ b/static/js/publisher/hooks/useSideNavigationData.ts
@@ -8,11 +8,13 @@ import {
   useBrandStores,
   usePublisher,
   useValidationSets,
+  useUserPrivileges,
 } from "./";
 import { brandIdState, brandStoresState } from "../state/brandStoreState";
 import { publisherState } from "../state/publisherState";
 import { validationSetsState } from "../state/validationSetsState";
 import { accountKeysState } from "../state/accountKeysState";
+import { userPrivilegesState } from "../state/userPrivilegesState";
 
 /**
  * Load all the data that is needed for side navigation, more specifically:
@@ -30,12 +32,14 @@ function useSideNavigationData() {
   const { data: brandStoresData } = useBrandStores();
   const { data: brandData } = useBrand(storeId);
   const { data: accountKeysData } = useAccountKeys();
+  const { data: userPrivilegesData } = useUserPrivileges();
 
   const setBrandStores = useSetAtom(brandStoresState);
   const setPublisher = useSetAtom(publisherState);
   const setBrandId = useSetAtom(brandIdState);
   const setValidationSets = useSetAtom(validationSetsState);
   const setAccountKeys = useSetAtom(accountKeysState);
+  const setUserPrivileges = useSetAtom(userPrivilegesState);
 
   useEffect(() => {
     setBrandId(brandData?.["account-id"] || brandIdState.init);
@@ -56,6 +60,10 @@ function useSideNavigationData() {
   useEffect(() => {
     setAccountKeys(accountKeysData || accountKeysState.init);
   }, [accountKeysData]);
+
+  useEffect(() => {
+    setUserPrivileges(userPrivilegesData || userPrivilegesState.init);
+  }, [userPrivilegesData]);
 }
 
 export default useSideNavigationData;

--- a/static/js/publisher/hooks/useUserPrivileges.ts
+++ b/static/js/publisher/hooks/useUserPrivileges.ts
@@ -14,8 +14,10 @@ function useUserPrivileges() {
 
       const responseData: ApiResponse<UserPrivileges> = await response.json();
 
-      if (!responseData.success || !responseData.data) {
-        throw new Error(responseData.message);
+      if (!responseData.success || responseData.data == null) {
+        throw new Error(
+          responseData.message ?? "Unable to fetch user information",
+        );
       }
 
       return responseData.data;

--- a/static/js/publisher/hooks/useUserPrivileges.ts
+++ b/static/js/publisher/hooks/useUserPrivileges.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "react-query";
+
+import type { ApiResponse, UserPrivileges } from "../types/shared";
+
+function useUserPrivileges() {
+  return useQuery({
+    queryKey: ["userPrivileges"],
+    queryFn: async () => {
+      const response = await fetch("/api/whoami");
+
+      if (!response.ok) {
+        throw new Error("Unable to fetch user information");
+      }
+
+      const responseData: ApiResponse<UserPrivileges> = await response.json();
+
+      if (!responseData.success || !responseData.data) {
+        throw new Error(responseData.message);
+      }
+
+      return responseData.data;
+    },
+  });
+}
+
+export default useUserPrivileges;

--- a/static/js/publisher/state/userPrivilegesState.ts
+++ b/static/js/publisher/state/userPrivilegesState.ts
@@ -1,0 +1,7 @@
+import { atom } from "jotai";
+
+import type { UserPrivileges } from "../types/shared";
+
+const userPrivilegesState = atom(null as UserPrivileges);
+
+export { userPrivilegesState };

--- a/static/js/publisher/types/shared.ts
+++ b/static/js/publisher/types/shared.ts
@@ -146,6 +146,17 @@ export type Publisher = {
   } | null;
 } | null;
 
+export type UserPrivileges = {
+  account: {
+    "display-name": string;
+    email: string;
+    id: string;
+    username: string;
+  };
+  "brand-permissions": Record<string, string[]>;
+  permissions: string[];
+} | null;
+
 export type UsePoliciesResponse = {
   isLoading: boolean;
   isError: boolean;


### PR DESCRIPTION
## Done

- Added a `useUserPrivileges` hook that fetches the existing `/api/whoami` data with a privileges-oriented query key.
- Added `userPrivilegesState` so side navigation data can store the current user's privileges in Jotai.
- Added the `UserPrivileges` shared type and wired the hook through the publisher hooks barrel and side-navigation data loader.
- Added Vitest coverage for successful, failed, and errored privilege requests.

## How to QA

All checks should pass

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): This is a frontend data hook/state naming and wiring change for an existing authenticated endpoint. It does not change access control, inputs, or exposed data.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38365

## Screenshots

N/A

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
