### PR TITLE
WD-38167 snap.yaml permissions API

### DIFF
--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -1,3 +1,4 @@
+from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiResponseErrorList
 import flask
 from flask import make_response
 from flask.json import jsonify
@@ -292,35 +293,56 @@ def permissions(snap_name):
     If a query parameter is missing, this endpoint returns HTTP 400.
     If lookup or parsing fails, the response contains an ``errors`` list.
     """
-    channel = flask.request.args.get("channel")
-    if channel is None:
-        return make_response(
-            {"success": False, "errors": ['"channel" parameter is required']},
-            400,
-        )
+    missing_params = [
+        p for p in ("channel", "architecture") if not flask.request.args.get(p)
+    ]
 
-    architecture = flask.request.args.get("architecture")
-    if architecture is None:
+    if missing_params:
         return make_response(
             {
                 "success": False,
-                "errors": ['"architecture" parameter is required'],
+                "errors": [
+                    f'"{param}" parameter is required'
+                    for param in missing_params
+                ],
             },
             400,
         )
 
-    details = None
+    channel = flask.request.args.get("channel")
+    architecture = flask.request.args.get("architecture")
 
     try:
         details = device_gateway.get_item_details(
             snap_name, api_version=2, fields=["snap-yaml"]
         )
+    except StoreApiResourceNotFound:
+        return make_response(
+            {
+                "success": False,
+                "errors": [f'"{snap_name}" does not exist'],
+            },
+            404,
+        )
+    except StoreApiResponseErrorList as e:
+        return make_response(
+            {
+                "success": False,
+                "errors": [
+                    f"{error.get('message', 'An error occurred')}"
+                    for error in e.errors
+                ],
+            },
+            e.status_code,
+        )
 
-        def predicate(_channel):
-            name: str = _channel.get("channel", {}).get("name", "")
-            arch: str = _channel.get("channel", {}).get("architecture", "")
-            return name == channel and arch == architecture
+    def predicate(_channel):
+        channel_entry = _channel.get("channel", {})
+        name: str = channel_entry.get("name", "")
+        arch: str = channel_entry.get("architecture", "")
+        return name == channel and arch == architecture
 
+    try:
         channel_map = details.get("channel-map", [])
         match = next((c for c in channel_map if predicate(c)), None)
 
@@ -331,7 +353,6 @@ def permissions(snap_name):
             )
 
         raw_snap_yaml = match.get("snap-yaml")
-        print(raw_snap_yaml)
         snap_yaml = get_yaml_loader().load(raw_snap_yaml)
 
         res = {
@@ -354,12 +375,9 @@ def permissions(snap_name):
         }
     except Exception as e:
         res = {"success": True if details else False, "errors": [str(e)]}
-        pass
 
     response = make_response(res, 200)
-    response.cache_control.max_age = (
-        0 if res.get("status") == "error" else 3600
-    )
+    response.cache_control.max_age = 0 if not res.get("success") else 3600
     return response
 
 

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -14,6 +14,7 @@ from webapp.api.github import repository_is_public
 from webapp.api.launchpad_provenance import LaunchpadProvenance
 from webapp.endpoints.utils import get_auditable_map_cache_key
 from cache.cache_utility import redis_cache
+from webapp.helpers import get_yaml_loader
 
 from canonicalwebteam.store_api.devicegw import DeviceGW
 from canonicalwebteam.store_api.dashboard import Dashboard
@@ -273,6 +274,77 @@ def auditable_revisions(snap_name):
 
     response = make_response(res, 200)
     response.cache_control.max_age = 0 if res.get("error") else 3600
+    return response
+
+
+@snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
+def permissions(snap_name):
+    channel = flask.request.args.get("channel")
+    if channel is None:
+        return make_response(
+            {"success": False, "errors": ['"channel" parameter is required']},
+            400,
+        )
+
+    architecture = flask.request.args.get("architecture")
+    if architecture is None:
+        return make_response(
+            {
+                "success": False,
+                "errors": ['"architecture" parameter is required'],
+            },
+            400,
+        )
+
+    details = None
+
+    try:
+        details = device_gateway.get_item_details(
+            snap_name, api_version=2, fields=["snap-yaml"]
+        )
+
+        def predicate(_channel):
+            name: str = _channel.get("channel", {}).get("name", "")
+            arch: str = _channel.get("channel", {}).get("architecture", "")
+            return name == channel and arch == architecture
+
+        channel_map = details.get("channel-map", [])
+        match = next(c for c in channel_map if predicate(c))
+
+        if match is None:
+            raise Exception(
+                f'channel "{channel}" does not exist for architecture "{architecture}"'
+            )
+
+        raw_snap_yaml = match.get("snap-yaml")
+        snap_yaml = get_yaml_loader().load(raw_snap_yaml)
+
+        res = {
+            "success": True,
+            "data": {
+                "confinement": snap_yaml["confinement"],
+                "interfaces": [
+                    {
+                        "name": name,
+                        "interface": plug["interface"],
+                        # "description": "TODO",
+                        # "raw_yaml": "TODO",
+                        # "categories": ["TODO"],
+                        # "auto_connect": False,
+                        # "details": ["TODO"]
+                    }
+                    for name, plug in snap_yaml["plugs"].items()
+                ],
+            },
+        }
+    except Exception as e:
+        res = {"success": True if details else False, "errors": [str(e)]}
+        pass
+
+    response = make_response(res, 200)
+    response.cache_control.max_age = (
+        0 if res.get("status") == "error" else 3600
+    )
     return response
 
 

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -322,12 +322,12 @@ def permissions(snap_name):
             return name == channel and arch == architecture
 
         channel_map = details.get("channel-map", [])
-        match = next(c for c in channel_map if predicate(c))
+        match = next((c for c in channel_map if predicate(c)), None)
 
         if match is None:
             raise Exception(
                 f'channel "{channel}" does not exist for architecture '
-                '"{architecture}"'
+                f'"{architecture}"'
             )
 
         raw_snap_yaml = match.get("snap-yaml")

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -285,8 +285,9 @@ def permissions(snap_name):
     It gets the channel map, finds the matching channel and architecture, and
     parses the ``snap-yaml`` field.
 
-    The response contains ``confinement`` from ``snap.yaml``. It also contains
-    ``interfaces`` as ``[{"name": <plug name>, "interface": <interface name>}]``.
+    The response contains:
+    - ``confinement`` from ``snap-yaml``
+    - ``interfaces`` as ``[{"name": <plug name>, "interface": <interface>}]``
 
     If a query parameter is missing, this endpoint returns HTTP 400.
     If lookup or parsing fails, the response contains an ``errors`` list.
@@ -325,7 +326,8 @@ def permissions(snap_name):
 
         if match is None:
             raise Exception(
-                f'channel "{channel}" does not exist for architecture "{architecture}"'
+                f'channel "{channel}" does not exist for architecture '
+                '"{architecture}"'
             )
 
         raw_snap_yaml = match.get("snap-yaml")

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -1,4 +1,7 @@
-from canonicalwebteam.exceptions import StoreApiResourceNotFound, StoreApiResponseErrorList
+from canonicalwebteam.exceptions import (
+    StoreApiResourceNotFound,
+    StoreApiResponseErrorList,
+)
 import flask
 from flask import make_response
 from flask.json import jsonify

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -279,6 +279,18 @@ def auditable_revisions(snap_name):
 
 @snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
 def permissions(snap_name):
+    """Return the interfaces that a snap requests for one channel build.
+
+    This endpoint needs the ``channel`` and ``architecture`` query parameters.
+    It gets the channel map, finds the matching channel and architecture, and
+    parses the ``snap-yaml`` field.
+
+    The response contains ``confinement`` from ``snap.yaml``. It also contains
+    ``interfaces`` as ``[{"name": <plug name>, "interface": <interface name>}]``.
+
+    If a query parameter is missing, this endpoint returns HTTP 400.
+    If lookup or parsing fails, the response contains an ``errors`` list.
+    """
     channel = flask.request.args.get("channel")
     if channel is None:
         return make_response(

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -331,6 +331,7 @@ def permissions(snap_name):
             )
 
         raw_snap_yaml = match.get("snap-yaml")
+        print(raw_snap_yaml)
         snap_yaml = get_yaml_loader().load(raw_snap_yaml)
 
         res = {
@@ -340,14 +341,14 @@ def permissions(snap_name):
                 "interfaces": [
                     {
                         "name": name,
-                        "interface": plug["interface"],
+                        "interface": plug.get("interface", name),
                         # "description": "TODO",
                         # "raw_yaml": "TODO",
                         # "categories": ["TODO"],
                         # "auto_connect": False,
                         # "details": ["TODO"]
                     }
-                    for name, plug in snap_yaml["plugs"].items()
+                    for name, plug in snap_yaml.get("plugs", {}).items()
                 ],
             },
         }

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -283,7 +283,8 @@ def auditable_revisions(snap_name):
 
 @snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
 def permissions(snap_name):
-    """Return the interfaces that a snap requests for one channel build.
+    """Return the permissions that a snap requests for one specific channel
+    and architecture.
 
     This endpoint needs the ``channel`` and ``architecture`` query parameters.
     It gets the channel map, finds the matching channel and architecture, and


### PR DESCRIPTION
This is a stacked PR, it should only be merged with the rest of the stack

## Done 
- created new API endpoint for extracting permissions based on snap.yaml manifest

## How to QA
- visit https://snapcraft-io-5839.demos.haus/api/lxd/permissions?channel=6%2Fstable&architecture=amd64
- the response data shows the snap is under strict containment and has a bunch of plugs with `content` interface
- check https://snapcraft-io-5839.demos.haus/api/workshop/permissions?channel=stable&architecture=amd64
- this time containment is classic and there are no interfaces
- remove the channel/architecture parameter from the URL and you should get an error response with HTTP code 400
- https://snapcraft-io-5839.demos.haus/api/snap-that-doesnt-exist/permissions?channel=stable&architecture=amd64
- should return an error message and the response should have a 404 code

## Testing

- [x] This PR has tests (in the other PR in this stack)
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): this API only exposes public data

## Issue / Card

Fixes WD-38167, WD-38168

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>