### PR TITLE
feat: Use user permissions for remodel actions

### DIFF
--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -248,8 +248,12 @@ function Remodel(): React.JSX.Element {
     if (!canManageRemodelAllowlist) {
       setRemodelsToDelete([]);
       setShowBulkDeleteModal(false);
+
+      if (id && modelId && !isClosedPanel(location.pathname, "configure")) {
+        navigate(`/admin/${id}/models/${modelId}/remodel`, { replace: true });
+      }
     }
-  }, [canManageRemodelAllowlist]);
+  }, [canManageRemodelAllowlist, id, modelId, location.pathname, navigate]);
 
   return (
     <>

--- a/static/js/publisher/pages/Remodel/Remodel.tsx
+++ b/static/js/publisher/pages/Remodel/Remodel.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-router-dom";
 import { Notification, Icon, Button, Modal } from "@canonical/react-components";
 
-import { useRemodels } from "../../hooks";
+import { useRemodels, useUserPrivileges } from "../../hooks";
 import { remodelsListState } from "../../state/remodelsState";
 import { brandIdState, brandStoreState } from "../../state/brandStoreState";
 import { setPageTitle, isClosedPanel } from "../../utils";
@@ -26,6 +26,12 @@ const getRemodelRowId = (remodel: Remodel): string => {
   const serial = remodel["from-serial"] ?? "all-serials";
   return `${remodel["from-model"]}:${remodel["to-model"]}:${serial}`;
 };
+
+const remodelManagementPermissions = [
+  "create-remodel-allowlist",
+  "delete-remodel-allowlist",
+  "update-remodel-allowlist",
+];
 
 function Remodel(): React.JSX.Element {
   const { id, modelId } = useParams();
@@ -56,6 +62,7 @@ function Remodel(): React.JSX.Element {
       page: currentCursor,
     },
   );
+  const { data: userPrivilegesData } = useUserPrivileges();
   const setRemodels = useSetAtom(remodelsListState);
   const [showNotification, setShowNotification] = useState(false);
   const [notificationMessage, setNotificationMessage] = useState(
@@ -72,6 +79,11 @@ function Remodel(): React.JSX.Element {
   const [isBulkDeleting, setIsBulkDeleting] = useState(false);
   const brandStore = useAtomValue(brandStoreState(id));
   const navigate = useNavigate();
+  const brandPermissions =
+    userPrivilegesData?.["brand-permissions"]?.[brandId] || [];
+  const canManageRemodelAllowlist = remodelManagementPermissions.every(
+    (permission) => brandPermissions.includes(permission),
+  );
 
   const handleEditChange = (rowId: string, value: string) => {
     setEditedDescriptions((previous) => ({
@@ -232,6 +244,13 @@ function Remodel(): React.JSX.Element {
     }
   }, [isLoading, isError, data, brandId, id]);
 
+  useEffect(() => {
+    if (!canManageRemodelAllowlist) {
+      setRemodelsToDelete([]);
+      setShowBulkDeleteModal(false);
+    }
+  }, [canManageRemodelAllowlist]);
+
   return (
     <>
       <div className="u-fixed-width u-flex-column u-flex-grow">
@@ -251,34 +270,36 @@ function Remodel(): React.JSX.Element {
           </Notification>
         ) : (
           <>
-            <div className="u-fixed-width u-align--right">
-              <Button
-                disabled={remodelsToDelete.length === 0 || isBulkDeleting}
-                onClick={() => setShowBulkDeleteModal(true)}
-                className={isBulkDeleting ? "has-icon" : ""}
-              >
-                {isBulkDeleting ? (
-                  <>
-                    <Icon
-                      name="spinner"
-                      className="u-animation--spin is-light"
-                    />
-                    &nbsp;Deleting...
-                  </>
-                ) : remodelsToDelete.length > 1 ? (
-                  `Delete ${remodelsToDelete.length} remodels`
-                ) : (
-                  "Delete remodel"
-                )}
-              </Button>
+            {canManageRemodelAllowlist && (
+              <div className="u-fixed-width u-align--right">
+                <Button
+                  disabled={remodelsToDelete.length === 0 || isBulkDeleting}
+                  onClick={() => setShowBulkDeleteModal(true)}
+                  className={isBulkDeleting ? "has-icon" : ""}
+                >
+                  {isBulkDeleting ? (
+                    <>
+                      <Icon
+                        name="spinner"
+                        className="u-animation--spin is-light"
+                      />
+                      &nbsp;Deleting...
+                    </>
+                  ) : remodelsToDelete.length > 1 ? (
+                    `Delete ${remodelsToDelete.length} remodels`
+                  ) : (
+                    "Delete remodel"
+                  )}
+                </Button>
 
-              <Link
-                className={`p-button--positive ${isError && !data ? "is-disabled" : ""}`}
-                to={`/admin/${id}/models/${modelId}/remodel/configure`}
-              >
-                Configure remodels
-              </Link>
-            </div>
+                <Link
+                  className={`p-button--positive ${isError && !data ? "is-disabled" : ""}`}
+                  to={`/admin/${id}/models/${modelId}/remodel/configure`}
+                >
+                  Configure remodels
+                </Link>
+              </div>
+            )}
 
             <div className="u-flex-column u-flex-grow">
               {data && (
@@ -299,6 +320,7 @@ function Remodel(): React.JSX.Element {
                   onEditCancel={handleEditCancel}
                   remodelsToDelete={remodelsToDelete}
                   setRemodelsToDelete={setRemodelsToDelete}
+                  canManageRemodelAllowlist={canManageRemodelAllowlist}
                 />
               )}
             </div>
@@ -404,37 +426,41 @@ function Remodel(): React.JSX.Element {
           </Modal>
         )}
       </PortalEntrance>
-      <PortalEntrance name="aside">
-        <div
-          className={`l-aside__overlay ${
-            isClosedPanel(location.pathname, "configure") ? "u-hide" : ""
-          }`}
-          onClick={() => {
-            navigate(`/admin/${id}/models/${modelId}/remodel`);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
+      {canManageRemodelAllowlist && (
+        <PortalEntrance name="aside">
+          <div
+            className={`l-aside__overlay ${
+              isClosedPanel(location.pathname, "configure") ? "u-hide" : ""
+            }`}
+            onClick={() => {
               navigate(`/admin/${id}/models/${modelId}/remodel`);
-            }
-          }}
-          role="button"
-          tabIndex={0}
-          aria-label="Return to remodels"
-        ></div>
-        <aside
-          className={`l-aside ${
-            isClosedPanel(location.pathname, "configure") ? "is-collapsed" : ""
-          }`}
-        >
-          <ConfigureRemodelForm
-            refetch={refetch}
-            setShowNotification={setShowNotification}
-            setNotificationMessage={setNotificationMessage}
-            setShowErrorNotification={setShowErrorNotification}
-            setErrorMessage={setErrorMessage}
-          />
-        </aside>
-      </PortalEntrance>
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                navigate(`/admin/${id}/models/${modelId}/remodel`);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            aria-label="Return to remodels"
+          ></div>
+          <aside
+            className={`l-aside ${
+              isClosedPanel(location.pathname, "configure")
+                ? "is-collapsed"
+                : ""
+            }`}
+          >
+            <ConfigureRemodelForm
+              refetch={refetch}
+              setShowNotification={setShowNotification}
+              setNotificationMessage={setNotificationMessage}
+              setShowErrorNotification={setShowErrorNotification}
+              setErrorMessage={setErrorMessage}
+            />
+          </aside>
+        </PortalEntrance>
+      )}
     </>
   );
 }

--- a/static/js/publisher/pages/Remodel/RemodelTable.tsx
+++ b/static/js/publisher/pages/Remodel/RemodelTable.tsx
@@ -26,6 +26,7 @@ type Props = {
   onEditCancel: (rowId: string) => void;
   remodelsToDelete: Remodel[];
   setRemodelsToDelete: (remodels: Remodel[]) => void;
+  canManageRemodelAllowlist: boolean;
 };
 
 const getRemodelRowId = (remodel: Remodel): string => {
@@ -48,6 +49,7 @@ function RemodelTable({
   onEditCancel,
   remodelsToDelete,
   setRemodelsToDelete,
+  canManageRemodelAllowlist,
 }: Props): React.JSX.Element {
   const [isChecked, setIsChecked] = useState(false);
   const [isIndeterminate, setIsIndeterminate] = useState(false);
@@ -74,33 +76,37 @@ function RemodelTable({
   };
 
   const headers = [
-    {
-      style: withCheckboxStyles,
-      content: (
-        <div
-          style={{
-            position: "relative",
-            top: "-9px",
-          }}
-        >
-          <CheckboxInput
-            labelClassName="u-no-margin--bottom"
-            onChange={(e) => {
-              if (e.target.checked) {
-                setRemodelsToDelete(remodels);
-                setIsChecked(true);
-              } else {
-                setRemodelsToDelete([]);
-                setIsChecked(false);
-              }
-            }}
-            checked={isChecked}
-            indeterminate={isIndeterminate}
-            label=<span className="table-cell-checkbox__label">Name</span>
-          />
-        </div>
-      ),
-    },
+    ...(canManageRemodelAllowlist
+      ? [
+          {
+            style: withCheckboxStyles,
+            content: (
+              <div
+                style={{
+                  position: "relative",
+                  top: "-9px",
+                }}
+              >
+                <CheckboxInput
+                  labelClassName="u-no-margin--bottom"
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setRemodelsToDelete(remodels);
+                      setIsChecked(true);
+                    } else {
+                      setRemodelsToDelete([]);
+                      setIsChecked(false);
+                    }
+                  }}
+                  checked={isChecked}
+                  indeterminate={isIndeterminate}
+                  label=<span className="table-cell-checkbox__label">Name</span>
+                />
+              </div>
+            ),
+          },
+        ]
+      : []),
     {
       content: "Target model",
       style: { width: "250px" },
@@ -133,28 +139,32 @@ function RemodelTable({
 
     return {
       columns: [
-        {
-          content: (
-            <CheckboxInput
-              labelClassName="u-no-margin--bottom u-no-padding--top"
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setRemodelsToDelete([...remodelsToDelete, remodel]);
-                } else {
-                  setRemodelsToDelete(
-                    remodelsToDelete.filter(
-                      (item) => getRemodelRowId(item) !== rowId,
-                    ),
-                  );
-                }
-              }}
-              checked={isRowChecked}
-              label=<span className="table-cell-checkbox__label">
-                {remodel["to-model"]}
-              </span>
-            />
-          ),
-        },
+        ...(canManageRemodelAllowlist
+          ? [
+              {
+                content: (
+                  <CheckboxInput
+                    labelClassName="u-no-margin--bottom u-no-padding--top"
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setRemodelsToDelete([...remodelsToDelete, remodel]);
+                      } else {
+                        setRemodelsToDelete(
+                          remodelsToDelete.filter(
+                            (item) => getRemodelRowId(item) !== rowId,
+                          ),
+                        );
+                      }
+                    }}
+                    checked={isRowChecked}
+                    label=<span className="table-cell-checkbox__label">
+                      {remodel["to-model"]}
+                    </span>
+                  />
+                ),
+              },
+            ]
+          : []),
         { content: remodel["to-model"], className: "u-truncate" },
         {
           content: remodel["from-serial"] || "All serial policies",
@@ -165,7 +175,7 @@ function RemodelTable({
           className: "u-align--right",
         },
         {
-          content: (
+          content: canManageRemodelAllowlist ? (
             <>
               <Input
                 type="text"
@@ -204,6 +214,8 @@ function RemodelTable({
                 </div>
               )}
             </>
+          ) : (
+            originalValue
           ),
         },
       ],

--- a/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/Remodel.test.tsx
@@ -7,13 +7,19 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import Remodel from "../Remodel";
-import { useRemodels, useModels, useSortTableData } from "../../../hooks";
+import {
+  useRemodels,
+  useModels,
+  useSortTableData,
+  useUserPrivileges,
+} from "../../../hooks";
 
 import type { UseQueryResult } from "react-query";
 import type {
   ApiResponse,
   RemodelResponse,
   Model,
+  UserPrivileges,
 } from "../../../types/shared";
 
 const mockFilterQuery = "test-model";
@@ -34,6 +40,7 @@ vi.mock("../../../hooks", () => ({
   useRemodels: vi.fn(),
   useModels: vi.fn(),
   useSortTableData: vi.fn(),
+  useUserPrivileges: vi.fn(),
 }));
 
 const queryClient = new QueryClient({
@@ -151,8 +158,51 @@ mockUseSortTableData.mockReturnValue({
 });
 
 const mockUseRemodels = vi.mocked(useRemodels);
+const mockUseUserPrivileges = vi.mocked(useUserPrivileges);
+
+const remodelManagementPermissions = [
+  "create-remodel-allowlist",
+  "delete-remodel-allowlist",
+  "update-remodel-allowlist",
+];
+
+const useUserPrivilegesWithRemodelManagement = {
+  data: {
+    account: {
+      "display-name": "Test User",
+      email: "test@example.com",
+      id: "test-account-id",
+      username: "test-user",
+    },
+    "brand-permissions": {
+      "": remodelManagementPermissions,
+    },
+    permissions: [],
+  },
+} as unknown as UseQueryResult<UserPrivileges, Error>;
+
+const useUserPrivilegesWithoutRemodelManagement = {
+  data: {
+    account: {
+      "display-name": "Test User",
+      email: "test@example.com",
+      id: "test-account-id",
+      username: "test-user",
+    },
+    "brand-permissions": {
+      "": ["create-remodel-allowlist", "delete-remodel-allowlist"],
+    },
+    permissions: [],
+  },
+} as unknown as UseQueryResult<UserPrivileges, Error>;
 
 describe("Remodel", () => {
+  beforeEach(() => {
+    mockUseUserPrivileges.mockReturnValue(
+      useUserPrivilegesWithRemodelManagement,
+    );
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -571,5 +621,46 @@ describe("Remodel", () => {
       });
       expect(deleteButton).toHaveAttribute("aria-disabled", "true");
     });
+  });
+
+  it("hides remodel management actions without all required permissions", async () => {
+    mockUseUserPrivileges.mockReturnValue(
+      useUserPrivilegesWithoutRemodelManagement,
+    );
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+
+    renderComponent();
+
+    expect(
+      screen.queryByRole("button", { name: "Delete remodel" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Configure remodels" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Configure a remodel" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(await screen.findByText("test remodel")).toBeInTheDocument();
+  });
+
+  it("hides remodel management actions while privileges are unavailable", async () => {
+    mockUseUserPrivileges.mockReturnValue({
+      data: undefined,
+    } as unknown as UseQueryResult<UserPrivileges, Error>);
+    mockUseRemodels.mockReturnValue(useRemodelsWithData);
+
+    renderComponent();
+
+    expect(
+      screen.queryByRole("button", { name: "Delete remodel" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Configure remodels" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(await screen.findByText("test remodel")).toBeInTheDocument();
   });
 });

--- a/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
+++ b/static/js/publisher/pages/Remodel/__tests__/RemodelTable.test.tsx
@@ -50,6 +50,7 @@ const renderComponent = ({
   onEditCancel = vi.fn(),
   remodelsToDelete = [],
   setRemodelsToDelete = vi.fn(),
+  canManageRemodelAllowlist = true,
 }: {
   isSavingEdit?: boolean;
   editedDescriptions?: Record<string, string>;
@@ -58,6 +59,7 @@ const renderComponent = ({
   onEditCancel?: (rowId: string) => void;
   remodelsToDelete?: Remodel[];
   setRemodelsToDelete?: (remodels: Remodel[]) => void;
+  canManageRemodelAllowlist?: boolean;
 } = {}) => {
   return render(
     <BrowserRouter>
@@ -77,6 +79,7 @@ const renderComponent = ({
           onEditCancel={onEditCancel}
           remodelsToDelete={remodelsToDelete}
           setRemodelsToDelete={setRemodelsToDelete}
+          canManageRemodelAllowlist={canManageRemodelAllowlist}
         />
       </QueryClientProvider>
     </BrowserRouter>,
@@ -300,5 +303,29 @@ describe("RemodelTable", () => {
     expect(checkboxes[1]).toBeChecked();
     // Third checkbox (second row) should not be checked
     expect(checkboxes[2]).not.toBeChecked();
+  });
+
+  it("does not render checkboxes when remodel management is not allowed", () => {
+    renderComponent({ canManageRemodelAllowlist: false });
+
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+  });
+
+  it("renders note descriptions as text when remodel management is not allowed", () => {
+    renderComponent({
+      canManageRemodelAllowlist: false,
+      editedDescriptions: { [firstRowId]: "modified description" },
+    });
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Save" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Revert" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("test remodel")).toBeInTheDocument();
+    expect(screen.getByText("second remodel")).toBeInTheDocument();
+    expect(screen.queryByText("modified description")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done

Uses the user privileges data to only show create, update and delete actions to remodels if the user has sufficient permissions

## How to QA
- Go to https://snapcraft-io-5842.demos.haus/admin/ahnuP3quahti9vis8aiw/models/test-superalpaca-00/remodel
- Check that you can configure, delete and edit the note of remodels

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38227

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
