### PR TITLE
Snap permissions (aka package transparency, WD-35689)

### DIFF
--- a/tests/endpoints/tests_snaps_permissions.py
+++ b/tests/endpoints/tests_snaps_permissions.py
@@ -1,0 +1,227 @@
+from unittest.mock import patch
+
+from canonicalwebteam.exceptions import (
+    StoreApiResourceNotFound,
+    StoreApiResponseErrorList,
+)
+
+from tests.endpoints.endpoint_testing import TestEndpoints
+
+
+class TestSnapPermissionsEndpoint(TestEndpoints):
+    def _url(self, query=""):
+        base_url = "/api/mumble/permissions"
+        return f"{base_url}?{query}" if query else base_url
+
+    def test_missing_channel_parameter_returns_400(self):
+        response = self.client.get(self._url("architecture=amd64"))
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["errors"], ['"channel" parameter is required'])
+
+    def test_missing_architecture_parameter_returns_400(self):
+        response = self.client.get(self._url("channel=latest/stable"))
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(
+            data["errors"], ['"architecture" parameter is required']
+        )
+
+    def test_missing_both_parameters_returns_400(self):
+        response = self.client.get(self._url())
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data["success"])
+        self.assertEqual(
+            data["errors"],
+            [
+                '"channel" parameter is required',
+                '"architecture" parameter is required',
+            ],
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_confinement_and_interfaces(self, mock_get_item_details):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": (
+                        "confinement: strict\n"
+                        "plugs:\n"
+                        "  network:\n"
+                        "    interface: network\n"
+                        "  home:\n"
+                        "    interface: home\n"
+                    ),
+                }
+            ]
+        }
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"]["confinement"], "strict")
+        self.assertEqual(
+            data["data"]["interfaces"],
+            [
+                {"name": "network", "interface": "network"},
+                {"name": "home", "interface": "home"},
+            ],
+        )
+        mock_get_item_details.assert_called_once_with(
+            "mumble", api_version=2, fields=["snap-yaml"]
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_defaults_interface_name_when_missing(self, mock_get_item_details):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": (
+                        "confinement: strict\n" "plugs:\n" "  desktop: {}\n"
+                    ),
+                }
+            ]
+        }
+
+        data = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        ).get_json()
+
+        self.assertTrue(data["success"])
+        self.assertEqual(
+            data["data"]["interfaces"],
+            [{"name": "desktop", "interface": "desktop"}],
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_empty_interfaces_when_no_plugs(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": "confinement: strict\n",
+                }
+            ]
+        }
+
+        data = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        ).get_json()
+
+        self.assertTrue(data["success"])
+        self.assertEqual(data["data"]["interfaces"], [])
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_error_when_channel_or_arch_does_not_match(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "arm64",
+                    },
+                    "snap-yaml": "confinement: strict\n",
+                }
+            ]
+        }
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertEqual(
+            data["errors"],
+            [
+                'channel "latest/stable" does not exist for architecture '
+                '"amd64"'
+            ],
+        )
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_errors_when_snap_yaml_parsing_fails(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.return_value = {
+            "channel-map": [
+                {
+                    "channel": {
+                        "name": "latest/stable",
+                        "architecture": "amd64",
+                    },
+                    "snap-yaml": "plugs: [",
+                }
+            ]
+        }
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(data["success"])
+        self.assertIn("errors", data)
+        self.assertEqual(len(data["errors"]), 1)
+        self.assertIsInstance(data["errors"][0], str)
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_404_when_snap_does_not_exist(self, mock_get_item_details):
+        mock_get_item_details.side_effect = StoreApiResourceNotFound()
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(data["success"])
+        self.assertEqual(data["errors"], ['"mumble" does not exist'])
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_returns_store_api_errors_with_upstream_status(
+        self, mock_get_item_details
+    ):
+        mock_get_item_details.side_effect = StoreApiResponseErrorList(
+            "upstream error",
+            503,
+            [{"message": "upstream unavailable"}, {"code": "oops"}],
+        )
+
+        response = self.client.get(
+            self._url("channel=latest/stable&architecture=amd64")
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 503)
+        self.assertFalse(data["success"])
+        self.assertEqual(
+            data["errors"], ["upstream unavailable", "An error occurred"]
+        )

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -1,3 +1,7 @@
+from canonicalwebteam.exceptions import (
+    StoreApiResourceNotFound,
+    StoreApiResponseErrorList,
+)
 import flask
 from flask import make_response
 from flask.json import jsonify
@@ -14,6 +18,7 @@ from webapp.api.github import repository_is_public
 from webapp.api.launchpad_provenance import LaunchpadProvenance
 from webapp.endpoints.utils import get_auditable_map_cache_key
 from cache.cache_utility import redis_cache
+from webapp.helpers import get_yaml_loader
 
 from canonicalwebteam.store_api.devicegw import DeviceGW
 from canonicalwebteam.store_api.dashboard import Dashboard
@@ -273,6 +278,110 @@ def auditable_revisions(snap_name):
 
     response = make_response(res, 200)
     response.cache_control.max_age = 0 if res.get("error") else 3600
+    return response
+
+
+@snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/permissions')
+def permissions(snap_name):
+    """Return the permissions that a snap requests for one specific channel
+    and architecture.
+
+    This endpoint needs the ``channel`` and ``architecture`` query parameters.
+    It gets the channel map, finds the matching channel and architecture, and
+    parses the ``snap-yaml`` field.
+
+    The response contains:
+    - ``confinement`` from ``snap-yaml``
+    - ``interfaces`` as ``[{"name": <plug name>, "interface": <interface>}]``
+
+    If a query parameter is missing, this endpoint returns HTTP 400.
+    If lookup or parsing fails, the response contains an ``errors`` list.
+    """
+    missing_params = [
+        p for p in ("channel", "architecture") if not flask.request.args.get(p)
+    ]
+
+    if missing_params:
+        return make_response(
+            {
+                "success": False,
+                "errors": [
+                    f'"{param}" parameter is required'
+                    for param in missing_params
+                ],
+            },
+            400,
+        )
+
+    channel = flask.request.args.get("channel")
+    architecture = flask.request.args.get("architecture")
+
+    try:
+        details = device_gateway.get_item_details(
+            snap_name, api_version=2, fields=["snap-yaml"]
+        )
+    except StoreApiResourceNotFound:
+        return make_response(
+            {
+                "success": False,
+                "errors": [f'"{snap_name}" does not exist'],
+            },
+            404,
+        )
+    except StoreApiResponseErrorList as e:
+        return make_response(
+            {
+                "success": False,
+                "errors": [
+                    f"{error.get('message', 'An error occurred')}"
+                    for error in e.errors
+                ],
+            },
+            e.status_code,
+        )
+
+    def predicate(_channel):
+        channel_entry = _channel.get("channel", {})
+        name: str = channel_entry.get("name", "")
+        arch: str = channel_entry.get("architecture", "")
+        return name == channel and arch == architecture
+
+    try:
+        channel_map = details.get("channel-map", [])
+        match = next((c for c in channel_map if predicate(c)), None)
+
+        if match is None:
+            raise Exception(
+                f'channel "{channel}" does not exist for architecture '
+                f'"{architecture}"'
+            )
+
+        raw_snap_yaml = match.get("snap-yaml")
+        snap_yaml = get_yaml_loader().load(raw_snap_yaml)
+
+        res = {
+            "success": True,
+            "data": {
+                "confinement": snap_yaml["confinement"],
+                "interfaces": [
+                    {
+                        "name": name,
+                        "interface": plug.get("interface", name),
+                        # "description": "TODO",
+                        # "raw_yaml": "TODO",
+                        # "categories": ["TODO"],
+                        # "auto_connect": False,
+                        # "details": ["TODO"]
+                    }
+                    for name, plug in snap_yaml.get("plugs", {}).items()
+                ],
+            },
+        }
+    except Exception as e:
+        res = {"success": True if details else False, "errors": [str(e)]}
+
+    response = make_response(res, 200)
+    response.cache_control.max_age = 0 if not res.get("success") else 3600
     return response
 
 


### PR DESCRIPTION
This PR is the base of a stack for the new snap permissions (aka package transparency) feature. To make sure the stack won't be merged accidentally while incomplete, this PR will remain a draft until all branches above have been approved.

## Done
The contents of this PR were already approved in #5839 and #5840

## How to QA

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): this API only exposes public data

## Issue / Card

Fixes #

## Screenshots

## UX Approval

- [ ] This PR does not require UX approval
- [x] This PR does require UX approval (add context):

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>