### PR TITLE
Add Pragma buttons to publisher save and preview bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "@babel/preset-typescript": "7.28.5",
     "@canonical/analytics-events": "1.1.2",
     "@canonical/cookie-policy": "3.10.0",
-    "@canonical/ds-assets": "0.32.0",
+    "@canonical/ds-assets": "0.34.0",
     "@canonical/global-nav": "3.8.0",
     "@canonical/react-components": "4.5.2",
-    "@canonical/react-ds-global": "0.32.0",
+    "@canonical/react-ds-global": "0.34.0",
     "@canonical/store-components": "0.55.0",
     "@canonical/styles": "0.32.0",
     "@dnd-kit/core": "6.3.1",
@@ -123,6 +123,8 @@
     "lodash": "4.18.1",
     "picomatch": ">=2.3.2",
     "brace-expansion": ">=2.0.2",
-    "@tootallnate/once": "3.0.1"
+    "@tootallnate/once": "3.0.1",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   }
 }

--- a/static/js/publisher/components/SaveAndPreview/SaveAndPreview.test.tsx
+++ b/static/js/publisher/components/SaveAndPreview/SaveAndPreview.test.tsx
@@ -5,6 +5,34 @@ import type { FormEvent } from "react";
 
 import SaveAndPreview from "./SaveAndPreview";
 
+vi.mock("@canonical/react-ds-global", () => {
+  const Button = ({
+    anticipation: _anticipation,
+    children,
+    disabled,
+    importance: _importance,
+    loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    anticipation?: string;
+    importance?: string;
+    loading?: boolean;
+  }) => (
+    <button
+      aria-disabled={disabled || loading ? "true" : undefined}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+
+  return {
+    Button,
+    withTooltip: (Component: React.ComponentType) => Component,
+  };
+});
+
 const reset = vi.fn();
 
 const renderComponent = (
@@ -31,10 +59,7 @@ beforeEach(() => {
 
 test("the 'Revert' button is disabled by default", () => {
   renderComponent(false, false, true);
-  expect(screen.getByRole("button", { name: "Revert" })).toHaveAttribute(
-    "aria-disabled",
-    "true",
-  );
+  expect(screen.getByRole("button", { name: "Revert" })).toBeDisabled();
 });
 
 test("the 'Revert' button is enabled is data is dirty", () => {
@@ -44,10 +69,7 @@ test("the 'Revert' button is enabled is data is dirty", () => {
 
 test("the 'Save' button is disabled by default", () => {
   renderComponent(false, false, true);
-  expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
-    "aria-disabled",
-    "true",
-  );
+  expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 });
 
 test("the 'Save' button is enabled is data is dirty", () => {
@@ -62,18 +84,12 @@ test("the 'Save' button shows loading state if saving", () => {
 
 test("the 'Save' button is disabled when saving", () => {
   renderComponent(true, true, true);
-  expect(screen.getByRole("button", { name: "Saving" })).toHaveAttribute(
-    "aria-disabled",
-    "true",
-  );
+  expect(screen.getByRole("button", { name: "Saving" })).toBeDisabled();
 });
 
 test("the 'Save' button is disabled if the form is invalid", () => {
   renderComponent(false, false, false);
-  expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
-    "aria-disabled",
-    "true",
-  );
+  expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 });
 
 test("revert button resets the form", async () => {

--- a/static/js/publisher/components/SaveAndPreview/SaveAndPreview.tsx
+++ b/static/js/publisher/components/SaveAndPreview/SaveAndPreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
-import { Row, Col, Button } from "@canonical/react-components";
+import { Row, Col } from "@canonical/react-components";
+import { Button, withTooltip } from "@canonical/react-ds-global";
 
 import debounce from "../../../libs/debounce";
 
@@ -11,6 +12,11 @@ type Props = {
   isValid: boolean;
   showPreview?: boolean;
 };
+
+const PreviewButtonWithTooltip = withTooltip(
+  Button,
+  <>Previews will only work in the same browser, locally</>,
+);
 
 function SaveAndPreview({
   snapName,
@@ -96,7 +102,7 @@ function SaveAndPreview({
   return (
     <>
       <div
-        className="snapcraft-p-sticky js-sticky-bar"
+        className="snapcraft-p-sticky"
         ref={stickyBar}
         style={{ margin: "0 -1.5rem", padding: "0 1.5rem" }}
       >
@@ -110,24 +116,24 @@ function SaveAndPreview({
           <Col size={5}>
             <div className="u-align--right">
               {showPreview && (
-                <Button
-                  type="submit"
-                  className="p-button--base p-tooltip--btm-center"
-                  aria-describedby="preview-tooltip"
-                  form="preview-form"
-                >
-                  Preview
-                  <span
-                    className="p-tooltip__message"
-                    role="tooltip"
-                    id="preview-tooltip"
+                // Must wrap to set the right margin because the `Button`
+                // within `PreviewButtonWithTooltip` is wrapped, and these
+                // styles go directly to the `Button` component, therefore
+                // the spacing doesn't take effect
+                <span style={{ marginRight: "1rem" }}>
+                  <PreviewButtonWithTooltip
+                    aria-describedby="preview-tooltip"
+                    type="submit"
+                    form="preview-form"
+                    importance="tertiary"
                   >
-                    Previews will only work in the same browser, locally
-                  </span>
-                </Button>
+                    Preview
+                  </PreviewButtonWithTooltip>
+                </span>
               )}
               <Button
-                appearance="default"
+                importance="secondary"
+                className="u-no-margin--bottom"
                 disabled={!isDirty}
                 type="reset"
                 data-js="save-and-preview-revert"
@@ -138,19 +144,17 @@ function SaveAndPreview({
                 Revert
               </Button>
               <Button
-                appearance="positive"
+                anticipation="constructive"
+                importance="primary"
+                className="u-no-margin--bottom"
                 disabled={!isDirty || isSaving}
                 type="submit"
-                style={{ minWidth: "68px" }}
+                // Needed so save loading button doesn't cause a jump
+                style={{ width: "68px" }}
+                loading={isSaving}
                 data-js="save-and-preview-save"
               >
-                {isSaving ? (
-                  <i className="p-icon--spinner is-light u-animation--spin">
-                    Saving
-                  </i>
-                ) : (
-                  "Save"
-                )}
+                {isSaving ? "Saving" : "Save"}
               </Button>
             </div>
           </Col>

--- a/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
@@ -9,6 +9,34 @@ import "@testing-library/jest-dom";
 import ListingForm from "../ListingForm";
 import { mockListingData } from "../../../../test-utils";
 
+vi.mock("@canonical/react-ds-global", () => {
+  const Button = ({
+    anticipation: _anticipation,
+    children,
+    disabled,
+    importance: _importance,
+    loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    anticipation?: string;
+    importance?: string;
+    loading?: boolean;
+  }) => (
+    <button
+      aria-disabled={disabled || loading ? "true" : undefined}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+
+  return {
+    Button,
+    withTooltip: (Component: React.ComponentType) => Component,
+  };
+});
+
 vi.mock("react-router-dom", async (importOriginal) => ({
   ...(await importOriginal()),
   useParams: () => ({

--- a/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
@@ -9,6 +9,34 @@ import "@testing-library/jest-dom";
 import Listing from "../../Listing";
 import { mockListingData } from "../../../../test-utils";
 
+vi.mock("@canonical/react-ds-global", () => {
+  const Button = ({
+    anticipation: _anticipation,
+    children,
+    disabled,
+    importance: _importance,
+    loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    anticipation?: string;
+    importance?: string;
+    loading?: boolean;
+  }) => (
+    <button
+      aria-disabled={disabled || loading ? "true" : undefined}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+
+  return {
+    Button,
+    withTooltip: (Component: React.ComponentType) => Component,
+  };
+});
+
 vi.mock("react-router-dom", async (importOriginal) => ({
   ...(await importOriginal()),
   useParams: () => ({

--- a/static/js/publisher/pages/Listing/__tests__/Listing.test.tsx
+++ b/static/js/publisher/pages/Listing/__tests__/Listing.test.tsx
@@ -8,6 +8,34 @@ import "@testing-library/jest-dom";
 import Listing from "../Listing";
 import { mockListingData } from "../../../test-utils/mockListingData";
 
+vi.mock("@canonical/react-ds-global", () => {
+  const Button = ({
+    anticipation: _anticipation,
+    children,
+    disabled,
+    importance: _importance,
+    loading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    anticipation?: string;
+    importance?: string;
+    loading?: boolean;
+  }) => (
+    <button
+      aria-disabled={disabled || loading ? "true" : undefined}
+      disabled={disabled || loading}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+
+  return {
+    Button,
+    withTooltip: (Component: React.ComponentType) => Component,
+  };
+});
+
 const testListingData = {
   message: "",
   success: true,

--- a/static/js/publisher/pages/PublisherSettings/__tests__/PublisherSettingsForm.test.tsx
+++ b/static/js/publisher/pages/PublisherSettings/__tests__/PublisherSettingsForm.test.tsx
@@ -48,14 +48,8 @@ function renderComponent(settings = {}) {
 describe("PublisherSettingsForm", () => {
   test("'Revert' and 'Save' buttons disabled by default", () => {
     renderComponent();
-    expect(screen.getByRole("button", { name: "Revert" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
-    expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
-      "aria-disabled",
-      "true",
-    );
+    expect(screen.getByRole("button", { name: "Revert" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
   test("sets visibility", () => {

--- a/static/js/test/setup.ts
+++ b/static/js/test/setup.ts
@@ -1,0 +1,9 @@
+class ResizeObserverMock implements ResizeObserver {
+  observe(): void {}
+
+  unobserve(): void {}
+
+  disconnect(): void {}
+}
+
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);

--- a/static/sass/_pragma-migration-overrides.scss
+++ b/static/sass/_pragma-migration-overrides.scss
@@ -1,0 +1,12 @@
+// This file is here to handle any potential clashes
+// Please add an explanation above any overrides to describe
+// what issue they are fixing
+@mixin pragma-migration-overrides {
+  .ds {
+    // Vanilla adds an `opacity` of `0.33` to disabled buttons,
+    // which combined with Pragma styles, creates very low contrast
+    &.button:disabled {
+      opacity: 1;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -201,6 +201,10 @@ $color-social-icon-foreground: $color-light;
 @import "snapcraft_p-table-pagination-controls";
 @include snapcraft-p-table-pagination-controls;
 
+// Required for any clashes between Vanilla and Pragma
+@import "_pragma-migration-overrides";
+@include pragma-migration-overrides;
+
 dl {
   margin-bottom: $spv--x-large;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -578,3 +578,9 @@ html {
     fill: $colors--theme--background-default;
   }
 }
+
+// The default Pragma tooltip doesn't have a `z-index` so gets
+// overlapped by other page elements
+.ds.tooltip {
+  z-index: 10;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -202,7 +202,7 @@ $color-social-icon-foreground: $color-light;
 @include snapcraft-p-table-pagination-controls;
 
 // Required for any clashes between Vanilla and Pragma
-@import "_pragma-migration-overrides";
+@import "pragma-migration-overrides";
 @include pragma-migration-overrides;
 
 dl {

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
     global: "globalThis", // in dev mode "randomstring" uses `global` rather than `globalThis`
   },
   resolve: {
+    dedupe: ["react", "react-dom"],
     alias: [
       // by default react-components exports a CJS module that can't be tree-shaken, we consume the ESM instead
       {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,6 +7,12 @@ export default defineConfig({
     dir: "static/js", // base directory for tests
     globals: true, // inject global `vi` object in tests so we don't have to import it
     environment: "jsdom",
+    setupFiles: ["static/js/test/setup.ts"],
+    server: {
+      deps: {
+        inline: ["@canonical/react-ds-global"],
+      },
+    },
     silent: "passed-only", // silence logs for passed tests
     pool: "threads",
     testTimeout: 20000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1053,15 +1053,15 @@
   dependencies:
     "@canonical/terrazzo-lsp" "^0.8.1"
 
-"@canonical/ds-assets@0.32.0", "@canonical/ds-assets@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/ds-assets/-/ds-assets-0.32.0.tgz#6af032bfd742bd740370be22ccd1015b62e248a5"
-  integrity sha512-wtLDqaksMUnD/1PQ1VZrwrWRIb7nyHyld8XIqQsL9J4bA6C90R/I0FyXmq2gPpRF37O2As2IR7ZybijetbjfmQ==
+"@canonical/ds-assets@0.34.0", "@canonical/ds-assets@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/ds-assets/-/ds-assets-0.34.0.tgz#1eeaf2be4a9997db6903366bd55b0a318ea8b1e4"
+  integrity sha512-aZ+pxiWs87xCsPllgcpznXaVCBQjXv2zyJqdkkznmp2E8FaRy9+XE/AflQ3aTJGe4zLqufnR1oBBcUN4pImSjg==
 
-"@canonical/ds-types@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/ds-types/-/ds-types-0.32.0.tgz#8dac13382aa27abd4862b02ae27dae3962720653"
-  integrity sha512-SpI1PqiV8AEdnyA4udvrXGDJteUvcG5i+I8FFgmzB/yzM07+PJyJdBMluAQm1HdJ9tgTtuTvXNixX4Q0snhYhg==
+"@canonical/ds-types@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/ds-types/-/ds-types-0.34.0.tgz#0d39880d0873a9b08186a6adb2cec72f0b04709e"
+  integrity sha512-5OH9USnXvzyXHCDTy4EREAhnqCQ3MijU+ufeXqzC4SIcCnnGVvOQISJBP9az4MJHKAE5qQIN3GC2oBzByCipSA==
 
 "@canonical/global-nav@3.8.0":
   version "3.8.0"
@@ -1102,27 +1102,27 @@
     prop-types "15.8.1"
     react-table "7.8.0"
 
-"@canonical/react-ds-global@0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-ds-global/-/react-ds-global-0.32.0.tgz#18278bfe14e2443ce0d190b2f8020639fba68577"
-  integrity sha512-y0M48lByXnewM26Af2naT4vIFA9G2LgkTHxh94+87+FeSvT/n5foShdcGegSufBpGBtKCPXr/vscJyzRZqwGIg==
+"@canonical/react-ds-global@0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-ds-global/-/react-ds-global-0.34.0.tgz#e9756077bb44268d4d26153bd7a15bb421f83495"
+  integrity sha512-H4BIlHu8kbrLjUJUDyHPcR633PVnudoskMOi7IJFOdI6xgl7UurqLXpeXRUwqUBlReRz3xjMzDyg2D+Txm26sQ==
   dependencies:
     "@canonical/design-tokens" "0.8.1"
-    "@canonical/ds-assets" "^0.32.0"
-    "@canonical/react-hooks" "^0.32.0"
-    "@canonical/storybook-config" "^0.32.0"
-    "@canonical/styles" "^0.32.0"
-    "@canonical/utils" "^0.32.0"
+    "@canonical/ds-assets" "^0.34.0"
+    "@canonical/react-hooks" "^0.34.0"
+    "@canonical/storybook-config" "^0.34.0"
+    "@canonical/styles" "^0.34.0"
+    "@canonical/utils" "^0.34.0"
     react "^19.2.4"
     react-dom "^19.2.4"
 
-"@canonical/react-hooks@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/react-hooks/-/react-hooks-0.32.0.tgz#01848cb8e37829b98a625a345a3e22ccc563ccd5"
-  integrity sha512-wzSTGD9ZJqsBxSOTuDEM1/ku1sKx2zaDkBWDw6HlGTFznVL4+8+7rOehdlTz8s/lnPMxBxuXVNfepBd+QzF9MQ==
+"@canonical/react-hooks@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-hooks/-/react-hooks-0.34.0.tgz#e8d3105a41c1f26c9a9fd168b14393169e87c73d"
+  integrity sha512-z4THMzlmsXLddITrbA+KGy6RvIie8xWT/0CPJVgx1rvIf/RtIrWkJ/4oD+INlU/kHCEQpNaXNAgoNETBcDYLvw==
   dependencies:
-    "@canonical/ds-types" "^0.32.0"
-    "@canonical/utils" "^0.32.0"
+    "@canonical/ds-types" "^0.34.0"
+    "@canonical/utils" "^0.34.0"
     react "^19.2.4"
     react-dom "^19.2.4"
 
@@ -1144,28 +1144,28 @@
     react-table "7.8.0"
     react-useportal "1.0.19"
 
-"@canonical/storybook-addon-shell-theme@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/storybook-addon-shell-theme/-/storybook-addon-shell-theme-0.32.0.tgz#974e784b4a76caf81704027a40abbff618a1160c"
-  integrity sha512-DeETzF/+MZf+ZP7lyNC3ySbeRN/E6P09yNooghPoaz0+hHuSGBWy8bDmXn8ezzXquR0j8ZEHv7tz/GelCifeIw==
+"@canonical/storybook-addon-shell-theme@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/storybook-addon-shell-theme/-/storybook-addon-shell-theme-0.34.0.tgz#9ead44182b56fe51177243bab80797fbdf5315f7"
+  integrity sha512-XF+9IOsXCQccZufU9q/HImbTng44M5zzx11eL2YrG2ASyWexMQv4qDhLq4JKFzduEaBg3bilgHA8mQhvDNJbxA==
 
-"@canonical/storybook-addon-utils@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/storybook-addon-utils/-/storybook-addon-utils-0.32.0.tgz#6d3aa53f5738438dddebae296c9d25858ac92661"
-  integrity sha512-6RSwMGvdgREHs8gaCty3bN7W/UV3f7qkGtzHa2YNPm8Wl78bd4xB7X55MzaE/anw0wFBwKyd0LhINUexM9jMAg==
+"@canonical/storybook-addon-utils@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/storybook-addon-utils/-/storybook-addon-utils-0.34.0.tgz#de26d534728b097d07e19dd79cf78e10c7ce00ff"
+  integrity sha512-tvL8x5Bo7qvzv644aUbB1rmoNAQxr+89ISo5+pLqbdGQLoG9l5Y+sPqXM692fLSRKq7qK8DYI0ompoWs9hVwxg==
   dependencies:
-    "@canonical/styles-debug" "^0.32.0"
+    "@canonical/styles-debug" "^0.34.0"
     "@storybook/icons" "^2.0.1"
 
-"@canonical/storybook-config@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/storybook-config/-/storybook-config-0.32.0.tgz#08652539ecdbab3042d4b93a5e29d06a7b1f3de1"
-  integrity sha512-l+DSybUK908xT4GonbXfbXfVcSK0QYvYncVJDfxLq3IzPzqqp0Y3lLDW3HSfcV6vd+PaLh3VCH6ccIAWh2GioQ==
+"@canonical/storybook-config@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/storybook-config/-/storybook-config-0.34.0.tgz#baeca7dac5e6990a34ab3b3511c16311e0337a9f"
+  integrity sha512-umhbYuxvVRrjRY0EsFFAXrPBa+vNe4bHcNyYtf5FhLlSio/wYumo0ek/0HAXo5LAJ/PVvh+v6m8+LqIK1ZCbYA==
   dependencies:
-    "@canonical/ds-assets" "^0.32.0"
-    "@canonical/storybook-addon-shell-theme" "^0.32.0"
-    "@canonical/storybook-addon-utils" "^0.32.0"
-    "@canonical/styles-debug" "^0.32.0"
+    "@canonical/ds-assets" "^0.34.0"
+    "@canonical/storybook-addon-shell-theme" "^0.34.0"
+    "@canonical/storybook-addon-utils" "^0.34.0"
+    "@canonical/styles-debug" "^0.34.0"
     "@chromatic-com/storybook" "^5.0.1"
     "@storybook/addon-a11y" "^10.3.1"
     "@storybook/addon-docs" "^10.3.1"
@@ -1173,12 +1173,13 @@
     "@storybook/addon-vitest" "^10.3.1"
     "@storybook/react-vite" "^10.3.1"
     "@storybook/svelte-vite" "^10.3.1"
+    "@storybook/sveltekit" "^10.3.1"
     "@storybook/web-components-vite" "^10.3.1"
 
-"@canonical/styles-debug@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/styles-debug/-/styles-debug-0.32.0.tgz#25a6930940fcd905894247ebe184226994d9dd3a"
-  integrity sha512-dqOCa+Ts734msOCtqZ5wBEBkj87sXE0DG20jsM8h7z1Mbymrnp+iRm/e3ewFIpC9hysPvLOrCN4dxhbf9c2Gtg==
+"@canonical/styles-debug@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/styles-debug/-/styles-debug-0.34.0.tgz#0dee3d9d4dd2991094e09a01ae7501f1c1c9bc13"
+  integrity sha512-uCTon1IaJgAw3KXYpDBeyQlto4vnk+cfyAcLgEUnE4jINYeURgaA1ICqXT6xtUORldmDxBphsFJum9EC34txmA==
 
 "@canonical/styles-typography@^0.32.0":
   version "0.32.0"
@@ -1188,13 +1189,30 @@
     "@canonical/design-tokens" "0.8.1"
     opentype.js "^1.3.4"
 
-"@canonical/styles@0.32.0", "@canonical/styles@^0.32.0":
+"@canonical/styles-typography@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/styles-typography/-/styles-typography-0.34.0.tgz#70cc594c789fca5817dc2eaf53617f7fd1873e01"
+  integrity sha512-SuHjc94rllaEJ8vE9k279OCVuoK2Sqkt0PiWvZjoPbfv+NQoD1r+pEGfx7pA+PHWOiZmE7ipPL+s9wCZm0RZlA==
+  dependencies:
+    "@canonical/design-tokens" "0.8.1"
+    opentype.js "^1.3.4"
+
+"@canonical/styles@0.32.0":
   version "0.32.0"
   resolved "https://registry.yarnpkg.com/@canonical/styles/-/styles-0.32.0.tgz#d276ba5015568981ee909733af8001f3ef05a753"
   integrity sha512-PoLHFxMwZOXhHRHkPu1lVAx5OQez+psB6GLTkcsv7Rvh7cSJbwlB86QIerSiOZS0+vh5s8e1x8fp7xSSMZTEKw==
   dependencies:
     "@canonical/design-tokens" "0.8.1"
     "@canonical/styles-typography" "^0.32.0"
+    normalize.css "^8.0.1"
+
+"@canonical/styles@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/styles/-/styles-0.34.0.tgz#295671ea1d00f153ae3db273ad8d5410bf4b19f7"
+  integrity sha512-JnXLCLSxyat9BSBDABJj0hpU+iCuBawD7CAjGgooFTvYviIFzG5P638LU9MRb9vnztZFBCnE48+g9tgXPF2Z4Q==
+  dependencies:
+    "@canonical/design-tokens" "0.8.1"
+    "@canonical/styles-typography" "^0.34.0"
     normalize.css "^8.0.1"
 
 "@canonical/terrazzo-lsp@^0.8.1":
@@ -1212,12 +1230,12 @@
   resolved "https://registry.yarnpkg.com/@canonical/token-types/-/token-types-0.8.1.tgz#029ee2947ac617b5699cd734d7598c633bc36fc6"
   integrity sha512-i0V9RaEPuySeTUcGn2NBulb0FXJcHInBtaI+awceokbcK75cc48/HxW1Gw4+GtI4D2xGn5W3EC58/O9siN4n7Q==
 
-"@canonical/utils@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@canonical/utils/-/utils-0.32.0.tgz#5e6a8c2a1fae174170f8cc6ed8a2a5243b2decf7"
-  integrity sha512-KgPyEeFcCwg2WjJQHvvokJVNY+T7WxwIlm4eRUmKtE0zaELgit4c6Nl2p8JOEa1cahscUfCFnziGEaBTk3YOzg==
+"@canonical/utils@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@canonical/utils/-/utils-0.34.0.tgz#fd0eb7ab1e9b18fd8734538f97c1ee4b5f260ed3"
+  integrity sha512-8dh7HwZEagVdjVVczZCey2rsyfRUzQkUxtIb32OQ1xS7u21xpiJmrL7hlTkwA1Y4gEZPOD5Gbbx6QQqscQq87Q==
   dependencies:
-    "@canonical/ds-types" "^0.32.0"
+    "@canonical/ds-types" "^0.34.0"
 
 "@chromatic-com/storybook@^5.0.1":
   version "5.2.1"
@@ -2519,6 +2537,14 @@
     "@storybook/global" "^5.0.0"
     "@storybook/icons" "^2.0.2"
 
+"@storybook/builder-vite@10.5.10":
+  version "10.5.10"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-vite/-/builder-vite-10.5.10.tgz#0caf06c122da29351bcc234421a58a631f181a49"
+  integrity sha512-O4GgIP0tKLRueom3EmU3OaBUHKjNYj+jkOvmTIkn3PYTiWVkCuHqSKEs4ADvRyaQuLH+peHhFe4JtkNC9KbtrQ==
+  dependencies:
+    "@storybook/csf-plugin" "10.5.10"
+    ts-dedent "^2.0.0"
+
 "@storybook/builder-vite@10.5.3":
   version "10.5.3"
   resolved "https://registry.yarnpkg.com/@storybook/builder-vite/-/builder-vite-10.5.3.tgz#4c0f5a11390222369da9b01409ecf7aace756e3f"
@@ -2526,6 +2552,13 @@
   dependencies:
     "@storybook/csf-plugin" "10.5.3"
     ts-dedent "^2.0.0"
+
+"@storybook/csf-plugin@10.5.10":
+  version "10.5.10"
+  resolved "https://registry.yarnpkg.com/@storybook/csf-plugin/-/csf-plugin-10.5.10.tgz#c65da1cdfe0a11795a14c518e9f8f828b8d54b3b"
+  integrity sha512-TaCLBrqVEr767+w58QDotDUiCTuE5cyRJuRcDlsKQyUIyGBv+lYD3lu8wBiVCYxgIjB/gu9HmqiC+0yx1rHzaw==
+  dependencies:
+    unplugin "^2.3.5"
 
 "@storybook/csf-plugin@10.5.3":
   version "10.5.3"
@@ -2581,6 +2614,17 @@
     react-docgen "^8.0.2"
     react-docgen-typescript "^2.2.2"
 
+"@storybook/svelte-vite@10.5.10":
+  version "10.5.10"
+  resolved "https://registry.yarnpkg.com/@storybook/svelte-vite/-/svelte-vite-10.5.10.tgz#ceebd7e823dd366bc756dc8bde094d2675323de5"
+  integrity sha512-yLqceMBE89p0L9vf9y6zE0ELeRxwfAU7ci3Hry7NEZkxQ4aYsuClUqCmlCLNrAI7nvoVK8v6fp82KgCcods95A==
+  dependencies:
+    "@storybook/builder-vite" "10.5.10"
+    "@storybook/svelte" "10.5.10"
+    magic-string "^0.30.0"
+    svelte2tsx "^0.7.55"
+    typescript "^4.9.4 || ^5.0.0"
+
 "@storybook/svelte-vite@^10.3.1":
   version "10.5.3"
   resolved "https://registry.yarnpkg.com/@storybook/svelte-vite/-/svelte-vite-10.5.3.tgz#ed2e841fceaa57de6157ccc1727eefdde902adeb"
@@ -2592,6 +2636,14 @@
     svelte2tsx "^0.7.55"
     typescript "^4.9.4 || ^5.0.0"
 
+"@storybook/svelte@10.5.10":
+  version "10.5.10"
+  resolved "https://registry.yarnpkg.com/@storybook/svelte/-/svelte-10.5.10.tgz#6e0ee333c398625d47b5652b7b0a5daf8849b659"
+  integrity sha512-jSEv1q5fJYTrhz7/DBYNc5gMmRJ8SyyyMikSvN4S6juuS0eJTZWGd62UpDH3ClfT/TQmTjTJH4HeEnbzJ+VrCA==
+  dependencies:
+    ts-dedent "^2.0.0"
+    type-fest "^5.6.0"
+
 "@storybook/svelte@10.5.3":
   version "10.5.3"
   resolved "https://registry.yarnpkg.com/@storybook/svelte/-/svelte-10.5.3.tgz#20d6ee1d53566d70932fa6f8121200a536eef060"
@@ -2599,6 +2651,15 @@
   dependencies:
     ts-dedent "^2.0.0"
     type-fest "^5.6.0"
+
+"@storybook/sveltekit@^10.3.1":
+  version "10.5.10"
+  resolved "https://registry.yarnpkg.com/@storybook/sveltekit/-/sveltekit-10.5.10.tgz#ce636db7e799f63adc2da68e70fdabf55fa9a0cb"
+  integrity sha512-sPHfTp1yitR+kftQV/0a7dDw3q4/zTXvBeWjgUC8DKkUY7NuFDRUOf00zE086B4vSXSZukf9484VyO+owBkLCQ==
+  dependencies:
+    "@storybook/builder-vite" "10.5.10"
+    "@storybook/svelte" "10.5.10"
+    "@storybook/svelte-vite" "10.5.10"
 
 "@storybook/web-components-vite@^10.3.1":
   version "10.5.3"
@@ -7939,17 +8000,10 @@ react-docgen@^8.0.2:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-react-dom@19.2.6:
+react-dom@19.2.6, "react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^19.2.4:
   version "19.2.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.6.tgz#44a81b0bcca22da814c00847d09d01c8615529b7"
   integrity sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==
-  dependencies:
-    scheduler "^0.27.0"
-
-"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react-dom@^19.2.4:
-  version "19.2.8"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.8.tgz#3b46b9eeda877cdff2cf13d2770fff4ae36c2ec2"
-  integrity sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==
   dependencies:
     scheduler "^0.27.0"
 
@@ -8062,15 +8116,10 @@ react-useportal@1.0.19:
   dependencies:
     use-ssr "^1.0.25"
 
-react@19.2.6:
+react@19.2.6, "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^19.2.4:
   version "19.2.6"
   resolved "https://registry.yarnpkg.com/react/-/react-19.2.6.tgz#3dadb8e12b2a7934c1d5317973e5dce1301f9a4d"
   integrity sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==
-
-"react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", react@^19.2.4:
-  version "19.2.8"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.8.tgz#a80663dbb58d69c6fe3fd291d3cb324e8a7dff2d"
-  integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
 
 read-cache@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Done
Adds [Pragma buttons](https://ds-react-global.canonical.com/?path=/docs/components-button--docs) to the "Save and preview" section of the publisher pages.

## How to QA
- Go to a snaps listing page, e.g. https://snapcraft-io-5850.demos.haus/steve-test-snap/listing
- Check that the "Preview" button has a tooltip on hover
- Check that the "Preview" button works as expected
- Check that the "Revert" button works as expected
- Check that the "Save" button works as expected
- Go to a snaps settings page, e.g. https://snapcraft-io-5850.demos.haus/steve-test-snap/settings
- Check that the "Revert" button works as expected
- Check that the "Save" button works as expected

Some things to note:
- The "Save and preview" bar is not sticky which is [an existing issue not introduced by this PR](https://warthogs.atlassian.net/browse/WD-38482)
- The `js-sticky-bar` class was removed from the sticky bar as it isn't actually used
- Using the [withTooltip HOC](https://ds-react-global.canonical.com/?path=/docs/components-tooltip-withtooltip--docs) showed an error in the console caused by two Reacts loaded on the page, fixed by the changes to `package.json` and `vite.config.js`
- `/tests/setup.ts` is needed to mock `ResizeObserver` in `jsdom` as it is used by the Pragma Tooltip component

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes #

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):