### PR TITLE
fix: Save and Revert buttons disable after form reset

### DIFF
--- a/static/js/publisher/hooks/useMutateListingData.ts
+++ b/static/js/publisher/hooks/useMutateListingData.ts
@@ -12,6 +12,7 @@ type Options = {
   getDefaultData: (arg: ListingData) => { [key: string]: unknown };
   refetch: () => void;
   reset: UseFormReset<FieldValues>;
+  onSaveSuccess?: (values: FieldValues) => void;
   setStatusNotification: Dispatch<SetStateAction<StatusNotification>>;
   setUpdateMetadataOnRelease: Dispatch<SetStateAction<boolean>>;
   shouldShowUpdateMetadataWarning: (arg: FieldValues) => boolean;
@@ -28,6 +29,7 @@ function useMutateListingData({
   dirtyFields,
   refetch,
   reset,
+  onSaveSuccess,
   setStatusNotification,
   setUpdateMetadataOnRelease,
   shouldShowUpdateMetadataWarning,
@@ -122,7 +124,7 @@ function useMutateListingData({
       }
       return (await response.json()) as MutationResponse;
     },
-    onSuccess: (data: MutationResponse) => {
+    onSuccess: (data: MutationResponse, values: FieldValues) => {
       const mainPanel = document.querySelector(".l-main") as HTMLElement;
       if (mainPanel) {
         mainPanel.scrollTo({ top: 0, left: 0, behavior: "smooth" });
@@ -134,6 +136,7 @@ function useMutateListingData({
           message: data.errors.map((value) => value.message),
         });
       } else {
+        onSaveSuccess?.(values);
         setStatusNotification({
           success: true,
           message: "Changes applied successfully.",

--- a/static/js/publisher/pages/Listing/AdditionalInformation/AdditionalInformation.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/AdditionalInformation.tsx
@@ -1,6 +1,5 @@
 import {
   UseFormRegister,
-  UseFormGetValues,
   UseFormSetValue,
   UseFormWatch,
   FieldValues,
@@ -14,7 +13,6 @@ import type { ListingData } from "../../../types";
 type Props = {
   data: ListingData;
   register: UseFormRegister<FieldValues>;
-  getValues: UseFormGetValues<FieldValues>;
   setValue: UseFormSetValue<FieldValues>;
   watch: UseFormWatch<FieldValues>;
 };
@@ -22,10 +20,15 @@ type Props = {
 function AdditionalInformation({
   data,
   register,
-  getValues,
   setValue,
   watch,
 }: Props): React.JSX.Element {
+  const publicMetricsEnabled = watch("public_metrics_enabled") as boolean;
+  const publicMetricsTerritories = watch(
+    "public_metrics_territories",
+  ) as boolean;
+  const publicMetricsDistros = watch("public_metrics_distros") as boolean;
+
   return (
     <>
       <h2 className="p-heading--4">Additional information</h2>
@@ -49,7 +52,7 @@ function AdditionalInformation({
                 className="p-checkbox__input"
                 aria-labelledby="public-metrics-checkbox"
                 {...register("public_metrics_enabled")}
-                defaultChecked={getValues("public_metrics_enabled")}
+                checked={publicMetricsEnabled}
               />
               <span className="p-checkbox__label" id="public-metrics-checkbox">
                 Display public popularity charts
@@ -63,9 +66,9 @@ function AdditionalInformation({
                   type="checkbox"
                   className="p-checkbox__input"
                   aria-labelledby="world-map-checkbox"
-                  disabled={!getValues("public_metrics_enabled")}
+                  disabled={!publicMetricsEnabled}
                   {...register("public_metrics_territories")}
-                  defaultChecked={getValues("public_metrics_territories")}
+                  checked={publicMetricsTerritories}
                 />
                 <span className="p-checkbox__label" id="world-map-checkbox">
                   World map
@@ -81,9 +84,9 @@ function AdditionalInformation({
                   type="checkbox"
                   className="p-checkbox__input"
                   aria-labelledby="linux-distributions-checkbox"
-                  disabled={!getValues("public_metrics_enabled")}
+                  disabled={!publicMetricsEnabled}
                   {...register("public_metrics_distros")}
-                  defaultChecked={getValues("public_metrics_distros")}
+                  checked={publicMetricsDistros}
                 />
                 <span
                   className="p-checkbox__label"

--- a/static/js/publisher/pages/Listing/AdditionalInformation/LicenseInputs.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/LicenseInputs.tsx
@@ -22,8 +22,8 @@ type Props = {
 };
 
 function LicenseInputs({ listingData, register, setValue, watch }: Props) {
-  const [licenseType, setLicenseType] = useState(listingData?.license_type);
   const [license, setLicense] = useState(listingData?.license);
+  const licenseType = watch("license_type") as string;
 
   const simpleLicenseId = nanoid();
   const customLicenseId = nanoid();
@@ -50,13 +50,10 @@ function LicenseInputs({ listingData, register, setValue, watch }: Props) {
                 <input
                   type="radio"
                   className="p-radio__input"
-                  name="license-type"
                   aria-labelledby={simpleLicenseId}
                   value="simple"
                   checked={licenseType === "simple"}
-                  onChange={() => {
-                    setLicenseType("simple");
-                  }}
+                  {...register("license_type")}
                 />
                 <span className="p-radio__label" id={simpleLicenseId}>
                   Simple
@@ -68,14 +65,14 @@ function LicenseInputs({ listingData, register, setValue, watch }: Props) {
                 <input
                   type="radio"
                   className="p-radio__input"
-                  name="license-type"
                   aria-labelledby={customLicenseId}
                   value="custom"
                   checked={licenseType === "custom"}
-                  onChange={() => {
-                    setLicenseType("custom");
-                    setValue("license", license);
-                  }}
+                  {...register("license_type", {
+                    onChange: () => {
+                      setValue("license", license);
+                    },
+                  })}
                 />
                 <span className="p-radio__label" id={customLicenseId}>
                   Custom SPDX expression

--- a/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/AdditionalInformation.test.tsx
+++ b/static/js/publisher/pages/Listing/AdditionalInformation/__tests__/AdditionalInformation.test.tsx
@@ -9,7 +9,7 @@ import { FieldValues, useForm } from "react-hook-form";
 import { getDefaultListingData } from "../../../../utils";
 
 function TestAdditionalInformation() {
-  const { register, setValue, watch, getValues } = useForm<FieldValues>({
+  const { register, setValue, watch } = useForm<FieldValues>({
     defaultValues: getDefaultListingData(mockListingData),
   });
 
@@ -18,7 +18,6 @@ function TestAdditionalInformation() {
       <AdditionalInformation
         data={mockListingData}
         register={register}
-        getValues={getValues}
         setValue={setValue}
         watch={watch}
       />

--- a/static/js/publisher/pages/Listing/ListingForm/ListingForm.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/ListingForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useForm, useFormState, FieldValues } from "react-hook-form";
 import { Strip, Notification } from "@canonical/react-components";
@@ -26,8 +26,89 @@ type Props = {
   refetch: () => void;
 };
 
+function isFile(value: unknown): value is File {
+  return typeof File !== "undefined" && value instanceof File;
+}
+
+function isEmptyFileList(value: unknown): value is FileList {
+  return (
+    typeof FileList !== "undefined" &&
+    value instanceof FileList &&
+    value.length === 0
+  );
+}
+
+function getComparableListingValues(values: FieldValues): FieldValues {
+  const comparableValues = { ...values };
+
+  if (!comparableValues.public_metrics_enabled) {
+    comparableValues.public_metrics_distros = false;
+    comparableValues.public_metrics_territories = false;
+  }
+
+  Object.entries(comparableValues).forEach(([key, value]) => {
+    if (isEmptyFileList(value)) {
+      delete comparableValues[key];
+    }
+  });
+
+  return comparableValues;
+}
+
+function areFieldValuesEqual(value: unknown, defaultValue: unknown): boolean {
+  if (Object.is(value, defaultValue)) {
+    return true;
+  }
+
+  if (isFile(value) && isFile(defaultValue)) {
+    return (
+      value.name === defaultValue.name &&
+      value.size === defaultValue.size &&
+      value.type === defaultValue.type &&
+      value.lastModified === defaultValue.lastModified
+    );
+  }
+
+  if (Array.isArray(value) && value.length === 1) {
+    return areFieldValuesEqual(value[0], defaultValue);
+  }
+
+  if (Array.isArray(defaultValue) && defaultValue.length === 1) {
+    return areFieldValuesEqual(value, defaultValue[0]);
+  }
+
+  if (Array.isArray(value) && Array.isArray(defaultValue)) {
+    return (
+      value.length === defaultValue.length &&
+      value.every((item, index) =>
+        areFieldValuesEqual(item, defaultValue[index]),
+      )
+    );
+  }
+
+  if (
+    value &&
+    defaultValue &&
+    typeof value === "object" &&
+    typeof defaultValue === "object"
+  ) {
+    const keys = new Set([...Object.keys(value), ...Object.keys(defaultValue)]);
+
+    return [...keys].every((key) =>
+      areFieldValuesEqual(
+        (value as Record<string, unknown>)[key],
+        (defaultValue as Record<string, unknown>)[key],
+      ),
+    );
+  }
+
+  return false;
+}
+
 function ListingForm({ data, refetch }: Props): React.JSX.Element {
   const { snapId } = useParams();
+  const defaultValues = useMemo(() => getDefaultListingData(data), [data]);
+  const [savedValues, setSavedValues] = useState<FieldValues>(defaultValues);
 
   const {
     register,
@@ -40,10 +121,15 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
     handleSubmit,
     watch,
   } = useForm<FieldValues>({
-    defaultValues: getDefaultListingData(data),
+    defaultValues,
   });
 
   const { dirtyFields } = useFormState({ control });
+  const currentValues = watch();
+  const isDirty = !areFieldValuesEqual(
+    getComparableListingValues(currentValues),
+    getComparableListingValues(savedValues),
+  );
 
   const [notificationStrip, setNotificationStrip] =
     useState<StatusNotification>({});
@@ -64,6 +150,7 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
     getDefaultData: getDefaultListingData,
     refetch,
     reset,
+    onSaveSuccess: setSavedValues,
     setStatusNotification: setNotificationStrip,
     setUpdateMetadataOnRelease,
     shouldShowUpdateMetadataWarning,
@@ -104,7 +191,7 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
         <Tour steps={listingTourSteps} />
         <SaveAndPreview
           snapName={snapId || ""}
-          isDirty={formState.isDirty}
+          isDirty={isDirty}
           reset={reset}
           isSaving={isLoading}
           isValid={formState.isValid}
@@ -187,7 +274,6 @@ function ListingForm({ data, refetch }: Props): React.JSX.Element {
           <AdditionalInformation
             data={data}
             register={register}
-            getValues={getValues}
             setValue={setValue}
             watch={watch}
           />

--- a/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
@@ -16,10 +16,14 @@ vi.mock("react-router-dom", async (importOriginal) => ({
   }),
 }));
 
-function renderComponent(updateMetadataOnRelease = false) {
+function renderComponent(
+  updateMetadataOnRelease = false,
+  listingDataOverrides = {},
+) {
   const data = {
     ...mockListingData,
     update_metadata_on_release: updateMetadataOnRelease,
+    ...listingDataOverrides,
   };
   const queryClient = new QueryClient();
 
@@ -66,6 +70,222 @@ describe("ListingForm", () => {
     expect(screen.getByRole("button", { name: "Start tour" })).toBeVisible();
   });
 
+  test("Save and Revert buttons reflect form dirty state", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent();
+    });
+
+    const titleInput = screen.getByRole("textbox", {
+      name: "Title: required",
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    expect(saveButton).toHaveAttribute("aria-disabled", "true");
+    expect(revertButton).toHaveAttribute("aria-disabled", "true");
+
+    await user.type(titleInput, " edited");
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.clear(titleInput);
+    await user.type(titleInput, "test-snap");
+
+    await waitFor(() => {
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.type(titleInput, " edited");
+    await user.click(revertButton);
+
+    await waitFor(() => {
+      expect(titleInput).toHaveValue("test-snap");
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  test("Save and Revert buttons are enabled after changing additional information again", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent();
+    });
+
+    const metricsCheckbox = screen.getByRole("checkbox", {
+      name: "Display public popularity charts",
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    await user.click(metricsCheckbox);
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(revertButton);
+
+    await waitFor(() => {
+      expect(metricsCheckbox).not.toBeChecked();
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(metricsCheckbox);
+
+    await waitFor(() => {
+      expect(metricsCheckbox).toBeChecked();
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  test("Save and Revert buttons are enabled after unchecking enabled public metrics again", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent(false, {
+        public_metrics_blacklist: [],
+        public_metrics_enabled: true,
+      });
+    });
+
+    const metricsCheckbox = screen.getByRole("checkbox", {
+      name: "Display public popularity charts",
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    expect(metricsCheckbox).toBeChecked();
+
+    await user.click(metricsCheckbox);
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(revertButton);
+
+    await waitFor(() => {
+      expect(metricsCheckbox).toBeChecked();
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(metricsCheckbox);
+
+    await waitFor(() => {
+      expect(metricsCheckbox).not.toBeChecked();
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  test("Save and Revert buttons are enabled after changing nested metrics again", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent();
+    });
+
+    const metricsCheckbox = screen.getByRole("checkbox", {
+      name: "Display public popularity charts",
+    });
+    const worldMapCheckbox = screen.getByRole("checkbox", {
+      name: "World map",
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    await user.click(metricsCheckbox);
+    await user.click(worldMapCheckbox);
+    await user.click(revertButton);
+
+    await waitFor(() => {
+      expect(metricsCheckbox).not.toBeChecked();
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(metricsCheckbox);
+    await user.click(worldMapCheckbox);
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  test("Save and Revert buttons are enabled after changing license again", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent();
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    await user.click(screen.getByRole("button", { name: "Remove license" }));
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(revertButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("testing-license")).toBeVisible();
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove license" }));
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  test("Save and Revert buttons are enabled after changing license type again", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent();
+    });
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    await user.click(screen.getByLabelText("Custom SPDX expression"));
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(revertButton);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Simple")).toBeChecked();
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(screen.getByLabelText("Custom SPDX expression"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Custom SPDX expression")).toBeChecked();
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
   test("Notification displayed when update_metadata_on_release", () => {
     renderComponent(true);
     expect(
@@ -89,6 +309,37 @@ describe("ListingForm", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Changes applied successfully.")).toBeVisible();
+    });
+  });
+
+  test("Save and Revert buttons are disabled after successful save", async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      renderComponent(false);
+    });
+
+    const titleInput = screen.getByRole("textbox", {
+      name: "Title: required",
+    });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    const revertButton = screen.getByRole("button", { name: "Revert" });
+
+    await user.type(titleInput, " edited");
+
+    await waitFor(() => {
+      expect(saveButton).not.toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).not.toHaveAttribute("aria-disabled", "true");
+    });
+
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Changes applied successfully.")).toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(saveButton).toHaveAttribute("aria-disabled", "true");
+      expect(revertButton).toHaveAttribute("aria-disabled", "true");
     });
   });
 


### PR DESCRIPTION
## Done

Fixes an issue where the "Save" and "Revert" buttons on the listing page were not disabled after a form had been reset. They also did not return to their disabled state once the form had been successfully saved.

**Note**: The save and preview bar isn't currently sticky, which is an existing bug in production. There is [a separate issue for this](https://warthogs.atlassian.net/browse/WD-38482).

## How to QA
- Go to a snaps listing page, e.g. https://snapcraft-io-5851.demos.haus/steve-test-snap/listing
- Check that the "Save" and "Revert" buttons are disabled
- Make some changes to the form and check that the "Save" and "Revert" buttons become enabled
- Click the "Revert" button and check that the "Save" and "Revert" buttons are now disabled
- Make a change to the form and save it and check that on success the buttons are now disabled
- Go to a snaps settings page, e.g. https://snapcraft-io-5851.demos.haus/steve-test-snap/settings
- Follow the previous QA steps for the listing page

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): User input is already sanitised

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38483

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
