### PR TITLE
fix: Save and preview bar sticky positioning

### DIFF
--- a/static/sass/_snapcraft_l-application.scss
+++ b/static/sass/_snapcraft_l-application.scss
@@ -16,6 +16,10 @@
       }
     }
 
+    .p-panel__content {
+      overflow: visible;
+    }
+
     .l-navigation-bar {
       z-index: 200;
 
@@ -26,10 +30,6 @@
 
     .l-navigation {
       background-color: #262626;
-
-      .p-panel__content {
-        overflow: visible;
-      }
     }
 
     .l-navigation__drawer {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -507,10 +507,6 @@ dl {
   }
 }
 
-.publisher-app > .p-panel > .p-panel__content {
-  overflow: visible;
-}
-
 .releases-track-aside {
   height: 100%;
   position: fixed !important;


### PR DESCRIPTION
## Done
Fixes issue where the save and preview bar isn't sticky

## How to QA
- Go to a snaps listing page, e.g. https://snapcraft-io-5852.demos.haus/steve-test-snap/listing
- Scroll up and down the page and check that the save and preview bar is sticky

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38482

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
