### PR TITLE
feat: add launchpad repo support to auditable feature

### DIFF
--- a/tests/api/tests_launchpad_provenance.py
+++ b/tests/api/tests_launchpad_provenance.py
@@ -1,9 +1,12 @@
+from threading import Lock
 from unittest import TestCase
 from unittest.mock import MagicMock
 
+from webapp.api.exceptions import ApiTimeoutError
 from webapp.api.launchpad_provenance import (
     LaunchpadProvenance,
     extract_github_repository,
+    extract_launchpad_repository,
 )
 
 
@@ -81,6 +84,64 @@ class TestExtractGithubRepository(TestCase):
 
     def test_none(self):
         self.assertIsNone(extract_github_repository(None))
+
+
+class TestExtractLaunchpadRepository(TestCase):
+    def test_project_repository(self):
+        self.assertEqual(
+            extract_launchpad_repository(
+                "https://api.launchpad.net/devel/~mozilla-snaps"
+                "/firefox-snap/+git/firefox-snap"
+            ),
+            "~mozilla-snaps/firefox-snap/+git/firefox-snap",
+        )
+
+    def test_distro_source_package_repository(self):
+        self.assertEqual(
+            extract_launchpad_repository(
+                "https://api.launchpad.net/devel/~hellsworth/ubuntu"
+                "/+source/libreoffice/+git/libreoffice-snap"
+            ),
+            "~hellsworth/ubuntu/+source/libreoffice/+git/libreoffice-snap",
+        )
+
+    def test_personal_repository(self):
+        self.assertEqual(
+            extract_launchpad_repository(
+                "https://api.launchpad.net/devel/~someone/+git/thing"
+            ),
+            "~someone/+git/thing",
+        )
+
+    def test_trailing_slash(self):
+        self.assertEqual(
+            extract_launchpad_repository(
+                "https://api.launchpad.net/devel/~a/b/+git/c/"
+            ),
+            "~a/b/+git/c",
+        )
+
+    def test_redacted_private_repository(self):
+        self.assertIsNone(
+            extract_launchpad_repository("tag:launchpad.net:2008:redacted")
+        )
+
+    def test_non_launchpad_host(self):
+        self.assertIsNone(
+            extract_launchpad_repository(
+                "https://evil.com/?x=api.launchpad.net/devel/~a/+git/b"
+            )
+        )
+
+    def test_not_a_git_link(self):
+        self.assertIsNone(
+            extract_launchpad_repository(
+                "https://api.launchpad.net/devel/~mozilla-snaps"
+            )
+        )
+
+    def test_none(self):
+        self.assertIsNone(extract_launchpad_repository(None))
 
 
 class TestBuildProvenanceMap(TestCase):
@@ -263,6 +324,152 @@ class TestBuildProvenanceMap(TestCase):
         self.assertIsNone(result["github_repository"])
         self.assertIsNone(result["revisions"]["1721"]["amd64"]["commit_url"])
 
+    def test_launchpad_hosted_repo_yields_commit_url(self):
+        recipe = {
+            "entries": [
+                {
+                    "store_name": "firefox",
+                    "git_repository_url": None,
+                    "git_repository_link": (
+                        "https://api.launchpad.net/devel/~mozilla-snaps"
+                        "/firefox-snap/+git/firefox-snap"
+                    ),
+                    "completed_builds_collection_link": "https://lp/p1",
+                }
+            ]
+        }
+        page = {
+            "entries": [_build("amd64", 8763, "659a47f4")],
+            "next_collection_link": None,
+        }
+
+        client = self._client(recipe, [page])
+        result = client.build_provenance_map(
+            "firefox", max_pages=5, max_recipes=5
+        )
+
+        self.assertIsNone(result["github_repository"])
+        self.assertEqual(
+            result["launchpad_repository"],
+            "~mozilla-snaps/firefox-snap/+git/firefox-snap",
+        )
+        amd64 = result["revisions"]["8763"]["amd64"]
+        self.assertEqual(
+            amd64["commit_url"],
+            "https://git.launchpad.net/~mozilla-snaps/firefox-snap"
+            "/+git/firefox-snap/commit/?id=659a47f4",
+        )
+
+    def test_github_wins_over_launchpad_link(self):
+        recipe = {
+            "entries": [
+                {
+                    "store_name": "mumble",
+                    "git_repository_url": (
+                        "https://github.com/snapcrafters/mumble"
+                    ),
+                    "git_repository_link": (
+                        "https://api.launchpad.net/devel/~x/+git/y"
+                    ),
+                    "completed_builds_collection_link": "https://lp/p1",
+                }
+            ]
+        }
+        page = {
+            "entries": [_build("amd64", 1721, "aaa")],
+            "next_collection_link": None,
+        }
+
+        client = self._client(recipe, [page])
+        result = client.build_provenance_map(
+            "mumble", max_pages=5, max_recipes=5
+        )
+
+        self.assertEqual(
+            result["revisions"]["1721"]["amd64"]["commit_url"],
+            "https://github.com/snapcrafters/mumble/commit/aaa",
+        )
+
+    def test_timeout_is_reported_as_launchpad_timeout(self):
+        recipe = {
+            "entries": [
+                {
+                    "store_name": "mumble",
+                    "git_repository_url": (
+                        "https://github.com/snapcrafters/mumble"
+                    ),
+                    "completed_builds_collection_link": "https://lp/p1",
+                }
+            ]
+        }
+        session = MagicMock()
+
+        def get(url, params=None):
+            if url.endswith("+snaps"):
+                return _response(recipe)
+            raise ApiTimeoutError("took too long")
+
+        session.get.side_effect = get
+        client = LaunchpadProvenance(session=session)
+        result = client.build_provenance_map(
+            "mumble", max_pages=5, max_recipes=5
+        )
+
+        self.assertTrue(result["failed"])
+        self.assertEqual(result["reason"], "launchpad_timeout")
+
+    def test_other_errors_are_reported_as_launchpad_error(self):
+        recipe = {
+            "entries": [
+                {
+                    "store_name": "mumble",
+                    "git_repository_url": (
+                        "https://github.com/snapcrafters/mumble"
+                    ),
+                    "completed_builds_collection_link": "https://lp/p1",
+                }
+            ]
+        }
+        session = MagicMock()
+
+        def get(url, params=None):
+            if url.endswith("+snaps"):
+                return _response(recipe)
+            raise Exception("boom")
+
+        session.get.side_effect = get
+        client = LaunchpadProvenance(session=session)
+        result = client.build_provenance_map(
+            "mumble", max_pages=5, max_recipes=5
+        )
+
+        self.assertEqual(result["reason"], "launchpad_error")
+
+    def test_successful_scan_has_no_reason(self):
+        recipe = {
+            "entries": [
+                {
+                    "store_name": "mumble",
+                    "git_repository_url": (
+                        "https://github.com/snapcrafters/mumble"
+                    ),
+                    "completed_builds_collection_link": "https://lp/p1",
+                }
+            ]
+        }
+        page = {
+            "entries": [_build("amd64", 1721, "aaa")],
+            "next_collection_link": None,
+        }
+
+        client = self._client(recipe, [page])
+        result = client.build_provenance_map(
+            "mumble", max_pages=5, max_recipes=5
+        )
+
+        self.assertFalse(result["failed"])
+        self.assertIsNone(result["reason"])
+
     def test_no_recipe_returns_empty(self):
         session = MagicMock()
         session.get.return_value = _response({"entries": []})
@@ -418,19 +625,20 @@ class TestRecipeSelection(TestCase):
 
         self.assertEqual(len(scanned), 2)
 
-    def test_a_failing_recipe_stops_the_scan(self):
-        # Each request costs up to 12s, so failures must not stack up.
+    def test_failing_recipes_do_not_stack_up(self):
         entries = [
             _recipe(f"r{i}", None, f"https://lp/r{i}") for i in range(4)
         ]
         attempts = []
+        lock = Lock()
 
         session = MagicMock()
 
         def get(url, params=None):
             if url.endswith("+snaps"):
                 return _response({"entries": entries})
-            attempts.append(url)
+            with lock:
+                attempts.append(url)
             raise Exception("read timed out")
 
         session.get.side_effect = get
@@ -440,4 +648,6 @@ class TestRecipeSelection(TestCase):
         )
 
         self.assertTrue(result["failed"])
-        self.assertEqual(len(attempts), 1)
+        self.assertEqual(
+            sorted(attempts), [f"https://lp/r{i}" for i in range(4)]
+        )

--- a/tests/api/tests_launchpad_provenance.py
+++ b/tests/api/tests_launchpad_provenance.py
@@ -150,11 +150,13 @@ class TestBuildProvenanceMap(TestCase):
         lookup and successive build pages for the collection link."""
         session = MagicMock()
         pages = iter(build_pages)
+        lock = Lock()
 
         def get(url, params=None):
             if url.endswith("+snaps"):
                 return _response(recipe)
-            return _response(next(pages))
+            with lock:
+                return _response(next(pages))
 
         session.get.side_effect = get
         return LaunchpadProvenance(session=session)
@@ -469,6 +471,31 @@ class TestBuildProvenanceMap(TestCase):
 
         self.assertFalse(result["failed"])
         self.assertIsNone(result["reason"])
+
+    def test_recipe_lookup_timeout_reports_launchpad_timeout(self):
+        session = MagicMock()
+        session.get.side_effect = ApiTimeoutError("took too long")
+        client = LaunchpadProvenance(session=session)
+
+        result = client.build_provenance_map(
+            "mumble", max_pages=5, max_recipes=5
+        )
+
+        self.assertTrue(result["failed"])
+        self.assertEqual(result["reason"], "launchpad_timeout")
+        self.assertEqual(result["revisions"], {})
+
+    def test_recipe_lookup_error_reports_launchpad_error(self):
+        session = MagicMock()
+        session.get.side_effect = Exception("boom")
+        client = LaunchpadProvenance(session=session)
+
+        result = client.build_provenance_map(
+            "mumble", max_pages=5, max_recipes=5
+        )
+
+        self.assertTrue(result["failed"])
+        self.assertEqual(result["reason"], "launchpad_error")
 
     def test_no_recipe_returns_empty(self):
         session = MagicMock()

--- a/tests/api/tests_launchpad_provenance.py
+++ b/tests/api/tests_launchpad_provenance.py
@@ -652,7 +652,7 @@ class TestRecipeSelection(TestCase):
 
         self.assertEqual(len(scanned), 2)
 
-    def test_failing_recipes_do_not_stack_up(self):
+    def test_failure_does_not_short_circuit_other_recipes(self):
         entries = [
             _recipe(f"r{i}", None, f"https://lp/r{i}") for i in range(4)
         ]

--- a/tests/endpoints/tests_snaps_auditable.py
+++ b/tests/endpoints/tests_snaps_auditable.py
@@ -256,7 +256,7 @@ class TestAuditableEndpoint(TestEndpoints):
                 "reason": "unexpected_error",
             },
         )
-        self.assertEqual(response.cache_control.max_age, 0)
+        self.assertEqual(response.cache_control.max_age, FAILED_PROVENANCE_TTL)
 
     @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
     @patch("webapp.endpoints.snaps.launchpad_provenance.build_provenance_map")
@@ -465,7 +465,7 @@ class TestAuditableRevisionsEndpoint(TestEndpoints):
                 "reason": "unexpected_error",
             },
         )
-        self.assertEqual(response.cache_control.max_age, 0)
+        self.assertEqual(response.cache_control.max_age, FAILED_PROVENANCE_TTL)
 
     @patch("webapp.endpoints.snaps.launchpad_provenance.build_provenance_map")
     def test_revisions_omitted_when_repository_is_gone(self, mock_map):

--- a/tests/endpoints/tests_snaps_auditable.py
+++ b/tests/endpoints/tests_snaps_auditable.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from tests.endpoints.endpoint_testing import TestEndpoints
+from webapp.api.exceptions import ApiTimeoutError
 from webapp.endpoints.snaps import (
     FAILED_PROVENANCE_TTL,
     _get_provenance_map,
@@ -35,12 +36,14 @@ def _provenance(
     revisions,
     github_repository="snapcrafters/mumble",
     failed=False,
+    reason=None,
 ):
     return {
         "github_repository": github_repository,
         "git_repository_url": "https://github.com/snapcrafters/mumble",
         "revisions": revisions,
         "failed": failed,
+        "reason": reason,
     }
 
 
@@ -246,7 +249,12 @@ class TestAuditableEndpoint(TestEndpoints):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.get_json(), {"auditable": False, "status": "error"}
+            response.get_json(),
+            {
+                "auditable": False,
+                "status": "error",
+                "reason": "unexpected_error",
+            },
         )
         self.assertEqual(response.cache_control.max_age, 0)
 
@@ -335,6 +343,80 @@ class TestAuditableEndpoint(TestEndpoints):
         self.assertTrue(data["auditable"])
         self.assertEqual(data["status"], "verified")
 
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    @patch("webapp.endpoints.snaps.launchpad_provenance.build_provenance_map")
+    def test_default_channel_arch_without_that_risk_is_skipped(
+        self, mock_map, mock_details
+    ):
+        mock_details.return_value = _details(
+            [
+                _channel("amd64", "latest", "edge", 900),
+                _channel("arm64", "latest", "stable", 1721),
+            ]
+        )
+        mock_map.return_value = _provenance(
+            {"1721": {"arm64": VERIFIED_BUILD}}
+        )
+
+        data = self.client.get("/api/mumble/auditable").get_json()
+
+        self.assertEqual(data["architecture"], "arm64")
+        self.assertEqual(data["revision"], 1721)
+        self.assertTrue(data["auditable"])
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    @patch("webapp.endpoints.snaps.launchpad_provenance.build_provenance_map")
+    def test_amd64_preferred_when_it_publishes_the_default_channel(
+        self, mock_map, mock_details
+    ):
+        mock_details.return_value = _details(
+            [
+                _channel("arm64", "latest", "stable", 1798),
+                _channel("amd64", "latest", "stable", 1721),
+            ]
+        )
+        mock_map.return_value = _provenance(
+            {"1721": {"amd64": VERIFIED_BUILD}}
+        )
+
+        data = self.client.get("/api/mumble/auditable").get_json()
+
+        self.assertEqual(data["architecture"], "amd64")
+        self.assertEqual(data["revision"], 1721)
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    @patch("webapp.endpoints.snaps.launchpad_provenance.build_provenance_map")
+    def test_error_carries_the_failure_reason(self, mock_map, mock_details):
+        mock_details.return_value = _details(
+            [_channel("amd64", "latest", "stable", 1721)]
+        )
+        mock_map.return_value = _provenance(
+            {}, failed=True, reason="launchpad_timeout"
+        )
+
+        data = self.client.get("/api/mumble/auditable").get_json()
+
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["reason"], "launchpad_timeout")
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_store_timeout_is_reported(self, mock_details):
+        mock_details.side_effect = ApiTimeoutError("took too long")
+
+        data = self.client.get("/api/mumble/auditable").get_json()
+
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["reason"], "store_timeout")
+
+    @patch("webapp.endpoints.snaps.device_gateway.get_item_details")
+    def test_unexpected_errors_are_distinguishable(self, mock_details):
+        mock_details.side_effect = AttributeError("bug in our own code")
+
+        data = self.client.get("/api/mumble/auditable").get_json()
+
+        self.assertEqual(data["status"], "error")
+        self.assertEqual(data["reason"], "unexpected_error")
+
 
 class TestAuditableRevisionsEndpoint(TestEndpoints):
     def setUp(self):
@@ -376,7 +458,12 @@ class TestAuditableRevisionsEndpoint(TestEndpoints):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.get_json(),
-            {"github_repository": None, "revisions": {}, "error": True},
+            {
+                "github_repository": None,
+                "revisions": {},
+                "error": True,
+                "reason": "unexpected_error",
+            },
         )
         self.assertEqual(response.cache_control.max_age, 0)
 

--- a/webapp/api/launchpad_provenance.py
+++ b/webapp/api/launchpad_provenance.py
@@ -1,7 +1,11 @@
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 
+from webapp.api.exceptions import ApiTimeoutError
 from webapp.api.requests import Session
+
+MAX_CONCURRENT_SCANS = 10
 
 LAUNCHPAD_API_URL = os.getenv(
     "LAUNCHPAD_API_URL", "https://api.launchpad.net/devel/"
@@ -12,6 +16,17 @@ GITHUB_URL_RE = re.compile(
     r"^(?:https?://)?(?:www\.)?github\.com/"
     r"(?P<repo>[^/]+/[^/]+?)(?:\.git)?/?$"
 )
+
+LAUNCHPAD_GIT_RE = re.compile(
+    r"^https?://api\.launchpad\.net/[^/]+/"
+    r"(?P<path>~[^/]+/(?:[^/]+/)*\+git/[^/]+?)/?$"
+)
+
+
+def failure_reason(exc):
+    if isinstance(exc, ApiTimeoutError):
+        return "launchpad_timeout"
+    return "launchpad_error"
 
 
 def extract_github_repository(git_repository_url):
@@ -29,6 +44,44 @@ def extract_github_repository(git_repository_url):
     return None
 
 
+def extract_launchpad_repository(git_repository_link):
+    """Extract the git.launchpad.net path from a Launchpad link"""
+    if not git_repository_link:
+        return None
+
+    match = LAUNCHPAD_GIT_RE.match(git_repository_link)
+    if match:
+        return match.groupdict()["path"]
+    return None
+
+
+def build_commit_url(source, commit_sha):
+    """Build a browsable commit URL for a recipe's source"""
+    if source.get("github_repository"):
+        return (
+            f"https://github.com/{source['github_repository']}"
+            f"/commit/{commit_sha}"
+        )
+    if source.get("launchpad_repository"):
+        return (
+            f"https://git.launchpad.net/{source['launchpad_repository']}"
+            f"/commit/?id={commit_sha}"
+        )
+    return None
+
+
+def recipe_source(recipe):
+    """Resolve where a recipe's source is hosted."""
+    git_repository_url = recipe.get("git_repository_url")
+    return {
+        "git_repository_url": git_repository_url,
+        "github_repository": extract_github_repository(git_repository_url),
+        "launchpad_repository": extract_launchpad_repository(
+            recipe.get("git_repository_link")
+        ),
+    }
+
+
 class LaunchpadProvenance:
     """Read-only, anonymous client for Launchpad build provenance.
 
@@ -40,13 +93,21 @@ class LaunchpadProvenance:
 
     def __init__(self, session=None, api_url=LAUNCHPAD_API_URL):
         self.api_url = api_url
+        self._owns_session = session is None
         self.session = session or Session()
         self.session.headers["Accept"] = "application/json"
 
-    def _get(self, url, params=None):
-        response = self.session.get(url, params=params)
+    def _get(self, url, params=None, session=None):
+        response = (session or self.session).get(url, params=params)
         response.raise_for_status()
         return response.json()
+
+    def _new_session(self):
+        if not self._owns_session:
+            return self.session
+        session = Session()
+        session.headers["Accept"] = "application/json"
+        return session
 
     def get_recipes(self, store_name, max_recipes):
         """Find the public Launchpad recipes for a store name, best first.
@@ -77,28 +138,31 @@ class LaunchpadProvenance:
 
         return matches[:max_recipes]
 
-    def iter_builds(self, collection_link, max_pages):
-        """Collect completed builds, up to ``max_pages`` pages.
-
-        Returns ``(entries, failed)``; whatever was gathered is returned
-        even when a page request errored.
-        """
+    def iter_builds(self, collection_link, max_pages, session=None):
+        """Collect completed builds"""
         entries = []
         url = collection_link
         pages = 0
 
         while url and pages < max_pages:
             try:
-                data = self._get(url)
-            except Exception:
-                return entries, True
+                data = self._get(url, session=session)
+            except Exception as exc:
+                return entries, failure_reason(exc)
             entries.extend(data.get("entries", []))
             url = data.get("next_collection_link")
             pages += 1
 
-        return entries, False
+        return entries, None
 
-    def _merge_builds(self, builds, github_repository, revisions):
+    def _scan_recipe(self, recipe, max_pages):
+        return self.iter_builds(
+            recipe["completed_builds_collection_link"],
+            max_pages,
+            session=self._new_session(),
+        )
+
+    def _merge_builds(self, builds, source, revisions):
         """Fold one recipe's builds into the shared revision map.
 
         Returns True if anything was added; earlier recipes win on conflict.
@@ -122,12 +186,7 @@ class LaunchpadProvenance:
             if arch in arch_map:
                 continue
 
-            commit_url = None
-            if github_repository:
-                commit_url = (
-                    f"https://github.com/{github_repository}"
-                    f"/commit/{commit_sha}"
-                )
+            commit_url = build_commit_url(source, commit_sha)
 
             build_id = None
             build_url = None
@@ -146,7 +205,8 @@ class LaunchpadProvenance:
                 "build_url": build_url,
                 # Per entry: a merged map can span recipes with different
                 # sources.
-                "github_repository": github_repository,
+                "github_repository": source.get("github_repository"),
+                "launchpad_repository": source.get("launchpad_repository"),
             }
             added = True
 
@@ -158,6 +218,7 @@ class LaunchpadProvenance:
         Shape:
             {
                 "github_repository": "owner/repo" | None,
+                "launchpad_repository": "~owner/proj/+git/name" | None,
                 "git_repository_url": "https://..." | None,
                 "revisions": {
                     "<store_revision>": {
@@ -180,52 +241,66 @@ class LaunchpadProvenance:
 
         result = {
             "github_repository": None,
+            "launchpad_repository": None,
             "git_repository_url": None,
             "revisions": {},
             # Set when an upstream request failed, so callers can avoid
             # caching a transient failure as a negative answer.
             "failed": False,
+            "reason": None,
         }
 
         if not recipes:
             return result
 
+        candidates = [
+            recipe
+            for recipe in recipes
+            if recipe.get("completed_builds_collection_link")
+        ]
+        if not candidates:
+            return result
+
         # Share the page budget across candidates: revisions being resolved
         # are recent and builds are newest first, so breadth beats depth.
-        pages_each = max(1, max_pages // len(recipes))
+        pages_each = max(1, max_pages // len(candidates))
+
+        # receopes are fetched in parallel
+        with ThreadPoolExecutor(
+            max_workers=min(MAX_CONCURRENT_SCANS, len(candidates))
+        ) as executor:
+            scans = list(
+                executor.map(
+                    lambda recipe: self._scan_recipe(recipe, pages_each),
+                    candidates,
+                )
+            )
+
         revisions = result["revisions"]
         source = None
         fallback = None
 
-        for recipe in recipes:
-            collection_link = recipe.get("completed_builds_collection_link")
-            if not collection_link:
-                continue
-
-            git_repository_url = recipe.get("git_repository_url")
-            github_repository = extract_github_repository(git_repository_url)
+        for recipe, (builds, reason) in zip(candidates, scans):
+            recipe_src = recipe_source(recipe)
             if fallback is None:
-                fallback = (git_repository_url, github_repository)
-
-            builds, failed = self.iter_builds(collection_link, pages_each)
+                fallback = recipe_src
 
             if (
-                self._merge_builds(builds, github_repository, revisions)
+                self._merge_builds(builds, recipe_src, revisions)
                 and source is None
             ):
                 # The recipe that produced revisions, not the first sorted.
-                source = (git_repository_url, github_repository)
+                source = recipe_src
 
-            if failed:
-                # Launchpad is struggling, scanning the remaining candidates
-                # would just queue up more 12s timeouts on this request.
+            if reason and not result["failed"]:
                 result["failed"] = True
-                break
+                result["reason"] = reason
 
         if source is None:
             source = fallback
         if source:
-            result["git_repository_url"] = source[0]
-            result["github_repository"] = source[1]
+            result["git_repository_url"] = source["git_repository_url"]
+            result["github_repository"] = source["github_repository"]
+            result["launchpad_repository"] = source["launchpad_repository"]
 
         return result

--- a/webapp/api/launchpad_provenance.py
+++ b/webapp/api/launchpad_provenance.py
@@ -156,11 +156,16 @@ class LaunchpadProvenance:
         return entries, None
 
     def _scan_recipe(self, recipe, max_pages):
-        return self.iter_builds(
-            recipe["completed_builds_collection_link"],
-            max_pages,
-            session=self._new_session(),
-        )
+        session = self._new_session()
+        try:
+            return self.iter_builds(
+                recipe["completed_builds_collection_link"],
+                max_pages,
+                session=session,
+            )
+        finally:
+            if session is not self.session:
+                session.close()
 
     def _merge_builds(self, builds, source, revisions):
         """Fold one recipe's builds into the shared revision map.
@@ -237,8 +242,6 @@ class LaunchpadProvenance:
         Only uploaded builds with a ``revision_id`` are included; revision
         keys are strings so the map survives JSON round-trips.
         """
-        recipes = self.get_recipes(store_name, max_recipes)
-
         result = {
             "github_repository": None,
             "launchpad_repository": None,
@@ -249,6 +252,13 @@ class LaunchpadProvenance:
             "failed": False,
             "reason": None,
         }
+
+        try:
+            recipes = self.get_recipes(store_name, max_recipes)
+        except Exception as exc:
+            result["failed"] = True
+            result["reason"] = failure_reason(exc)
+            return result
 
         if not recipes:
             return result

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -20,7 +20,7 @@ BSI_URL = os.getenv("BSI_URL", "https://build.snapcraft.io")
 LP_MAX_BUILD_PAGES = int(os.getenv("LP_MAX_BUILD_PAGES", "5"))
 # Max Launchpad recipes to scan per store name: one name can match dozens
 # (firefox has 62), so the right one is rarely the first.
-LP_MAX_RECIPES = int(os.getenv("LP_MAX_RECIPES", "5"))
+LP_MAX_RECIPES = int(os.getenv("LP_MAX_RECIPES", "20"))
 ENVIRONMENT = os.getenv("ENVIRONMENT", "devel")
 IS_DEVELOPMENT = ENVIRONMENT == "devel"
 COMMIT_ID = os.getenv("COMMIT_ID", "commit_id")

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -248,7 +248,7 @@ def auditable(snap_name):
 
     response = make_response(res, 200)
     response.cache_control.max_age = (
-        0 if res.get("status") == "error" else 3600
+        FAILED_PROVENANCE_TTL if res.get("status") == "error" else 3600
     )
     return response
 
@@ -257,14 +257,7 @@ def auditable(snap_name):
     '/api/<regex("' + snap_regex + '"):snap_name>/auditable-revisions'
 )
 def auditable_revisions(snap_name):
-    """Public endpoint backing the Security tab's per-revision commit links.
-
-    Returns commit links for the snap's recent revisions (bounded by
-    LP_MAX_BUILD_PAGES). Revisions without provenance are simply absent.
-    ``error`` is true when Launchpad couldn't be reached, so the Security
-    tab can distinguish "no provenance" from "couldn't load right now". A
-    truncated scan is not an error: this endpoint is bounded by design.
-    """
+    """Public endpoint backing the Security tab's per-revision commit links """
     res = {
         "github_repository": None,
         "revisions": {},
@@ -300,7 +293,9 @@ def auditable_revisions(snap_name):
         }
 
     response = make_response(res, 200)
-    response.cache_control.max_age = 0 if res.get("error") else 3600
+    response.cache_control.max_age = (
+        FAILED_PROVENANCE_TTL if res.get("error") else 3600
+    )
     return response
 
 

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -10,6 +10,7 @@ import webapp.helpers as helpers
 from webapp.decorators import login_required, exchange_required
 from webapp.store import logic
 from webapp.config import LP_MAX_BUILD_PAGES, LP_MAX_RECIPES
+from webapp.api.exceptions import ApiError, ApiTimeoutError
 from webapp.api.github import repository_is_public
 from webapp.api.launchpad_provenance import LaunchpadProvenance
 from webapp.endpoints.utils import get_auditable_map_cache_key
@@ -100,6 +101,14 @@ def dns_verified_status(snap_name):
     return response
 
 
+def _request_failure_reason(exc):
+    if isinstance(exc, ApiTimeoutError):
+        return "store_timeout"
+    if isinstance(exc, ApiError):
+        return "store_error"
+    return "unexpected_error"
+
+
 def _get_provenance_map(snap_name):
     """Return the (cached) Launchpad provenance map for a snap.
 
@@ -141,7 +150,17 @@ def _resolve_default_install(details):
     default_track = details.get("default-track") or "latest"
     lowest_risk = logic.get_lowest_available_risk(channel_maps, default_track)
 
-    architecture = logic.get_default_architecture(channel_maps.keys())
+    published = [
+        arch
+        for arch, tracks in channel_maps.items()
+        if any(
+            release["risk"] == lowest_risk
+            for release in tracks.get(default_track, [])
+        )
+    ]
+    architecture = logic.get_default_architecture(
+        published or channel_maps.keys()
+    )
 
     releases = channel_maps.get(architecture, {}).get(default_track, [])
     for release in releases:
@@ -153,22 +172,7 @@ def _resolve_default_install(details):
 
 @snaps.route('/api/<regex("' + snap_regex + '"):snap_name>/auditable')
 def auditable(snap_name):
-    """Public endpoint backing the provenance badge under the Install button.
-
-    Returns the git commit the default install revision was built from on
-    Launchpad. The ``status`` field distinguishes every outcome so the badge
-    can react:
-
-    - ``verified``: built on Launchpad from a public commit (commit returned).
-    - ``unavailable``: a public GitHub recipe exists, but this revision has no
-      matching build (e.g. uploaded manually).
-    - ``not-provided``: no public provenance — no Launchpad recipe, or the
-      recipe's repo is private / non-GitHub.
-    - ``error``: Launchpad couldn't be reached, so retrying may help. A scan
-      that merely hit its bounds is normal, not an error.
-
-    Never raises to the user.
-    """
+    """Public endpoint backing the provenance badge under the Install button"""
     res = {"auditable": False, "status": "not-provided"}
 
     try:
@@ -187,6 +191,9 @@ def auditable(snap_name):
             github_repository = (build or {}).get(
                 "github_repository"
             ) or provenance_map.get("github_repository")
+            launchpad_repository = (build or {}).get(
+                "launchpad_repository"
+            ) or provenance_map.get("launchpad_repository")
 
             base = {
                 "auditable": False,
@@ -203,6 +210,7 @@ def auditable(snap_name):
                     "status": "verified",
                     "commit_sha": build["commit_sha"],
                     "github_repository": github_repository,
+                    "launchpad_repository": launchpad_repository,
                     "commit_url": build["commit_url"],
                     "build_id": build.get("build_id"),
                     "build_url": build.get("build_url"),
@@ -215,19 +223,28 @@ def auditable(snap_name):
             elif provenance_map.get("failed"):
                 # Only a real failure earns the error state, since it is the
                 # only case where "try again later" is true.
-                res = {**base, "status": "error"}
-            elif github_repository:
+                res = {
+                    **base,
+                    "status": "error",
+                    "reason": provenance_map.get("reason"),
+                }
+            elif github_repository or launchpad_repository:
                 # Public recipe exists, but this revision has no build/commit.
                 res = {
                     **base,
                     "status": "unavailable",
                     "github_repository": github_repository,
+                    "launchpad_repository": launchpad_repository,
                 }
             else:
-                # No public recipe (private or non-GitHub source).
+                # No public recipe.
                 res = {**base, "status": "not-provided"}
-    except Exception:
-        res = {"auditable": False, "status": "error"}
+    except Exception as exc:
+        res = {
+            "auditable": False,
+            "status": "error",
+            "reason": _request_failure_reason(exc),
+        }
 
     response = make_response(res, 200)
     response.cache_control.max_age = (
@@ -248,12 +265,18 @@ def auditable_revisions(snap_name):
     tab can distinguish "no provenance" from "couldn't load right now". A
     truncated scan is not an error: this endpoint is bounded by design.
     """
-    res = {"github_repository": None, "revisions": {}, "error": False}
+    res = {
+        "github_repository": None,
+        "revisions": {},
+        "error": False,
+        "reason": None,
+    }
 
     try:
         provenance_map = _get_provenance_map(snap_name)
         res["github_repository"] = provenance_map.get("github_repository")
         res["error"] = bool(provenance_map.get("failed"))
+        res["reason"] = provenance_map.get("reason")
 
         # If the repository is gone, every commit link would 404.
         if provenance_map.get("source_available", True):
@@ -268,8 +291,13 @@ def auditable_revisions(snap_name):
                             "build_url": build.get("build_url"),
                         }
                         break
-    except Exception:
-        res = {"github_repository": None, "revisions": {}, "error": True}
+    except Exception as exc:
+        res = {
+            "github_repository": None,
+            "revisions": {},
+            "error": True,
+            "reason": _request_failure_reason(exc),
+        }
 
     response = make_response(res, 200)
     response.cache_control.max_age = 0 if res.get("error") else 3600

--- a/webapp/endpoints/snaps.py
+++ b/webapp/endpoints/snaps.py
@@ -257,7 +257,7 @@ def auditable(snap_name):
     '/api/<regex("' + snap_regex + '"):snap_name>/auditable-revisions'
 )
 def auditable_revisions(snap_name):
-    """Public endpoint backing the Security tab's per-revision commit links """
+    """Public endpoint backing the Security tab's per-revision commit links"""
     res = {
         "github_repository": None,
         "revisions": {},


### PR DESCRIPTION
## Done
Adde launchpad repository support for auditable snaps

## How to QA
- demos doesnt work:( because of "push access denied, repository does not exist or may require authorization: authorization failed: no basic auth credentials"
- checkout to feature branch
- go to http://localhost:8004/microcloud#tab-security
- Check the audability badge 
- click on the build
- verify launchpad build is opened
- find the "VCS revision"
- click on the commit link 
- verify launchpad commit change is opened
- verify the commit hashes matches.
- open the security tab
- verify links are working.
- go to http://localhost:8004/ghostwriter#tab-security
- Verify links work for git repos as well.

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38474

## Screenshots

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
