### PR TITLE
chore: Convert listing page buttons and icons to Pragma

### DIFF
--- a/static/js/publisher/pages/Listing/ContactInformation/ContactFields.tsx
+++ b/static/js/publisher/pages/Listing/ContactInformation/ContactFields.tsx
@@ -5,7 +5,8 @@ import {
   UseFormGetValues,
   UseFormRegister,
 } from "react-hook-form";
-import { Row, Col, Button, Icon } from "@canonical/react-components";
+import { Row, Col } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-ds-global";
 
 type Props = {
   register: UseFormRegister<FieldValues>;
@@ -37,7 +38,7 @@ function ContactFields({
           <Col size={5}>
             <Button
               type="button"
-              appearance="link"
+              variant="link"
               onClick={() => {
                 append({ url: "" });
               }}
@@ -68,12 +69,12 @@ function ContactFields({
           <Col size={2}>
             <Button
               type="button"
-              appearance="base"
+              importance="tertiary"
               onClick={() => {
                 remove(index);
               }}
             >
-              <Icon name="delete" />
+              <Icon icon="delete" />
               <span className="u-off-screen">Remove this link</span>
             </Button>
           </Col>
@@ -85,7 +86,7 @@ function ContactFields({
           <Col size={5} emptyLarge={3}>
             <Button
               type="button"
-              appearance="link"
+              variant="link"
               onClick={() => {
                 append({ url: "" });
               }}

--- a/static/js/publisher/pages/Listing/ListingDetails/ImageUpload.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/ImageUpload.tsx
@@ -12,9 +12,9 @@ import {
   Col,
   Notification,
   Switch,
-  Icon,
   loadTheme,
 } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-ds-global";
 
 import { validateImageDimensions } from "../../../utils";
 
@@ -228,9 +228,7 @@ function ImageUpload({
                     height: `${previewHeight}px`,
                   }}
                 >
-                  <Icon name="plus" light={isDark}>
-                    Add image
-                  </Icon>
+                  <Icon icon="plus">Add image</Icon>
                 </div>
               )}
               <input
@@ -256,9 +254,9 @@ function ImageUpload({
             </div>
 
             {showDeleteButton() && (
-              <button
+              <Button
                 type="button"
-                className={`p-button--base snap-remove-icon ${!darkThemeEnabled && "is-light"}`}
+                className="snap-remove-icon"
                 onClick={() => {
                   setImageIsValid(true);
                   setValue(imageUrlFieldKey, "", {
@@ -267,10 +265,11 @@ function ImageUpload({
                   setValue(imageFieldKey, new File([], ""));
                   setPreviewImageUrl("");
                 }}
+                importance={darkThemeEnabled ? "primary" : "tertiary"}
               >
-                <Icon name="delete" light={isDark} />
+                <Icon icon="delete" />
                 <span className="u-off-screen">Remove {type}</span>
-              </button>
+              </Button>
             )}
           </div>
 
@@ -301,9 +300,9 @@ function ImageUpload({
 
         {helpText && <div className="p-form-help-text">{helpText}</div>}
 
-        <button
+        <Button
           type="button"
-          className="p-button--link"
+          variant="link"
           onClick={() => {
             setShowImageRestrictions(!showImageRestrictions);
           }}
@@ -323,7 +322,7 @@ function ImageUpload({
               </>
             )}
           </small>
-        </button>
+        </Button>
         {showImageRestrictions && (
           <ul>
             <li>

--- a/static/js/publisher/pages/Listing/ListingDetails/ListingDetails.tsx
+++ b/static/js/publisher/pages/Listing/ListingDetails/ListingDetails.tsx
@@ -7,7 +7,8 @@ import type {
   Control,
   FormState,
 } from "react-hook-form";
-import { Row, Col, Button, Icon } from "@canonical/react-components";
+import { Row, Col } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-ds-global";
 
 import ImageUpload from "./ImageUpload";
 import Screenshots from "./Screenshots";
@@ -226,7 +227,7 @@ function ListingDetails({
           <Col size={2}>
             <Button
               type="button"
-              appearance="base"
+              importance="tertiary"
               onClick={() => {
                 setValue("secondary_category", "", {
                   shouldDirty: data.secondary_category !== "",
@@ -234,7 +235,7 @@ function ListingDetails({
                 setHasSecondCategory(false);
               }}
             >
-              <Icon name="delete" />
+              <Icon icon="delete" />
               <span className="u-off-screen">Remove secondary category</span>
             </Button>
           </Col>
@@ -246,7 +247,7 @@ function ListingDetails({
           <Col size={5} emptyLarge={3}>
             <Button
               type="button"
-              appearance="link"
+              variant="link"
               className="u-no-margin--bottom"
               onClick={() => {
                 setHasSecondCategory(true);
@@ -391,8 +392,8 @@ function ListingDetails({
             )}
           </div>
           <Button
-            appearance="link"
             type="button"
+            variant="link"
             onClick={() => {
               setShowSupportedMarkdownSyntax(!showSupportedMarkdownSyntax);
             }}

--- a/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
@@ -31,8 +31,17 @@ vi.mock("@canonical/react-ds-global", () => {
     </button>
   );
 
+  const Icon = ({
+    children: _children,
+    icon: _icon,
+  }: {
+    children?: React.ReactNode;
+    icon: string;
+  }) => <span aria-hidden="true" />;
+
   return {
     Button,
+    Icon,
     withTooltip: (Component: React.ComponentType) => Component,
   };
 });

--- a/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
@@ -31,8 +31,17 @@ vi.mock("@canonical/react-ds-global", () => {
     </button>
   );
 
+  const Icon = ({
+    children: _children,
+    icon: _icon,
+  }: {
+    children?: React.ReactNode;
+    icon: string;
+  }) => <span aria-hidden="true" />;
+
   return {
     Button,
+    Icon,
     withTooltip: (Component: React.ComponentType) => Component,
   };
 });

--- a/static/js/publisher/pages/Listing/__tests__/Listing.test.tsx
+++ b/static/js/publisher/pages/Listing/__tests__/Listing.test.tsx
@@ -30,8 +30,17 @@ vi.mock("@canonical/react-ds-global", () => {
     </button>
   );
 
+  const Icon = ({
+    children: _children,
+    icon: _icon,
+  }: {
+    children?: React.ReactNode;
+    icon: string;
+  }) => <span aria-hidden="true" />;
+
   return {
     Button,
+    Icon,
     withTooltip: (Component: React.ComponentType) => Component,
   };
 });

--- a/static/sass/_pragma-migration-overrides.scss
+++ b/static/sass/_pragma-migration-overrides.scss
@@ -8,5 +8,13 @@
     &.button:disabled {
       opacity: 1;
     }
+
+    // Pragma sets a background colour for tertiary buttons whereas
+    // Vanilla set the background to transparent. In this instance the button
+    // is set against a background with a slightly darker colour which it
+    // needs to inherit
+    &.button.snap-remove-icon {
+      background-color: transparent;
+    }
   }
 }

--- a/static/sass/_snapcraft_snap-image-upload.scss
+++ b/static/sass/_snapcraft_snap-image-upload.scss
@@ -105,12 +105,4 @@
     display: flex;
     justify-content: center;
   }
-
-  .snap-remove-icon:hover {
-    background-color: $color-mid-dark;
-
-    &.is-light {
-      background-color: $colors--theme--background-inputs;
-    }
-  }
 }


### PR DESCRIPTION
## Done
Converts the buttons and icons on the publisher listing page to Pragma components

## How to QA
- Go to a snaps listing page, e.g. https://snapcraft-io-5855.demos.haus/steve-test-snap/listing
- Check that the buttons and icons are as expected

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38541

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
