### PR TITLE
chore: Migrate Tour component to Pragma

### DIFF
--- a/static/js/publisher/components/Tour/Tour.tsx
+++ b/static/js/publisher/components/Tour/Tour.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import Joyride, { STATUS } from "react-joyride";
-import { Button, Icon } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-ds-global";
 
 import TourStep from "./TourStep";
 
@@ -45,6 +45,7 @@ function Tour({ steps }: Props): React.JSX.Element {
     <>
       <Button
         type="button"
+        importance="secondary"
         onClick={handleClickStart}
         style={{
           position: "fixed",
@@ -52,8 +53,9 @@ function Tour({ steps }: Props): React.JSX.Element {
           right: "2rem",
           zIndex: 100,
         }}
+        icon="help"
       >
-        <Icon name="question" />
+        <Icon icon="help" />
         <span className="u-off-screen">Start tour</span>
       </Button>
       <Joyride

--- a/static/js/publisher/components/Tour/Tour.tsx
+++ b/static/js/publisher/components/Tour/Tour.tsx
@@ -1,6 +1,9 @@
 import { useState } from "react";
 import Joyride, { STATUS } from "react-joyride";
-import { Button, Icon } from "@canonical/react-ds-global";
+// Still need to use the `Icon` from `react-components`
+// until the `IconButton` component is ready in Pragma
+import { Icon } from "@canonical/react-components";
+import { Button } from "@canonical/react-ds-global";
 
 import TourStep from "./TourStep";
 
@@ -54,7 +57,7 @@ function Tour({ steps }: Props): React.JSX.Element {
           zIndex: 100,
         }}
       >
-        <Icon icon="help" />
+        <Icon name="question" />
         <span className="u-off-screen">Start tour</span>
       </Button>
       <Joyride

--- a/static/js/publisher/components/Tour/Tour.tsx
+++ b/static/js/publisher/components/Tour/Tour.tsx
@@ -53,7 +53,6 @@ function Tour({ steps }: Props): React.JSX.Element {
           right: "2rem",
           zIndex: 100,
         }}
-        icon="help"
       >
         <Icon icon="help" />
         <span className="u-off-screen">Start tour</span>

--- a/static/js/publisher/components/Tour/TourStep.tsx
+++ b/static/js/publisher/components/Tour/TourStep.tsx
@@ -1,4 +1,4 @@
-import { Card, Button, Icon } from "@canonical/react-components";
+import { Card, Button, Icon } from "@canonical/react-ds-global";
 
 import type { TooltipRenderProps } from "react-joyride";
 
@@ -16,54 +16,59 @@ function TourStep(props: TooltipRenderProps): React.JSX.Element {
 
   return (
     <Card style={{ border: "none" }}>
-      <h4>{step.title}</h4>
-      {step.content}
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <div>
-          Done?{" "}
-          <button
-            className="p-button--link u-no-margin--bottom"
-            {...closeProps}
-          >
-            Skip tour
-          </button>
-          .
-        </div>
-        <div>
-          <span>
-            {index + 1} / {size}
-          </span>
+      <Card.Content>
+        <h4>{step.title}</h4>
+        {step.content}
+        <div style={{ display: "flex", justifyContent: "space-between" }}>
+          <div>
+            Done?{" "}
+            <Button
+              variant="link"
+              className="u-no-margin--bottom"
+              {...closeProps}
+            >
+              Skip tour
+            </Button>
+            .
+          </div>
+          <div>
+            <span>
+              {index + 1} / {size}
+            </span>
 
-          <Button
-            {...backProps}
-            disabled={index < 1}
-            className="u-no-margin--bottom"
-            style={{ marginLeft: "1rem" }}
-          >
-            <Icon name="chevron-left" />
-            <span className="u-off-screen">{backProps.title}</span>
-          </Button>
+            <Button
+              {...backProps}
+              disabled={index < 1}
+              className="u-no-margin--bottom"
+              style={{ marginLeft: "1rem" }}
+              importance="secondary"
+            >
+              <Icon icon="chevron-left" />
+              <span className="u-off-screen">{backProps.title}</span>
+            </Button>
 
-          {continuous && (
-            <>
-              <Button
-                appearance="positive"
-                {...primaryProps}
-                className="u-no-margin--bottom u-no-margin--right"
-              >
-                {isLastStep ? (
-                  <>Finish tour</>
-                ) : (
-                  <>
-                    <Icon name="chevron-right" light />
-                    <span className="u-off-screen">{primaryProps.title}</span>
-                  </>
-                )}
-              </Button>
-            </>
-          )}
+            {continuous && (
+              <>
+                <Button
+                  importance="primary"
+                  anticipation="constructive"
+                  {...primaryProps}
+                  className="u-no-margin--bottom u-no-margin--right"
+                >
+                  {isLastStep ? (
+                    <>Finish tour</>
+                  ) : (
+                    <>
+                      <Icon icon="chevron-right" />
+                      <span className="u-off-screen">{primaryProps.title}</span>
+                    </>
+                  )}
+                </Button>
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      </Card.Content>
     </Card>
   );
 }

--- a/static/js/publisher/components/Tour/TourStep.tsx
+++ b/static/js/publisher/components/Tour/TourStep.tsx
@@ -1,4 +1,7 @@
-import { Card, Button, Icon } from "@canonical/react-ds-global";
+// Still need to use the `Icon` from `react-components`
+// until the `IconButton` component is ready in Pragma
+import { Icon } from "@canonical/react-components";
+import { Card, Button } from "@canonical/react-ds-global";
 
 import type { TooltipRenderProps } from "react-joyride";
 
@@ -43,28 +46,26 @@ function TourStep(props: TooltipRenderProps): React.JSX.Element {
               style={{ marginLeft: "1rem" }}
               importance="secondary"
             >
-              <Icon icon="chevron-left" />
+              <Icon name="chevron-left" />
               <span className="u-off-screen">{backProps.title}</span>
             </Button>
 
             {continuous && (
-              <>
-                <Button
-                  importance="primary"
-                  anticipation="constructive"
-                  {...primaryProps}
-                  className="u-no-margin--bottom u-no-margin--right"
-                >
-                  {isLastStep ? (
-                    <>Finish tour</>
-                  ) : (
-                    <>
-                      <Icon icon="chevron-right" />
-                      <span className="u-off-screen">{primaryProps.title}</span>
-                    </>
-                  )}
-                </Button>
-              </>
+              <Button
+                importance="primary"
+                anticipation="constructive"
+                {...primaryProps}
+                className="u-no-margin--bottom u-no-margin--right"
+              >
+                {isLastStep ? (
+                  <>Finish tour</>
+                ) : (
+                  <>
+                    <Icon name="chevron-right" light />
+                    <span className="u-off-screen">{primaryProps.title}</span>
+                  </>
+                )}
+              </Button>
             )}
           </div>
         </div>

--- a/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
+++ b/static/js/publisher/pages/Listing/ListingForm/__tests__/ListingForm.test.tsx
@@ -31,6 +31,16 @@ vi.mock("@canonical/react-ds-global", () => {
     </button>
   );
 
+  const Card = ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>;
+
+  Card.Content = ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>;
+
   const Icon = ({
     children: _children,
     icon: _icon,
@@ -41,6 +51,7 @@ vi.mock("@canonical/react-ds-global", () => {
 
   return {
     Button,
+    Card,
     Icon,
     withTooltip: (Component: React.ComponentType) => Component,
   };

--- a/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
+++ b/static/js/publisher/pages/Listing/PreviewForm/__tests__/PreviewForm.test.tsx
@@ -31,6 +31,16 @@ vi.mock("@canonical/react-ds-global", () => {
     </button>
   );
 
+  const Card = ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>;
+
+  Card.Content = ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>;
+
   const Icon = ({
     children: _children,
     icon: _icon,
@@ -41,6 +51,7 @@ vi.mock("@canonical/react-ds-global", () => {
 
   return {
     Button,
+    Card,
     Icon,
     withTooltip: (Component: React.ComponentType) => Component,
   };

--- a/static/sass/_pragma-migration-overrides.scss
+++ b/static/sass/_pragma-migration-overrides.scss
@@ -7,6 +7,12 @@
     // which combined with Pragma styles, creates very low contrast
     &.button:disabled {
       opacity: 1;
+
+      // Icons don't lighten in Pragma buttons if disabled as yet,
+      // but text is, so we need to target icons
+      [class*="p-icon"] {
+        opacity: 0.33;
+      }
     }
 
     // Pragma sets a background colour for tertiary buttons whereas

--- a/static/sass/_pragma-migration-overrides.scss
+++ b/static/sass/_pragma-migration-overrides.scss
@@ -16,5 +16,9 @@
     &.button.snap-remove-icon {
       background-color: transparent;
     }
+
+    &.card {
+      background-color: #fff;
+    }
   }
 }

--- a/static/sass/_pragma-migration-overrides.scss
+++ b/static/sass/_pragma-migration-overrides.scss
@@ -16,7 +16,8 @@
     &.button.snap-remove-icon {
       background-color: transparent;
     }
-
+    // Pragma Card defaults can clash with Vanilla expectations in some contexts
+    // (e.g. Joyride tour tooltip), so force a white background for DS cards.
     &.card {
       background-color: #fff;
     }

--- a/static/sass/_pragma-migration-overrides.scss
+++ b/static/sass/_pragma-migration-overrides.scss
@@ -16,6 +16,7 @@
     &.button.snap-remove-icon {
       background-color: transparent;
     }
+
     // Pragma Card defaults can clash with Vanilla expectations in some contexts
     // (e.g. Joyride tour tooltip), so force a white background for DS cards.
     &.card {


### PR DESCRIPTION
## Done

Migrates buttons and cards in the publisher tour. The icons cannot be updated as their spacing doesn't work without text in the buttons. There will be an `IconButton` component in Pragma in the future.

## How to QA
- Go to a snap listing page, e.g. https://snapcraft-io-5856.demos.haus/steve-test-snap/listing
- Open the tour (if it doesn't open automatically)
- Check that the cards, buttons and icons are as expected (spacing will be slightly different due to the new design system)

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38542

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
