### PR TITLE
Update robots.txt to improve crawl efficiency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ setuptools<81.0
 Flask-Testing==0.8.1
 freezegun==1.5.5
 black==26.3.1
+protego==0.6.2
 flake8==7.3.0

--- a/robots.txt
+++ b/robots.txt
@@ -35,6 +35,7 @@ Disallow: /login/
 Disallow: /login-beta$
 Disallow: /logout$
 Disallow: /github/auth
+Disallow: /publisher/github/
 Disallow: /snaps$
 Disallow: /snaps/
 Disallow: /register-snap$
@@ -111,6 +112,7 @@ Disallow: /login/
 Disallow: /login-beta$
 Disallow: /logout$
 Disallow: /github/auth
+Disallow: /publisher/github/
 Disallow: /snaps$
 Disallow: /snaps/
 Disallow: /register-snap$

--- a/robots.txt
+++ b/robots.txt
@@ -1,9 +1,8 @@
 # ===========================================
 # snapcraft.io robots.txt
 # Strategy:
-#   - Block private/transactional/search paths for all.
-#   - Group major AI Retrieval & Crawling bots to optimize crawl budget.
-#   - Allow high-value store/docs paths; block noise.
+#   - Block private/transactional/search paths for all crawlers.
+#   - Keep every public page crawlable.
 #
 # Two snapcraft-specific quirks drive the rule shapes below:
 #   1. Snap detail pages live at the root (/<snap-name>), so rules are anchored
@@ -68,99 +67,6 @@ Disallow: /about/thank-you$
 Disallow: /api/
 Disallow: /*.json$
 Crawl-delay: 1
-
-# ===========================================
-# AI OPTIMIZED RULES
-# Includes: OpenAI (Browsing & Crawling), Perplexity, Anthropic, and Apple
-# ===========================================
-User-agent: GPTBot
-User-agent: ChatGPT-User
-User-agent: OAI-SearchBot
-User-agent: ClaudeBot
-User-agent: Claude-Web
-User-agent: anthropic-ai
-User-agent: Claude-SearchBot
-User-agent: Google-Extended
-User-agent: meta-externalagent
-User-agent: PerplexityBot
-User-agent: Perplexity-User
-User-agent: Applebot-Extended
-User-agent: cohere-ai
-User-agent: Bytespider
-
-# High-value Content Priority
-# Snap detail pages are not listed: they live at the root namespace, so there
-# is no prefix to allow. They are reachable via the sitemaps below.
-Allow: /about
-Allow: /about/listing$
-Allow: /about/release$
-Allow: /about/publicise$
-Allow: /build
-Allow: /blog
-Allow: /docs
-Allow: /iot
-Allow: /store
-Allow: /tutorials
-
-# Private / login-gated
-Disallow: /account$
-Disallow: /account/
-Disallow: /admin$
-Disallow: /admin/
-Disallow: /login$
-Disallow: /login/
-Disallow: /login-beta$
-Disallow: /logout$
-Disallow: /github/auth
-Disallow: /publisher/github/
-Disallow: /snaps$
-Disallow: /snaps/
-Disallow: /register-snap$
-Disallow: /register-snap/
-Disallow: /register-name-dispute$
-Disallow: /request-reserved-name$
-Disallow: /snap_info/
-Disallow: /packages/
-Disallow: /validation-sets$
-Disallow: /validation-sets/
-
-# Per-snap publisher dashboard (login-gated, sits under /<snap-name>/)
-Disallow: /*/builds
-Disallow: /*/collaboration
-Disallow: /*/create-track
-Disallow: /*/listing
-Disallow: /*/metrics
-Disallow: /*/preview
-Disallow: /*/publicise
-Disallow: /*/release
-Disallow: /*/releases
-Disallow: /*/settings
-
-# Block "Noise" (Forms, fragments, and endpoints that exhaust context windows)
-Disallow: /search$
-Disallow: /search?
-Disallow: /docs/search
-Disallow: /about/contact-us$
-Disallow: /about/thank-you$
-Disallow: /api/
-Disallow: /*.json$
-Disallow: /*/embedded
-Disallow: /*.svg$
-Disallow: /install/
-Disallow: /feeds/
-Disallow: /store/stats$
-Disallow: /store/featured-snaps/
-Disallow: /blog/feed
-Disallow: /blog/archives
-Disallow: /blog/latest-news
-Disallow: /blog/events-and-webinars
-Disallow: /blog/author/
-Disallow: /blog/group/
-Disallow: /blog/tag/
-Disallow: /blog/topic/
-
-# Performance
-Crawl-delay: 2
 
 # ===========================================
 # SITEMAPS

--- a/robots.txt
+++ b/robots.txt
@@ -130,6 +130,7 @@ Disallow: /*/metrics
 Disallow: /*/preview
 Disallow: /*/publicise
 Disallow: /*/release
+Disallow: /*/releases
 Disallow: /*/settings
 
 # Block "Noise" (Forms, fragments, and endpoints that exhaust context windows)

--- a/robots.txt
+++ b/robots.txt
@@ -55,6 +55,7 @@ Disallow: /*/metrics
 Disallow: /*/preview
 Disallow: /*/publicise
 Disallow: /*/release
+Disallow: /*/releases
 Disallow: /*/settings
 
 # Search, forms and machine endpoints

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,167 @@
+# ===========================================
+# snapcraft.io robots.txt
+# Strategy:
+#   - Block private/transactional/search paths for all.
+#   - Group major AI Retrieval & Crawling bots to optimize crawl budget.
+#   - Allow high-value store/docs paths; block noise.
+#
+# Two snapcraft-specific quirks drive the rule shapes below:
+#   1. Snap detail pages live at the root (/<snap-name>), so rules are anchored
+#      with $ or a trailing slash to avoid blocking snaps whose name starts
+#      with a reserved word (e.g. a snap called "account-manager").
+#   2. The publisher dashboard hangs off the same root namespace
+#      (/<snap-name>/listing, /metrics, ...), so those are blocked by pattern.
+#      The /about/* marketing pages collide with those patterns and are
+#      re-allowed explicitly - a longer match wins.
+# ===========================================
+
+# ===========================================
+# DEFAULT RULES - all crawlers
+# ===========================================
+User-Agent: *
+
+# Public marketing pages that collide with the dashboard patterns below
+Allow: /about/listing$
+Allow: /about/release$
+Allow: /about/publicise$
+
+# Private / login-gated
+Disallow: /account$
+Disallow: /account/
+Disallow: /admin$
+Disallow: /admin/
+Disallow: /login$
+Disallow: /login/
+Disallow: /login-beta$
+Disallow: /logout$
+Disallow: /github/auth
+Disallow: /snaps$
+Disallow: /snaps/
+Disallow: /register-snap$
+Disallow: /register-snap/
+Disallow: /register-name-dispute$
+Disallow: /request-reserved-name$
+Disallow: /snap_info/
+Disallow: /packages/
+Disallow: /validation-sets$
+Disallow: /validation-sets/
+
+# Per-snap publisher dashboard (login-gated, sits under /<snap-name>/)
+Disallow: /*/builds
+Disallow: /*/collaboration
+Disallow: /*/create-track
+Disallow: /*/listing
+Disallow: /*/metrics
+Disallow: /*/preview
+Disallow: /*/publicise
+Disallow: /*/release
+Disallow: /*/settings
+
+# Search, forms and machine endpoints
+Disallow: /search$
+Disallow: /search?
+Disallow: /docs/search
+Disallow: /about/contact-us$
+Disallow: /about/thank-you$
+Disallow: /api/
+Disallow: /*.json$
+Crawl-delay: 1
+
+# ===========================================
+# AI OPTIMIZED RULES
+# Includes: OpenAI (Browsing & Crawling), Perplexity, Anthropic, and Apple
+# ===========================================
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: OAI-SearchBot
+User-agent: ClaudeBot
+User-agent: Claude-Web
+User-agent: anthropic-ai
+User-agent: Claude-SearchBot
+User-agent: Google-Extended
+User-agent: meta-externalagent
+User-agent: PerplexityBot
+User-agent: Perplexity-User
+User-agent: Applebot-Extended
+User-agent: cohere-ai
+User-agent: Bytespider
+
+# High-value Content Priority
+# Snap detail pages are not listed: they live at the root namespace, so there
+# is no prefix to allow. They are reachable via the sitemaps below.
+Allow: /about
+Allow: /about/listing$
+Allow: /about/release$
+Allow: /about/publicise$
+Allow: /build
+Allow: /blog
+Allow: /docs
+Allow: /iot
+Allow: /store
+Allow: /tutorials
+
+# Private / login-gated
+Disallow: /account$
+Disallow: /account/
+Disallow: /admin$
+Disallow: /admin/
+Disallow: /login$
+Disallow: /login/
+Disallow: /login-beta$
+Disallow: /logout$
+Disallow: /github/auth
+Disallow: /snaps$
+Disallow: /snaps/
+Disallow: /register-snap$
+Disallow: /register-snap/
+Disallow: /register-name-dispute$
+Disallow: /request-reserved-name$
+Disallow: /snap_info/
+Disallow: /packages/
+Disallow: /validation-sets$
+Disallow: /validation-sets/
+
+# Per-snap publisher dashboard (login-gated, sits under /<snap-name>/)
+Disallow: /*/builds
+Disallow: /*/collaboration
+Disallow: /*/create-track
+Disallow: /*/listing
+Disallow: /*/metrics
+Disallow: /*/preview
+Disallow: /*/publicise
+Disallow: /*/release
+Disallow: /*/settings
+
+# Block "Noise" (Forms, fragments, and endpoints that exhaust context windows)
+Disallow: /search$
+Disallow: /search?
+Disallow: /docs/search
+Disallow: /about/contact-us$
+Disallow: /about/thank-you$
+Disallow: /api/
+Disallow: /*.json$
+Disallow: /*/embedded
+Disallow: /*.svg$
+Disallow: /install/
+Disallow: /feeds/
+Disallow: /store/stats$
+Disallow: /store/featured-snaps/
+Disallow: /blog/feed
+Disallow: /blog/archives
+Disallow: /blog/latest-news
+Disallow: /blog/events-and-webinars
+Disallow: /blog/author/
+Disallow: /blog/group/
+Disallow: /blog/tag/
+Disallow: /blog/topic/
+
+# Performance
+Crawl-delay: 2
+
+# ===========================================
+# SITEMAPS
+# ===========================================
+Sitemap: https://snapcraft.io/sitemap.xml
+Sitemap: https://snapcraft.io/sitemap-links.xml
+Sitemap: https://snapcraft.io/store/sitemap.xml
+Sitemap: https://snapcraft.io/tutorials/sitemap.xml

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,0 +1,169 @@
+import os
+import re
+import unittest
+
+from protego import Protego
+
+from webapp.app import create_app
+
+ROBOTS_PATH = os.path.join(os.path.dirname(__file__), "..", "robots.txt")
+BASE_URL = "https://snapcraft.io"
+
+
+def parse_groups(text):
+    groups = {}
+    pending = []
+    in_rules = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+
+        if not line or ":" not in line:
+            continue
+
+        key, value = (part.strip() for part in line.split(":", 1))
+        key = key.lower()
+
+        if key == "user-agent":
+            if in_rules:
+                pending = []
+                in_rules = False
+            pending.append(value.lower())
+            groups.setdefault(value.lower(), [])
+        elif key in ("allow", "disallow"):
+            in_rules = True
+            for agent in pending:
+                groups[agent].append((key, value))
+
+    return groups
+
+
+def is_login_gated(view):
+    seen = set()
+
+    while view is not None and id(view) not in seen:
+        seen.add(id(view))
+        code = getattr(view, "__code__", None)
+        if code is not None and code.co_name == "is_user_logged_in":
+            return True
+        view = getattr(view, "__wrapped__", None)
+
+    return False
+
+
+def sample_path(rule):
+    path = re.sub(r"<any\([^)]*\):[^>]+>", "snaps", rule)
+    path = re.sub(r"<regex\([^)]*\):[^>]+>", "firefox", path)
+    path = re.sub(r"<path:[^>]+>", "x/y", path)
+    path = re.sub(r"<[^>]*snap_name>", "firefox", path)
+
+    return re.sub(r"<[^>]+>", "x", path)
+
+
+class TestRobots(unittest.TestCase):
+    def setUp(self):
+        with open(ROBOTS_PATH) as robots_file:
+            robots = robots_file.read()
+
+        self.robots = Protego.parse(robots)
+        self.groups = parse_groups(robots)
+        self.app = create_app(testing=True)
+
+    def can_fetch(self, agent, path):
+        return self.robots.can_fetch(BASE_URL + path, agent)
+
+    def find_crawlable(self, paths):
+        return [
+            (agent, path)
+            for agent in self.groups
+            for path in paths
+            if self.can_fetch(agent, path)
+        ]
+
+    def find_blocked(self, paths):
+        return [
+            (agent, path)
+            for agent in self.groups
+            for path in paths
+            if not self.can_fetch(agent, path)
+        ]
+
+    def test_robots_txt_is_served_and_not_empty(self):
+        response = self.app.test_client().get("/robots.txt")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"User-Agent", response.data)
+
+    def test_login_gated_routes_are_disallowed_for_every_agent(self):
+        gated = sorted(
+            {
+                sample_path(rule.rule)
+                for rule in self.app.url_map.iter_rules()
+                if is_login_gated(self.app.view_functions.get(rule.endpoint))
+            }
+        )
+
+        self.assertTrue(gated, "no login-gated routes found")
+
+        leaks = self.find_crawlable(gated)
+
+        self.assertEqual(leaks, [], f"login-gated routes crawlable: {leaks}")
+
+    def test_public_content_is_crawlable_for_every_agent(self):
+        public_paths = [
+            "/",
+            "/about",
+            "/about/publish",
+            "/about/listing",
+            "/about/release",
+            "/about/publicise",
+            "/store",
+            "/store/categories/games",
+            "/blog/",
+            "/docs/",
+            "/build",
+            "/iot",
+            "/tutorials",
+            "/firefox",
+            "/publisher/canonical",
+        ]
+
+        blocked = self.find_blocked(public_paths)
+
+        self.assertEqual(
+            blocked, [], f"public content is not crawlable: {blocked}"
+        )
+
+    def test_snaps_named_after_reserved_paths_are_crawlable(self):
+        snap_paths = [
+            "/accountable2you",
+            "/administrative-assistant",
+            "/searchsploit",
+            "/search-helper-tool",
+            "/build-and-measure",
+            "/iot-manager",
+            "/iotconnect",
+            "/publisher-subscriber",
+            "/store-admin",
+            "/api-mocker-gateway",
+            "/apilume",
+        ]
+
+        blocked = self.find_blocked(snap_paths)
+
+        self.assertEqual(
+            blocked, [], f"snap pages blocked by an unanchored rule: {blocked}"
+        )
+
+    def test_wildcard_rules_apply_to_every_named_agent(self):
+        wildcard = set(self.groups["*"])
+
+        for agent, rules in self.groups.items():
+            if agent == "*":
+                continue
+
+            missing = sorted(wildcard - set(rules))
+
+            self.assertEqual(
+                missing, [], f"{agent} is missing rules from '*': {missing}"
+            )


### PR DESCRIPTION
## Done
robots.txt has been empty since the flask-base migration (#2565, 2020) which replaced a hardcoded empty response with an empty file. Everything was crawlable including paths require login.
Added rules that matches with [ubuntu.com](https://ubuntu.com/robots.txt) and  [canonical.com](https://canonical.com/robots.txt):
- Block account, admin, login, register-snap and validation-sets
- Block the per-snap publisher dashboard (/<snap>/listing, /metrics, /releases etc) which redirects to SSO and sits under the public snap namespace
- Block /api/, .json endpoints, search and contact forms
- Declare 4 sitemaps

There are rules with $ or a trailing slash because snap pages live at the root. Just adding  Disallow: /account would also block snaps whose name starts with "account". /about/listing, /about/release and /about/publicise are reallowed explicitly since they collide with the dashboard patterns.

## How to QA
n/a

## Testing

- [x] This PR has tests
- [] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes #
