### PR TITLE
refactor: remove deadlinks

### DIFF
--- a/templates/snapcraft/build.html
+++ b/templates/snapcraft/build.html
@@ -3,11 +3,6 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1EvemWJDOpjL-8ieCSiStKViFx-fgwfTaENueOYlB5ps/edit{% endblock %}
 
 {% block content %}
-<section class="p-strip is-shallow">
-  <div class="u-fixed-width">
-    <b>Ubuntu 18.04 is entering ESM.</b> This can impact you as a snap developer. Read more about <a href="https://snapcraft.io/docs/migrating-bases">Migrating between bases.</a>
-  </div>
-</section>
 <section id="main-content" class="p-strip">
   <div class="u-fixed-width">
     <h2 class="p-heading--2">

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -447,7 +447,8 @@ def snapcraft_blueprint():
     @snapcraft.route("/create")
     def create_redirect():
         return flask.redirect(
-            "https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap/",
+            "https://documentation.ubuntu.com/snapcraft/stable"
+            "/tutorials/craft-a-snap/",
             code=301,
         )
 

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -446,7 +446,10 @@ def snapcraft_blueprint():
 
     @snapcraft.route("/create")
     def create_redirect():
-        return flask.redirect("https://docs.snapcraft.io/build-snaps")
+        return flask.redirect(
+            "https://documentation.ubuntu.com/snapcraft/stable"
+            "/tutorials/craft-a-snap/"
+        )
 
     @snapcraft.route("/build")
     def build():

--- a/webapp/snapcraft/views.py
+++ b/webapp/snapcraft/views.py
@@ -447,8 +447,8 @@ def snapcraft_blueprint():
     @snapcraft.route("/create")
     def create_redirect():
         return flask.redirect(
-            "https://documentation.ubuntu.com/snapcraft/stable"
-            "/tutorials/craft-a-snap/"
+            "https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap/",
+            code=301,
         )
 
     @snapcraft.route("/build")


### PR DESCRIPTION
## Done
Removed/updated 2 deadlinks:
- https://snapcraft.io/create resolves to https://docs.snapcraft.io/build-snaps which is broken
- https://snapcraft.io/build there is a banner which is pretty old and the link is dead (https://snapcraft.io/docs/migrating-bases/)

## How to QA
- checkout to the feature branch
- go to localhost/build
- verify there is no legacy banner
- go to localhost/create
- verify https://documentation.ubuntu.com/snapcraft/stable/tutorials/craft-a-snap/ is opened

## Testing

- [ ] This PR has tests
- [x] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38672

