### PR TITLE
feat: Return SBOM data in info reponse

### DIFF
--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -88,6 +88,7 @@ class GetDetailsPageTest(TestCase):
                                 "unlisted",
                                 "links",
                                 "revision",
+                                "sboms",
                             ]
                         )
                     }

--- a/tests/store/tests_distro_page.py
+++ b/tests/store/tests_distro_page.py
@@ -73,6 +73,7 @@ class GetDistroPageTest(TestCase):
                                 "unlisted",
                                 "links",
                                 "revision",
+                                "sboms",
                             ]
                         )
                     }

--- a/tests/store/tests_embedded_card.py
+++ b/tests/store/tests_embedded_card.py
@@ -73,6 +73,7 @@ class GetEmbeddedCardTest(TestCase):
                                 "unlisted",
                                 "links",
                                 "revision",
+                                "sboms",
                             ]
                         )
                     }

--- a/tests/store/tests_github_badge.py
+++ b/tests/store/tests_github_badge.py
@@ -87,6 +87,7 @@ class GetGitHubBadgeTest(TestCase):
                                 "unlisted",
                                 "links",
                                 "revision",
+                                "sboms",
                             ]
                         )
                     }

--- a/tests/store/tests_public_logic.py
+++ b/tests/store/tests_public_logic.py
@@ -44,6 +44,7 @@ class StoreLogicTest(unittest.TestCase):
                         "risk": "risk",
                         "version": "version",
                         "revision": "revision",
+                        "sboms": None,
                     }
                 ]
             }
@@ -94,6 +95,7 @@ class StoreLogicTest(unittest.TestCase):
                         "risk": "risk",
                         "version": "version",
                         "revision": "revision",
+                        "sboms": None,
                     }
                 ],
                 "track1": [
@@ -105,6 +107,7 @@ class StoreLogicTest(unittest.TestCase):
                         "risk": "risk",
                         "version": "version",
                         "revision": "revision",
+                        "sboms": None,
                     }
                 ],
             }
@@ -156,6 +159,7 @@ class StoreLogicTest(unittest.TestCase):
                         "risk": "risk",
                         "version": "version",
                         "revision": "revision",
+                        "sboms": None,
                     }
                 ]
             },
@@ -169,9 +173,56 @@ class StoreLogicTest(unittest.TestCase):
                         "risk": "risk",
                         "version": "version",
                         "revision": "revision",
+                        "sboms": None,
                     }
                 ]
             },
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_channel_map_with_sboms(self):
+        sboms = [
+            {
+                "format": "spdx2.3.json",
+                "url": "https://api.snapcraft.io/api/v1/sboms/download/"
+                "sbom_snap_SNAP_ID.spdx2.3.json",
+            }
+        ]
+        channel_maps_list = [
+            {
+                "channel": {
+                    "name": "channel",
+                    "architecture": "arch",
+                    "track": "track",
+                    "risk": "risk",
+                    "released-at": "2019-01-12T16:48:41.821037+00:00",
+                },
+                "created-at": "2019-01-12T16:48:41.821037+00:00",
+                "confinement": "confinement",
+                "download": {"size": "size"},
+                "version": "version",
+                "revision": "revision",
+                "sboms": sboms,
+            }
+        ]
+
+        result = logic.convert_channel_maps(channel_maps_list)
+        expected_result = {
+            "arch": {
+                "track": [
+                    {
+                        "channel": "channel",
+                        "released-at": "12 January 2019",
+                        "confinement": "confinement",
+                        "size": "size",
+                        "risk": "risk",
+                        "version": "version",
+                        "revision": "revision",
+                        "sboms": sboms,
+                    }
+                ]
+            }
         }
 
         self.assertEqual(result, expected_result)

--- a/webapp/store/logic.py
+++ b/webapp/store/logic.py
@@ -211,6 +211,11 @@ def convert_channel_maps(channel_map):
         if track not in channel_map_restruct[arch]:
             channel_map_restruct[arch][track] = []
 
+        sboms = None
+
+        if "sboms" in channel:
+            sboms = channel["sboms"]
+
         info = {
             "released-at": convert_date(channel["channel"].get("released-at")),
             "version": channel.get("version"),
@@ -219,6 +224,7 @@ def convert_channel_maps(channel_map):
             "confinement": channel.get("confinement"),
             "size": channel["download"].get("size"),
             "revision": channel["revision"],
+            "sboms": sboms,
         }
 
         channel_map_restruct[arch][track].append(info)

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -45,6 +45,7 @@ FIELDS = [
     "unlisted",
     "links",
     "revision",
+    "sboms",
 ]
 
 FIELDS_EXTRA_DETAILS = [


### PR DESCRIPTION
## Done
Added `sboms` to the response from the info endpoint

## How to QA
- Go to some snap details page and check it loads without errors:
  - https://snapcraft-io-5868.demos.haus/steve-test-snap
  - https://snapcraft-io-5868.demos.haus/valkey
  - https://snapcraft-io-5868.demos.haus/mysql
  - https://snapcraft-io-5868.demos.haus/code
  - https://snapcraft-io-5868.demos.haus/firefox
- The python tests should pass

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Only surfaces public data

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-38745

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
