### PR TITLE
chore: Remove previous SBOM download implementation

### DIFF
--- a/static/js/public/snap-details/__tests__/channelMap.test.ts
+++ b/static/js/public/snap-details/__tests__/channelMap.test.ts
@@ -150,7 +150,6 @@ const channelMapData = {
   },
 };
 const defaultTrack = "latest";
-const hasSboms = false;
 
 describe("Channel map popup", () => {
   beforeEach(() => {
@@ -158,14 +157,7 @@ describe("Channel map popup", () => {
       ${OPEN_CHANNEL_MAP_BTN}
       ${CHANNEL_MAP_HTML}`;
 
-    channelMap(
-      selector,
-      packageName,
-      snapId,
-      channelMapData,
-      defaultTrack,
-      hasSboms,
-    );
+    channelMap(selector, packageName, snapId, channelMapData, defaultTrack);
 
     openChannelMap();
   });

--- a/static/js/public/snap-details/channelMap.ts
+++ b/static/js/public/snap-details/channelMap.ts
@@ -47,7 +47,6 @@ class ChannelMap {
   snapId: string;
   currentTab: string;
   defaultTrack: string;
-  hasSboms: boolean;
   selectorString: string;
   channelMapEl: HTMLElement;
   channelOverlayEl: HTMLElement;
@@ -55,7 +54,6 @@ class ChannelMap {
   events: SnapEvents;
   INSTALL_TEMPLATE: string = "";
   CHANNEL_ROW_TEMPLATE: string | undefined;
-  CHANNEL_SECURITY_ROW_TEMPLATE: string | undefined;
   arch: string | undefined;
   openButton: HTMLElement | null | undefined;
   openScreenName: string | undefined;
@@ -65,7 +63,6 @@ class ChannelMap {
     snapId: string,
     channelMapData: ChannelMapData,
     defaultTrack: string,
-    hasSboms: boolean,
   ) {
     this.RISK_ORDER = ["stable", "candidate", "beta", "edge"];
     this.packageName = packageName;
@@ -73,7 +70,6 @@ class ChannelMap {
     this.currentTab = "overview";
 
     this.defaultTrack = defaultTrack;
-    this.hasSboms = hasSboms;
 
     this.selectorString = selectorString;
     this.channelMapEl = document.querySelector(
@@ -149,9 +145,6 @@ class ChannelMap {
     const channelRowTemplateEl = document.querySelector(
       '[data-js="channel-map-row"]',
     );
-    const channelSecurityRowTemplateEl = document.querySelector(
-      '[data-js="channel-map-security-table-row"]',
-    );
 
     if (!installTemplateEl || !channelRowTemplateEl) {
       const buttonsVersions = document.querySelector(
@@ -165,8 +158,6 @@ class ChannelMap {
 
     this.INSTALL_TEMPLATE = installTemplateEl.innerHTML;
     this.CHANNEL_ROW_TEMPLATE = channelRowTemplateEl.innerHTML;
-    this.CHANNEL_SECURITY_ROW_TEMPLATE =
-      channelSecurityRowTemplateEl?.innerHTML;
 
     // get architectures from data
     const architectures = Object.keys(this.channelMapData);
@@ -489,7 +480,7 @@ class ChannelMap {
     applyDesktopStoreSupport(holder);
   }
 
-  writeTable(el: HTMLElement, data: string[][], tableType?: string): void {
+  writeTable(el: HTMLElement, data: string[][]): void {
     let cache: string | undefined;
     const tbody = data.map((row, i) => {
       const isSameTrack = cache && row[0] === cache;
@@ -505,16 +496,10 @@ class ChannelMap {
 
       let _row: string = "";
 
-      if (tableType && tableType === "security") {
-        if (this.CHANNEL_SECURITY_ROW_TEMPLATE) {
-          _row = this.CHANNEL_SECURITY_ROW_TEMPLATE;
-        }
-      } else {
-        if (this.CHANNEL_ROW_TEMPLATE) {
-          _row = this.CHANNEL_ROW_TEMPLATE.split("${rowClass}").join(
-            rowClass.join(" "),
-          );
-        }
+      if (this.CHANNEL_ROW_TEMPLATE) {
+        _row = this.CHANNEL_ROW_TEMPLATE.split("${rowClass}").join(
+          rowClass.join(" "),
+        );
       }
 
       row.forEach((val, index) => {
@@ -539,10 +524,6 @@ class ChannelMap {
       '[data-js="channel-map-table"]',
     ) as HTMLElement;
 
-    const tbodySecurityEl = this.channelMapEl.querySelector(
-      '[data-js="channel-map-security-table"]',
-    ) as HTMLElement;
-
     // If we're on the overview tab we only want to see latest/[all risks]
     // and [all tracks]/[highest risk], so filter out anything that isn't these
     const filtered = this.currentTab === "overview";
@@ -552,7 +533,6 @@ class ChannelMap {
     let trimmedNumberOfTracks = 0;
 
     const rows: Array<string[]> = [];
-    const securityRows: Array<string[]> = [];
 
     const trackList = filtered ? {} : archData;
 
@@ -577,14 +557,10 @@ class ChannelMap {
 
       // If we're filtering, but that list ends up with the same number of tracks
       // we don't need to show the tabs (we'll show the same data twice)
-      if (numberOfTracks === trimmedNumberOfTracks && !this.hasSboms) {
+      if (numberOfTracks === trimmedNumberOfTracks) {
         this.hideTabs();
       }
     }
-
-    const getSbomUrl = (revision: string): string => {
-      return `/download/sbom_snap_${this.snapId}_${revision}.spdx2.3.json`;
-    };
 
     // Create an array of columns
     Object.keys(trackList).forEach((track) => {
@@ -597,49 +573,8 @@ class ChannelMap {
           trackInfo["released-at"],
           trackInfo["confinement"],
         ]);
-
-        if (this.hasSboms) {
-          securityRows.push([
-            trackName,
-            trackInfo["risk"],
-            trackInfo["version"],
-            trackInfo["revision"],
-          ]);
-        }
       });
     });
-
-    if (this.hasSboms && securityRows.length > 0) {
-      Promise.all(
-        securityRows.map(async (row) => {
-          const revision = row[3];
-          const sbomUrl = getSbomUrl(revision);
-          const downloadLink = `<a href="${sbomUrl}" download>SPDX file&nbsp;<i class="p-icon--begin-downloading"></i></a>`;
-          const res = await fetch(sbomUrl, { method: "HEAD" });
-
-          if (res.status === 200) {
-            row.push(downloadLink);
-          } else {
-            row.push("Not available");
-          }
-
-          return row;
-        }),
-      ).then(() => {
-        this.writeTable(
-          tbodySecurityEl,
-          this.sortRows(securityRows),
-          "security",
-        );
-
-        // Enable "Security" tab only when SBOM requests
-        // are complete to avoid a race condition causing
-        // the table to have not rendered
-        const securityTab = document.querySelector("#channel-map-security-tab");
-        securityTab?.classList.remove("is-disabled");
-        securityTab?.setAttribute("aria-disabled", "false");
-      });
-    }
 
     this.writeTable(tbodyEl, this.sortRows(rows));
   }
@@ -677,25 +612,6 @@ class ChannelMap {
     selected.removeAttribute("aria-selected");
     clickEl.setAttribute("aria-selected", "true");
 
-    const versionTable = document.querySelector(
-      ".p-channel-map__version-table",
-    );
-    const securityTable = document.querySelector(
-      ".p-channel-map__security-table",
-    );
-
-    if (this.currentTab === "security") {
-      securityTable?.classList.remove("u-hide");
-      securityTable?.setAttribute("aria-hidden", "false");
-      versionTable?.classList.add("u-hide");
-      versionTable?.setAttribute("aria-hidden", "true");
-    } else {
-      versionTable?.classList.remove("u-hide");
-      versionTable?.setAttribute("aria-hidden", "false");
-      securityTable?.classList.add("u-hide");
-      securityTable?.setAttribute("aria-hidden", "true");
-    }
-
     if (this.arch && this.arch in this.channelMapData) {
       this.prepareTable(this.channelMapData[this.arch]);
     } else if (this.arch) {
@@ -710,14 +626,6 @@ export default function channelMap(
   snapId: string,
   channelMapData: ChannelMapData,
   defaultTrack: string,
-  hasSboms: boolean,
 ) {
-  return new ChannelMap(
-    el,
-    packageName,
-    snapId,
-    channelMapData,
-    defaultTrack,
-    hasSboms,
-  );
+  return new ChannelMap(el, packageName, snapId, channelMapData, defaultTrack);
 }

--- a/templates/store/snap-details.html
+++ b/templates/store/snap-details.html
@@ -453,7 +453,7 @@
       {% if channel_map %}
         var channelMap = {{ channel_map | tojson }};
         try {
-          snapcraft.public.storeDetails.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ snap_id|tojson }}, channelMap, "{{ default_track }}", {{ has_sboms|tojson }});
+          snapcraft.public.storeDetails.channelMap('#js-channel-map', {{ package_name|tojson }}, {{ snap_id|tojson }}, channelMap, "{{ default_track }}");
         } catch(e) {
           Sentry.captureException(e);
           document.querySelector('.js-open-channel-map').style.display = 'none';

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -111,22 +111,6 @@
                     All releases
                 </a>
               </li>
-              {% if has_sboms %}
-              <li class="p-tabs__item" role="presentation">
-                <a
-                  href="#"
-                  class="p-tabs__link is-disabled"
-                  role="tab"
-                  data-tab="security"
-                  data-js="switch-tab"
-                  aria-controls="security-information"
-                  aria-disabled="true"
-                  id="channel-map-security-tab"
-                >
-                    Security
-                </a>
-              </li>
-              {% endif %}
             </ul>
           </nav>
         </div>
@@ -141,20 +125,6 @@
               </tr>
             </thead>
             <tbody data-js="channel-map-table">
-            </tbody>
-          </table>
-        </div>
-        <div class="u-fixed-width p-channel-map__security-table u-hide" role="tabpanel" id="security-information" aria-hidden="true">
-          <table aria-label="Security information">
-            <thead>
-              <tr>
-                <th>Channel</th>
-                <th>Version</th>
-                <th>Revision</th>
-                <th>Download SBOM</th>
-              </tr>
-            </thead>
-            <tbody data-js="channel-map-security-table">
             </tbody>
           </table>
         </div>
@@ -200,15 +170,6 @@
     <td>${row[2]}</td>
     <td class="u-hide--medium u-hide--small">${row[3]}</td>
     <td class="u-align--center"><a href="#" class="p-channel-map__version-table-install" data-analytics-click data-analytics-target="details_channel_version_install" data-analytics-channel="${row[0]}/${row[1]}">Install &rsaquo;</a></td>
-  </tr>
-</script>
-
-<script type="text/template" id="channel-map-security-table-row-template" data-js="channel-map-security-table-row">
-  <tr>
-    <td>${row[0]}/${row[1]}</td>
-    <td>${row[2]}</td>
-    <td>${row[3]}</td>
-    <td>${row[4]}</td>
   </tr>
 </script>
 

--- a/tests/store/tests_details.py
+++ b/tests/store/tests_details.py
@@ -105,13 +105,6 @@ class GetDetailsPageTest(TestCase):
                 urlencode({"fields": ",".join(["aliases"])}),
             ]
         )
-        self.api_url_sboms = "".join(
-            [
-                "https://api.snapcraft.io/api/v1/",
-                "sboms/download/",
-                f"sbom_snap_{self.snap_id}_{self.revision}.spdx2.3.json",
-            ]
-        )
 
     def create_app(self):
         app = create_app(testing=True)
@@ -152,12 +145,6 @@ class GetDetailsPageTest(TestCase):
             ]
         )
         metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        sbom_url = "".join(
-            [
-                "https://api.snapcraft.io/api/v1/sboms/download/",
-                f"sbom_snap_{self.snap_id}_{self.revision}.spdx2.3.json",
-            ]
-        )
 
         responses.add(responses.GET, info_url, json=payload, status=200)
         responses.add(
@@ -167,7 +154,6 @@ class GetDetailsPageTest(TestCase):
             status=200,
         )
         responses.add(responses.POST, metrics_url, json={}, status=200)
-        responses.add(responses.HEAD, sbom_url, json={}, status=200)
 
         response = self.client.get("/" + snap_name)
 
@@ -195,12 +181,6 @@ class GetDetailsPageTest(TestCase):
         )
         find_url = "https://api.snapcraft.io/v2/snaps/find"
         metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        sbom_url = "".join(
-            [
-                "https://api.snapcraft.io/api/v1/sboms/download/",
-                f"sbom_snap_{self.snap_id}_{self.revision}.spdx2.3.json",
-            ]
-        )
 
         def find_snap(name, title):
             return {
@@ -224,7 +204,6 @@ class GetDetailsPageTest(TestCase):
         responses.add(responses.GET, info_url, json=payload, status=200)
         responses.add(responses.GET, find_url, json=find_response, status=200)
         responses.add(responses.POST, metrics_url, json={}, status=200)
-        responses.add(responses.HEAD, sbom_url, json={}, status=200)
 
         response = self.client.get("/" + snap_name)
         self.assertEqual(response.status_code, 200)
@@ -246,58 +225,6 @@ class GetDetailsPageTest(TestCase):
         self.assertEqual(featured_names, ["intellij-idea"])
         self.assertEqual(featured[0]["title"], "IntelliJ IDEA")
         self.assertEqual(featured[0]["background"], "#000000")
-
-    @responses.activate
-    def test_has_sboms_success(self):
-        payload = SNAP_PAYLOAD
-
-        responses.add(
-            responses.Response(
-                method="GET", url=self.api_url, json=payload, status=200
-            )
-        )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=200
-            )
-        )
-
-        metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        responses.add(
-            responses.Response(
-                method="POST", url=metrics_url, json={}, status=200
-            )
-        )
-
-        response = self.client.get(self.endpoint_url)
-
-        assert response.status_code == 200
-
-    @responses.activate
-    def test_has_sboms_error(self):
-        payload = SNAP_PAYLOAD
-
-        responses.add(
-            responses.Response(
-                method="GET", url=self.api_url, json=payload, status=200
-            )
-        )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=404
-            )
-        )
-
-        metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
-        responses.add(
-            responses.Response(
-                method="POST", url=metrics_url, json={}, status=200
-            )
-        )
-
-        response = self.client.head(self.api_url_sboms)
-
-        assert response.status_code == 404
 
     @responses.activate
     def test_api_404(self):
@@ -343,11 +270,7 @@ class GetDetailsPageTest(TestCase):
                 status=404,
             )
         )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=200
-            )
-        )
+
         metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
         responses.add(
             responses.Response(
@@ -449,11 +372,6 @@ class GetDetailsPageTest(TestCase):
                 status=200,
             )
         )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=200
-            )
-        )
 
         metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
         responses.add(
@@ -491,11 +409,6 @@ class GetDetailsPageTest(TestCase):
                 status=200,
             )
         )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=200
-            )
-        )
 
         metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
         responses.add(
@@ -524,11 +437,6 @@ class GetDetailsPageTest(TestCase):
                 url=self.api_url_details,
                 json=EMPTY_EXTRA_DETAILS_PAYLOAD,
                 status=200,
-            )
-        )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=200
             )
         )
 
@@ -577,11 +485,7 @@ class GetDetailsPageTest(TestCase):
                 status=200,
             )
         )
-        responses.add(
-            responses.Response(
-                method="HEAD", url=self.api_url_sboms, json={}, status=200
-            )
-        )
+
         metrics_url = "https://api.snapcraft.io/api/v1/snaps/metrics"
         responses.add(
             responses.Response(

--- a/webapp/store/snap_details_views.py
+++ b/webapp/store/snap_details_views.py
@@ -22,7 +22,6 @@ from canonicalwebteam.store_api.devicegw import DeviceGW
 from pybadges import badge
 
 device_gateway = DeviceGW("snap", helpers.api_session)
-device_gateway_sbom = DeviceGW("sbom", helpers.api_session)
 
 logger = logging.getLogger(__name__)
 
@@ -296,31 +295,6 @@ def snap_details_views(store):
 
         return True
 
-    def snap_has_sboms(revisions, snap_id):
-        if not revisions:
-            return False
-
-        sbom_path = f"download/sbom_snap_{snap_id}_{revisions[0]}.spdx2.3.json"
-        endpoint = device_gateway_sbom.get_endpoint_url(sbom_path)
-
-        res = requests.head(endpoint)
-
-        # backend returns 302 instead of 200 for a successful request
-        # adding the check for 200 in case this is changed without us knowing
-        if res.status_code == 200 or res.status_code == 302:
-            return True
-
-        return False
-
-    @store.route("/download/sbom_snap_<snap_id>_<revision>.spdx2.3.json")
-    def get_sbom(snap_id, revision):
-        sbom_path = f"download/sbom_snap_{snap_id}_{revision}.spdx2.3.json"
-        endpoint = device_gateway_sbom.get_endpoint_url(sbom_path)
-
-        res = requests.get(endpoint)
-
-        return flask.jsonify(res.json())
-
     @store.route('/<regex("' + snap_regex + '"):snap_name>')
     def snap_details(snap_name):
         """
@@ -401,8 +375,6 @@ def snap_details_views(store):
                 private=False,
             )
 
-        has_sboms = snap_has_sboms(context["revisions"], context["snap_id"])
-
         context.update(
             {
                 "countries": (
@@ -418,8 +390,6 @@ def snap_details_views(store):
                 "error_info": error_info,
             }
         )
-
-        context["has_sboms"] = has_sboms
 
         context["default_arch"] = logic.get_default_architecture(
             context["channel_map"].keys()


### PR DESCRIPTION
## Done
Removes the previous implementation of SBOM download links as they weren't working reliably, had a performance impact, and there is now a way using the store API info endpoint to avoid this complication. This is housekeeping to simplify the new implementation.

## How to QA
- Go to some snap detail pages and check that the channel map works as expected:
  - https://snapcraft-io-5869.demos.haus/valkey ([live version](https://snapcraft.io/valkey))
  - https://snapcraft-io-5869.demos.haus/code ([live version](https://snapcraft.io/code))
  - https://snapcraft-io-5869.demos.haus/postgresql ([live version](https://snapcraft.io/postgresql))

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why): Removing user facing functionality

## Issue / Card

n/a

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
