### PR TITLE
feat: Show SBOM download links in the channel map

### DIFF
--- a/static/js/public/snap-details/__tests__/channelMap.test.ts
+++ b/static/js/public/snap-details/__tests__/channelMap.test.ts
@@ -3,7 +3,7 @@ import { getByText } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
-import channelMap from "../channelMap";
+import channelMap, { type ChannelMapData } from "../channelMap";
 // @ts-expect-error importing the HTML template as a string
 import CHANNEL_MAP_HTML from "../../../../../templates/store/snap-details/_channel_map.html?raw";
 
@@ -51,6 +51,7 @@ const channelMapData = {
         size: 100,
         version: "1.0-amd64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "candidate",
@@ -61,6 +62,7 @@ const channelMapData = {
         size: 100,
         version: "1.1-amd64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "beta",
@@ -71,6 +73,7 @@ const channelMapData = {
         size: 100,
         version: "1.1-amd64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "edge",
@@ -81,6 +84,7 @@ const channelMapData = {
         size: 100,
         version: "1.2-amd64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "old",
@@ -91,6 +95,7 @@ const channelMapData = {
         size: 100,
         version: "0.1-amd64",
         track: "latest",
+        sboms: null,
       },
     ],
   },
@@ -105,6 +110,7 @@ const channelMapData = {
         size: 100,
         version: "1.0-arm64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "candidate",
@@ -115,6 +121,7 @@ const channelMapData = {
         size: 100,
         version: "1.1-arm64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "beta",
@@ -125,6 +132,7 @@ const channelMapData = {
         size: 100,
         version: "1.1-arm64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "edge",
@@ -135,6 +143,7 @@ const channelMapData = {
         size: 100,
         version: "1.2-arm64",
         track: "latest",
+        sboms: null,
       },
       {
         channel: "old",
@@ -145,112 +154,178 @@ const channelMapData = {
         size: 100,
         version: "0.1-arm64",
         track: "latest",
+        sboms: null,
       },
     ],
   },
 };
+const channelMapDataWithSboms = {
+  ...channelMapData,
+  amd64: {
+    latest: channelMapData.amd64.latest.map((channel, index) =>
+      index === 0
+        ? {
+            ...channel,
+            sboms: [
+              {
+                format: "spdx",
+                url: "https://example.com/test.spdx.json",
+              },
+            ],
+          }
+        : channel,
+    ),
+  },
+};
 const defaultTrack = "latest";
 
+function setupChannelMap(data: ChannelMapData = channelMapData) {
+  document.body.innerHTML = `
+    ${OPEN_CHANNEL_MAP_BTN}
+    ${CHANNEL_MAP_HTML}`;
+
+  channelMap(selector, packageName, snapId, data, defaultTrack);
+
+  openChannelMap();
+}
+
 describe("Channel map popup", () => {
-  beforeEach(() => {
-    document.body.innerHTML = `
-      ${OPEN_CHANNEL_MAP_BTN}
-      ${CHANNEL_MAP_HTML}`;
-
-    channelMap(selector, packageName, snapId, channelMapData, defaultTrack);
-
-    openChannelMap();
-  });
-
   afterEach(() => {
     document.body.innerHTML = "";
   });
 
-  test("renders correctly", () => {
-    const tbody = document.querySelector(`tbody`)!;
-    expect(tbody.childElementCount).toEqual(
-      channelMapData["amd64"].latest.length,
-    );
+  describe("with default channel data", () => {
+    beforeEach(() => {
+      setupChannelMap();
+    });
+
+    test("renders correctly", () => {
+      const tbody = document.querySelector(`tbody`)!;
+      expect(tbody.childElementCount).toEqual(
+        channelMapData["amd64"].latest.length,
+      );
+    });
+
+    test("architecture select updates table", async () => {
+      const user = userEvent.setup();
+
+      const select = document.querySelector<HTMLSelectElement>(
+        `[data-js="arch-select"]`,
+      )!;
+      await user.selectOptions(select, "arm64");
+
+      const tbody = document.querySelector(`tbody`)!;
+      expect(getByText(tbody!, `1.0-arm64`)).not.toBeNull();
+    });
+
+    test("clicking on install shows instructions", async () => {
+      const user = userEvent.setup();
+      const btn = document.querySelector(
+        `[data-js="slide-install-instructions"]`,
+      )!;
+      await user.click(btn);
+
+      expect(document.querySelector(`.p-channel-map__slides`)).toHaveClass(
+        "show-right",
+      );
+    });
+
+    test("clicking on install shows instructions for selected channel", async () => {
+      const user = userEvent.setup();
+      const btn = document.querySelector(
+        `[data-js="slide-install-instructions"][data-channel="latest/beta"]`,
+      )!;
+      await user.click(btn);
+
+      expect(getByText(document.body, /--beta/)).not.toBeNull();
+    });
+
+    test("edge channel has warning", async () => {
+      const user = userEvent.setup();
+      const btn = document.querySelector(
+        `[data-js="slide-install-instructions"][data-channel="latest/edge"]`,
+      )!;
+      await user.click(btn);
+
+      expect(getByText(document.body, /edge channel can break/)).not.toBeNull();
+    });
+
+    test("beta channel has warning", async () => {
+      const user = userEvent.setup();
+      const btn = document.querySelector(
+        `[data-js="slide-install-instructions"][data-channel="latest/beta"]`,
+      )!;
+      await user.click(btn);
+
+      expect(
+        getByText(document.body, /beta channel may have unfinished parts/),
+      ).not.toBeNull();
+    });
+
+    test("candidate channel has warning", async () => {
+      const user = userEvent.setup();
+      const btn = document.querySelector(
+        `[data-js="slide-install-instructions"][data-channel="latest/candidate"]`,
+      )!;
+      await user.click(btn);
+
+      expect(
+        getByText(
+          document.body,
+          /candidate channel need additional real world experimentation/,
+        ),
+      ).not.toBeNull();
+    });
+
+    test("old snaps have warning", async () => {
+      const user = userEvent.setup();
+      const btn = document.querySelector(
+        `[data-js="slide-install-instructions"][data-channel="latest/old"]`,
+      )!;
+      await user.click(btn);
+
+      expect(getByText(document.body, /might be unmaintained/)).not.toBeNull();
+    });
   });
 
-  test("architecture select updates table", async () => {
-    const user = userEvent.setup();
+  describe("with SBOM data", () => {
+    beforeEach(() => {
+      setupChannelMap(channelMapDataWithSboms);
+    });
 
-    const select = document.querySelector<HTMLSelectElement>(
-      `[data-js="arch-select"]`,
-    )!;
-    await user.selectOptions(select, "arm64");
+    test("security tab shows SBOM download links", async () => {
+      const user = userEvent.setup();
+      const securityTab = document.querySelector<HTMLElement>(
+        "#channel-map-security-tab",
+      )!;
 
-    const tbody = document.querySelector(`tbody`)!;
-    expect(getByText(tbody!, `1.0-arm64`)).not.toBeNull();
-  });
+      await user.click(securityTab);
 
-  test("clicking on install shows instructions", async () => {
-    const user = userEvent.setup();
-    const btn = document.querySelector(
-      `[data-js="slide-install-instructions"]`,
-    )!;
-    await user.click(btn);
+      const securityTable = document.querySelector(
+        ".p-channel-map__security-table",
+      )!;
+      const versionTable = document.querySelector(
+        ".p-channel-map__version-table",
+      )!;
+      const securityTableBody = document.querySelector(
+        '[data-js="channel-map-security-table"]',
+      )!;
+      const sbomDownloadLink = securityTableBody.querySelector("a")!;
+      const sbomRow = sbomDownloadLink.closest("tr")!;
 
-    expect(document.querySelector(`.p-channel-map__slides`)).toHaveClass(
-      "show-right",
-    );
-  });
-
-  test("clicking on install shows instructions for selected channel", async () => {
-    const user = userEvent.setup();
-    const btn = document.querySelector(
-      `[data-js="slide-install-instructions"][data-channel="latest/beta"]`,
-    )!;
-    await user.click(btn);
-
-    expect(getByText(document.body, /--beta/)).not.toBeNull();
-  });
-
-  test("edge channel has warning", async () => {
-    const user = userEvent.setup();
-    const btn = document.querySelector(
-      `[data-js="slide-install-instructions"][data-channel="latest/edge"]`,
-    )!;
-    await user.click(btn);
-
-    expect(getByText(document.body, /edge channel can break/)).not.toBeNull();
-  });
-
-  test("beta channel has warning", async () => {
-    const user = userEvent.setup();
-    const btn = document.querySelector(
-      `[data-js="slide-install-instructions"][data-channel="latest/beta"]`,
-    )!;
-    await user.click(btn);
-
-    expect(
-      getByText(document.body, /beta channel may have unfinished parts/),
-    ).not.toBeNull();
-  });
-
-  test("candidate channel has warning", async () => {
-    const user = userEvent.setup();
-    const btn = document.querySelector(
-      `[data-js="slide-install-instructions"][data-channel="latest/candidate"]`,
-    )!;
-    await user.click(btn);
-
-    expect(
-      getByText(
-        document.body,
-        /candidate channel need additional real world experimentation/,
-      ),
-    ).not.toBeNull();
-  });
-
-  test("old snaps have warning", async () => {
-    const user = userEvent.setup();
-    const btn = document.querySelector(
-      `[data-js="slide-install-instructions"][data-channel="latest/old"]`,
-    )!;
-    await user.click(btn);
-
-    expect(getByText(document.body, /might be unmaintained/)).not.toBeNull();
+      expect(securityTable).not.toHaveClass("u-hide");
+      expect(securityTable).toHaveAttribute("aria-hidden", "false");
+      expect(versionTable).toHaveClass("u-hide");
+      expect(versionTable).toHaveAttribute("aria-hidden", "true");
+      expect(sbomRow).toHaveTextContent("latest/stable");
+      expect(sbomRow).toHaveTextContent("1.0-amd64");
+      expect(sbomRow).toHaveTextContent("1");
+      expect(sbomDownloadLink).toHaveTextContent("SPDX file");
+      expect(sbomDownloadLink).toHaveAttribute(
+        "href",
+        "https://example.com/test.spdx.json",
+      );
+      expect(sbomDownloadLink).toHaveAttribute("download");
+    });
   });
 });

--- a/static/js/public/snap-details/channelMap.ts
+++ b/static/js/public/snap-details/channelMap.ts
@@ -30,6 +30,7 @@ interface SlideInstallInstructionsElement extends HTMLElement {
 }
 
 export interface ChannelData {
+  sboms: Array<{ format: string; url: string }> | null;
   track: string;
   confinement: string;
   "released-at": string;
@@ -54,6 +55,7 @@ class ChannelMap {
   events: SnapEvents;
   INSTALL_TEMPLATE: string = "";
   CHANNEL_ROW_TEMPLATE: string | undefined;
+  CHANNEL_SECURITY_ROW_TEMPLATE: string | undefined;
   arch: string | undefined;
   openButton: HTMLElement | null | undefined;
   openScreenName: string | undefined;
@@ -145,6 +147,9 @@ class ChannelMap {
     const channelRowTemplateEl = document.querySelector(
       '[data-js="channel-map-row"]',
     );
+    const channelSecurityRowTemplateEl = document.querySelector(
+      '[data-js="channel-map-security-table-row"]',
+    );
 
     if (!installTemplateEl || !channelRowTemplateEl) {
       const buttonsVersions = document.querySelector(
@@ -158,6 +163,8 @@ class ChannelMap {
 
     this.INSTALL_TEMPLATE = installTemplateEl.innerHTML;
     this.CHANNEL_ROW_TEMPLATE = channelRowTemplateEl.innerHTML;
+    this.CHANNEL_SECURITY_ROW_TEMPLATE =
+      channelSecurityRowTemplateEl?.innerHTML;
 
     // get architectures from data
     const architectures = Object.keys(this.channelMapData);
@@ -480,7 +487,7 @@ class ChannelMap {
     applyDesktopStoreSupport(holder);
   }
 
-  writeTable(el: HTMLElement, data: string[][]): void {
+  writeTable(el: HTMLElement, data: string[][], tableType?: string): void {
     let cache: string | undefined;
     const tbody = data.map((row, i) => {
       const isSameTrack = cache && row[0] === cache;
@@ -496,10 +503,16 @@ class ChannelMap {
 
       let _row: string = "";
 
-      if (this.CHANNEL_ROW_TEMPLATE) {
-        _row = this.CHANNEL_ROW_TEMPLATE.split("${rowClass}").join(
-          rowClass.join(" "),
-        );
+      if (tableType && tableType === "security") {
+        if (this.CHANNEL_SECURITY_ROW_TEMPLATE) {
+          _row = this.CHANNEL_SECURITY_ROW_TEMPLATE;
+        }
+      } else {
+        if (this.CHANNEL_ROW_TEMPLATE) {
+          _row = this.CHANNEL_ROW_TEMPLATE.split("${rowClass}").join(
+            rowClass.join(" "),
+          );
+        }
       }
 
       row.forEach((val, index) => {
@@ -524,6 +537,10 @@ class ChannelMap {
       '[data-js="channel-map-table"]',
     ) as HTMLElement;
 
+    const tbodySecurityEl = this.channelMapEl.querySelector(
+      '[data-js="channel-map-security-table"]',
+    ) as HTMLElement;
+
     // If we're on the overview tab we only want to see latest/[all risks]
     // and [all tracks]/[highest risk], so filter out anything that isn't these
     const filtered = this.currentTab === "overview";
@@ -533,6 +550,7 @@ class ChannelMap {
     let trimmedNumberOfTracks = 0;
 
     const rows: Array<string[]> = [];
+    const securityRows: Array<string[]> = [];
 
     const trackList = filtered ? {} : archData;
 
@@ -555,9 +573,20 @@ class ChannelMap {
         }
       });
 
+      const hasSboms = Object.keys(trackList).some((track) => {
+        return trackList[track].some((t) => t.sboms);
+      });
+
+      if (hasSboms) {
+        // Show "Security" tab only if SBOMs exist
+        const securityTab = document.querySelector("#channel-map-security-tab");
+        const securityTabParent = securityTab?.closest(".p-tabs__item");
+        securityTabParent?.classList.remove("u-hide");
+      }
+
       // If we're filtering, but that list ends up with the same number of tracks
       // we don't need to show the tabs (we'll show the same data twice)
-      if (numberOfTracks === trimmedNumberOfTracks) {
+      if (numberOfTracks === trimmedNumberOfTracks && !hasSboms) {
         this.hideTabs();
       }
     }
@@ -573,8 +602,20 @@ class ChannelMap {
           trackInfo["released-at"],
           trackInfo["confinement"],
         ]);
+
+        securityRows.push([
+          trackName,
+          trackInfo["risk"],
+          trackInfo["version"],
+          trackInfo["revision"],
+          trackInfo["sboms"]
+            ? `<a href="${trackInfo["sboms"]?.[0]?.url}" download>SPDX file&nbsp;<i class="p-icon--begin-downloading"></i></a>`
+            : "",
+        ]);
       });
     });
+
+    this.writeTable(tbodySecurityEl, this.sortRows(securityRows), "security");
 
     this.writeTable(tbodyEl, this.sortRows(rows));
   }
@@ -611,6 +652,25 @@ class ChannelMap {
     this.currentTab = tab;
     selected.removeAttribute("aria-selected");
     clickEl.setAttribute("aria-selected", "true");
+
+    const versionTable = document.querySelector(
+      ".p-channel-map__version-table",
+    );
+    const securityTable = document.querySelector(
+      ".p-channel-map__security-table",
+    );
+
+    if (this.currentTab === "security") {
+      securityTable?.classList.remove("u-hide");
+      securityTable?.setAttribute("aria-hidden", "false");
+      versionTable?.classList.add("u-hide");
+      versionTable?.setAttribute("aria-hidden", "true");
+    } else {
+      versionTable?.classList.remove("u-hide");
+      versionTable?.setAttribute("aria-hidden", "false");
+      securityTable?.classList.add("u-hide");
+      securityTable?.setAttribute("aria-hidden", "true");
+    }
 
     if (this.arch && this.arch in this.channelMapData) {
       this.prepareTable(this.channelMapData[this.arch]);

--- a/templates/store/snap-details/_channel_map.html
+++ b/templates/store/snap-details/_channel_map.html
@@ -111,6 +111,19 @@
                     All releases
                 </a>
               </li>
+              <li class="p-tabs__item u-hide" role="presentation">
+                <a
+                  href="#"
+                  class="p-tabs__link"
+                  role="tab"
+                  data-tab="security"
+                  data-js="switch-tab"
+                  aria-controls="security-information"
+                  id="channel-map-security-tab"
+                >
+                    Security
+                </a>
+              </li>
             </ul>
           </nav>
         </div>
@@ -125,6 +138,20 @@
               </tr>
             </thead>
             <tbody data-js="channel-map-table">
+            </tbody>
+          </table>
+        </div>
+        <div class="u-fixed-width p-channel-map__security-table u-hide" role="tabpanel" id="security-information" aria-hidden="true">
+          <table aria-label="Security information">
+            <thead>
+              <tr>
+                <th>Channel</th>
+                <th>Version</th>
+                <th>Revision</th>
+                <th>Download SBOM</th>
+              </tr>
+            </thead>
+            <tbody data-js="channel-map-security-table">
             </tbody>
           </table>
         </div>
@@ -170,6 +197,15 @@
     <td>${row[2]}</td>
     <td class="u-hide--medium u-hide--small">${row[3]}</td>
     <td class="u-align--center"><a href="#" class="p-channel-map__version-table-install" data-analytics-click data-analytics-target="details_channel_version_install" data-analytics-channel="${row[0]}/${row[1]}">Install &rsaquo;</a></td>
+  </tr>
+</script>
+
+<script type="text/template" id="channel-map-security-table-row-template" data-js="channel-map-security-table-row">
+  <tr>
+    <td>${row[0]}/${row[1]}</td>
+    <td>${row[2]}</td>
+    <td>${row[3]}</td>
+    <td>${row[4]}</td>
   </tr>
 </script>
 


### PR DESCRIPTION
## Done
Replaces the previous implementation of showing SBOM links in the channel tab. The behaviour is identical but the logic is simpler and more performant as there are no HTTP requests needed to test for the existence of SBOM URLs.

## How to QA
- Go to https://snapcraft-io-5871.demos.haus/valkey
  - Open the channel map (next to the "Install" button)
  - Check that there is a "Security" tab
  - In the "Security" tab, check that there is at least one SBOM link in the table
- Go to https://snapcraft-io-5871.demos.haus/postgresql
  - Open the channel map (next to the "Install" button)
  - Check that there is a "Security" tab
  - In the "Security" tab, check that there is at least one SBOM link in the table
- Go to https://snapcraft-io-5871.demos.haus/firefox
  - Open the channel map (next to the "Install" button)
  - Check that there is **not** a "Security" tab

## Testing

- [x] This PR has tests
- [ ] No testing required (explain why):

## Security

- [ ] Security considerations for review (list them):
  - [ ] Examples:
  - [ ] Access control: users can only access their own data
  - [ ] Input: user input is validated and sanitised
  - [ ] Sensitive data: secret or private data is not exposed in any way
  - [ ] ...
- [x] This PR has no security considerations (explain why):

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-36496

## Screenshots
n/a

## UX Approval

- [x] This PR does not require UX approval
- [ ] This PR does require UX approval (add context):
